### PR TITLE
Fix to prevent app crash on the "abandon" seed

### DIFF
--- a/src/components/OperationsList/Operation.js
+++ b/src/components/OperationsList/Operation.js
@@ -49,6 +49,10 @@ const OperationRaw = styled(Box).attrs({
 `
 
 const Address = ({ value }: { value: string }) => {
+    if (!value) {
+      return <Box />
+    }
+
   const addrSize = value.length / 2
 
   const left = value.slice(0, 10)


### PR DESCRIPTION
The case where there's no "from" address on an operation shouldn't happen... but on testnet (sh)it happens :+1: