### PR TITLE
Add developerMode settings

### DIFF
--- a/src/components/SettingsPage/sections/Profile.js
+++ b/src/components/SettingsPage/sections/Profile.js
@@ -95,6 +95,12 @@ class TabProfile extends PureComponent<Props, State> {
     }
   }
 
+  handleDeveloperMode = developerMode => {
+    this.props.saveSettings({
+      developerMode,
+    })
+  }
+
   render() {
     const { t, settings } = this.props
     const {
@@ -120,6 +126,12 @@ class TabProfile extends PureComponent<Props, State> {
               )}
               <CheckBox isChecked={isPasswordEnabled} onChange={this.handleChangePasswordCheck} />
             </Box>
+          </Row>
+          <Row
+            title={t('settings:profile.developerMode')}
+            desc={t('settings:profile.developerModeDesc')}
+          >
+            <CheckBox isChecked={settings.developerMode} onChange={this.handleDeveloperMode} />
           </Row>
           <Row title={t('settings:profile.reset')} desc={t('settings:profile.resetDesc')}>
             <Button danger onClick={this.handleOpenHardResetModal}>

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -21,6 +21,7 @@ export type SettingsState = {
     [currencyId: string]: CurrencySettings,
   },
   region: string,
+  developerMode: boolean,
 }
 
 /* have to check if available for all OS */
@@ -40,6 +41,7 @@ const defaultState: SettingsState = {
   marketIndicator: 'western',
   currenciesSettings: {},
   region,
+  developerMode: false,
 }
 
 const CURRENCY_DEFAULTS_SETTINGS: CurrencySettings = {
@@ -77,6 +79,8 @@ export const getCounterValueCode = (state: State) => state.settings.counterValue
 
 export const counterValueCurrencySelector = (state: State): ?Currency =>
   findCurrencyByTicker(getCounterValueCode(state))
+
+export const developerModeSelector = (state: State): boolean => state.settings.developerMode
 
 export const getLanguage = (state: State) => state.settings.language
 

--- a/src/types/common.js
+++ b/src/types/common.js
@@ -40,6 +40,7 @@ export type Settings = {
   marketIndicator: 'eastern' | 'western',
   currenciesSettings: CurrenciesSettings,
   region: string,
+  developerMode: boolean,
 }
 
 export type T = (?string, ?Object) => string

--- a/static/i18n/en/settings.yml
+++ b/static/i18n/en/settings.yml
@@ -46,6 +46,8 @@ profile:
   reset: Reset application
   resetDesc: Lorem ipsum dolor sit amet
   resetButton: Hard reset
+  developerMode: Developer Mode
+  developerModeDesc: Enable visibility of developer apps & currencies like Bitcoin Testnet
 about:
   faq: FAQ
   faqDesc: Lorem ipsum dolor sit amet


### PR DESCRIPTION
this PR is to settle a settings to allow to set a developer mode. we totally forgot about it but it's important. it is disabled by default so Bitcoin Testnet won't be visible unless this settings is enabled.

![capture d ecran 2018-05-07 a 07 15 45](https://user-images.githubusercontent.com/211411/39686048-fe4c7e20-51c6-11e8-829b-ca7bd791bd6a.png)


only when it is enabled: 
- we will show Bitcoin Testnet in list of choices of listCurrencies
- it will show special items in the manager, like on current chrome app

> NB: even if disabled, previously created testnet accounts still will continue to appear, it's just simpler like this (it's not magical, we just hide the choices from currency selects, also, user can just reset app if wants to remove the testnet accounts)

nothing of the point above is implemented but:
- we will introduce in live-common a way to know if a currency is developer. also, maybe we could be able to pass a flag in `listCurrencies(developerMode=false)` (which btw could be memoized)
- I don't know implication for manager but I assume it's easy to implement as it was in previous chrome app?