### PR TITLE
Improving instructions for yarn and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 Project has been tested with
 
 - [NodeJS](https://nodejs.org) v9.3.0
-- [Yarn](https://yarnpkg.com) v1.3.0
-- [Python](https://www.python.org/) v2.7.10 (used by [node-gyp](https://github.com/nodejs/node-gyp) to build native addons)
+- [Yarn](https://github.com/yarnpkg/yarn/releases/) v1.3.0
+- [Python](https://www.python.org/downloads/) v2.7.10 (used by [node-gyp](https://github.com/nodejs/node-gyp) to build native addons)
 - You will also need a C++ compiler
 
 #### Optional
@@ -22,13 +22,22 @@ Project has been tested with
 
 #### Setup
 
-1.  Install dependencies
 
+1.  Clone the ledger-live-desktop 
+
+- ```git clone https://github.com/LedgerHQ/ledger-live-desktop.git```
+- ```cd ledger-live-desktop```
+
+2. Install yarn and other dependencies
+
+- ```curl -o- -L https://yarnpkg.com/install.sh | bash ```
+
+3. Run yarn
 ```bash
 yarn
 ```
 
-2.  Create `.env` file
+4.  Create `.env` file
 
 ```bash
 # ENV VARIABLES


### PR DESCRIPTION
As an fyi, Yarn presently has a high priority issue which will result in a deprecation warning when building this and similar packages. 
The warning would look like this:
(node:36519) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

By pointing to the latest version of yarn for installation, this issue should eventually be resolved by the time new users setup the package.

More on this issue can be seen here: https://github.com/yarnpkg/yarn/issues/5477