### PR TITLE
fix potential issue during reorgs

### DIFF
--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -240,6 +240,11 @@ const EthereumBridge: WalletBridge<Transaction> = {
           const { txs } = await api.getTransactions(freshAddress, blockHash)
           if (unsubscribed) return
           if (txs.length === 0) {
+            next(a => ({
+              ...a,
+              blockHeight: block.height,
+              lastSyncDate: new Date(),
+            }))
             complete()
             return
           }

--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -93,6 +93,8 @@ function mergeOps(existing: Operation[], newFetched: Operation[]) {
   return uniqBy(all.sort((a, b) => b.date - a.date), 'id')
 }
 
+const SAFE_REORG_THRESHOLD = 80
+
 const fetchCurrentBlock = (perCurrencyId => currency => {
   if (perCurrencyId[currency.id]) return perCurrencyId[currency.id]()
   const api = apiForCurrency(currency)
@@ -231,6 +233,9 @@ const EthereumBridge: WalletBridge<Transaction> = {
         if (block.height === blockHeight) {
           complete()
         } else {
+          operations = operations.filter(
+            o => !o.blockHeight || blockHeight - o.blockHeight < SAFE_REORG_THRESHOLD,
+          )
           const blockHash = operations.length > 0 ? operations[0].blockHash : undefined
           const { txs } = await api.getTransactions(freshAddress, blockHash)
           if (unsubscribed) return

--- a/src/components/modals/AccountSettingRenderBody.js
+++ b/src/components/modals/AccountSettingRenderBody.js
@@ -167,6 +167,7 @@ class HelperComp extends PureComponent<Props, State> {
             </Container>
             <Spoiler title="Advanced logs">
               <textarea
+                readOnly
                 style={{
                   userSelect: 'text',
                   border: '1px dashed #f9f9f9',


### PR DESCRIPTION
@meriadec see approach i currently take. basically considering ops that are recent in term of nb of blockCount are temporary and filter them out so i paginate based on the most recent op but that is block-old enough. maybe we can take same approach for when libcore resync.