### PR TITLE
add a retry mecanism on the open()

### DIFF
--- a/src/helpers/promise.js
+++ b/src/helpers/promise.js
@@ -1,0 +1,27 @@
+// @flow
+
+// small utilities for Promises
+
+export const delay = (ms: number): Promise<void> => new Promise(f => setTimeout(f, ms))
+
+const defaults = {
+  maxRetry: 4,
+  interval: 300,
+  intervalMultiplicator: 1.5,
+}
+export function retry<A>(f: () => Promise<A>, options?: $Shape<typeof defaults>): Promise<A> {
+  const { maxRetry, interval, intervalMultiplicator } = { ...defaults, ...options }
+
+  return rec(maxRetry, interval)
+
+  function rec(remainingTry, interval) {
+    const result = f()
+    if (remainingTry <= 0) {
+      return result
+    }
+    // In case of failure, wait the interval, retry the action
+    return result.catch(() =>
+      delay(interval).then(() => rec(remainingTry - 1, interval * intervalMultiplicator)),
+    )
+  }
+}


### PR DESCRIPTION
this will fix most of the time you have the error `Failed to open device` but **there is a more fundamental issue** related to this..

---

Initially here is what i wanted to do: debouncing the .close() and reuse Transport instances across call. the issue is that we currently always `kill:true` the devices process.. we probably should not kill it and always have one and only one process that is always up & deal with the devices.

```
import debounce from 'lodash/debounce'

// TODO this should work but unfortunately our process get always re-started.. a device process should always be up IMO...
const transports = {}
const transportsDebouncedClose = {}

console.log('deviceAccess semaphore STARTED')

function takeDevice(path) {
  const t = transports[path]
  const debouncedClose = transportsDebouncedClose[path]
  if (debouncedClose) debouncedClose.cancel() // we use the resource so we need to cancel scheduled close()
  if (t) return t // if there is a transport instance, we just reuse it
  transports[path] = retry(() => TransportNodeHid.open(path)) // otherwise we create it with a retry mecanism because it sometimes fails
  console.log(`Transport#open ${path}`)
  return transports[path]
}

function releaseDevice(path, force) {
  if (!transportsDebouncedClose[path]) {
    // if there is no debounced function for the path, we will create one and always reuse it
    transportsDebouncedClose[path] = debounce(() => {
      const t = transports[path]
      if (t) {
        delete transports[path]
        t.close()
        console.log(`Transport#close ${path}`)
      }
    }, 1000)
  }
  const debouncedClose = transportsDebouncedClose[path]
  debouncedClose()
  if (force) debouncedClose.flush()
}
```

 and with this code in withDevice:

```
    takeSemaphorePromise(sem, async () => {
      const t = await takeDevice(devicePath)
      let error
      try {
        const res = await job(t)
        // $FlowFixMe
        return res
      } catch (e) {
        error = e
        throw e
      } finally {
        await releaseDevice(devicePath, !!error)
      }
    })
```