### PR TITLE
Improve how Sync happen

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@ledgerhq/hw-transport-node-hid": "^4.13.0",
     "@ledgerhq/ledger-core": "1.4.5",
     "@ledgerhq/live-common": "2.29.0",
+    "async": "^2.6.1",
     "axios": "^0.18.0",
     "babel-runtime": "^6.26.0",
     "bcryptjs": "^2.4.3",

--- a/src/actions/bridgeSync.js
+++ b/src/actions/bridgeSync.js
@@ -6,9 +6,3 @@ export const setAccountSyncState = (accountId: string, state: AsyncState) => ({
   accountId,
   state,
 })
-
-export const setAccountPullMoreState = (accountId: string, state: AsyncState) => ({
-  type: 'SET_ACCOUNT_PULL_MORE_STATE',
-  accountId,
-  state,
-})

--- a/src/bridge/LibcoreBridge.js
+++ b/src/bridge/LibcoreBridge.js
@@ -1,6 +1,7 @@
 // @flow
 import logger from 'logger'
 import React from 'react'
+import { Observable } from 'rxjs'
 import { map } from 'rxjs/operators'
 import type { Account } from '@ledgerhq/live-common/lib/types'
 import { decodeAccount, encodeAccount } from 'reducers/accounts'
@@ -54,53 +55,56 @@ const LibcoreBridge: WalletBridge<Transaction> = {
       .subscribe(observer)
   },
 
-  synchronize(account, { next, complete, error }) {
-    // FIXME TODO:
-    // - when you implement addPendingOperation you also here need to:
-    //   - if there were pendingOperations that are now in operations, remove them as well.
-    //   - if there are pendingOperations that is older than a threshold (that depends on blockchain speed typically)
-    //     then we probably should trash them out? it's a complex question for UI
-    ;(async () => {
-      try {
-        const rawAccount = encodeAccount(account)
-        const rawSyncedAccount = await libcoreSyncAccount.send({ rawAccount }).toPromise()
-        const syncedAccount = decodeAccount(rawSyncedAccount)
-        next(account => {
-          const accountOps = account.operations
-          const syncedOps = syncedAccount.operations
-          const patch: $Shape<Account> = {
-            freshAddress: syncedAccount.freshAddress,
-            freshAddressPath: syncedAccount.freshAddressPath,
-            balance: syncedAccount.balance,
-            blockHeight: syncedAccount.blockHeight,
-            lastSyncDate: new Date(),
-          }
+  synchronize: account =>
+    Observable.create(o => {
+      // FIXME TODO:
+      // - when you implement addPendingOperation you also here need to:
+      //   - if there were pendingOperations that are now in operations, remove them as well.
+      //   - if there are pendingOperations that is older than a threshold (that depends on blockchain speed typically)
+      //     then we probably should trash them out? it's a complex question for UI
+      ;(async () => {
+        try {
+          const rawAccount = encodeAccount(account)
+          const rawSyncedAccount = await libcoreSyncAccount.send({ rawAccount }).toPromise()
+          const syncedAccount = decodeAccount(rawSyncedAccount)
+          o.next(account => {
+            const accountOps = account.operations
+            const syncedOps = syncedAccount.operations
+            const patch: $Shape<Account> = {
+              freshAddress: syncedAccount.freshAddress,
+              freshAddressPath: syncedAccount.freshAddressPath,
+              balance: syncedAccount.balance,
+              blockHeight: syncedAccount.blockHeight,
+              lastSyncDate: new Date(),
+            }
 
-          const hasChanged =
-            accountOps.length !== syncedOps.length || // size change, we do a full refresh for now...
-            (accountOps.length > 0 && syncedOps.length > 0 && accountOps[0].id !== syncedOps[0].id) // if same size, only check if the last item has changed.
+            const hasChanged =
+              accountOps.length !== syncedOps.length || // size change, we do a full refresh for now...
+              (accountOps.length > 0 &&
+                syncedOps.length > 0 &&
+                accountOps[0].id !== syncedOps[0].id) // if same size, only check if the last item has changed.
 
-          if (hasChanged) {
-            patch.operations = syncedAccount.operations
-            patch.pendingOperations = [] // For now, we assume a change will clean the pendings.
-          }
+            if (hasChanged) {
+              patch.operations = syncedAccount.operations
+              patch.pendingOperations = [] // For now, we assume a change will clean the pendings.
+            }
 
-          return {
-            ...account,
-            ...patch,
-          }
-        })
-        complete()
-      } catch (e) {
-        error(e)
+            return {
+              ...account,
+              ...patch,
+            }
+          })
+          o.complete()
+        } catch (e) {
+          o.error(e)
+        }
+      })()
+      return {
+        unsubscribe() {
+          logger.warn('LibcoreBridge: unsub sync not implemented')
+        },
       }
-    })()
-    return {
-      unsubscribe() {
-        logger.warn('LibcoreBridge: unsub sync not implemented')
-      },
-    }
-  },
+    }),
 
   pullMoreOperations: () => Promise.reject(notImplemented),
 

--- a/src/bridge/UnsupportedBridge.js
+++ b/src/bridge/UnsupportedBridge.js
@@ -5,10 +5,10 @@ import type { WalletBridge } from './types'
 const genericError = new Error('UnsupportedBridge')
 
 const UnsupportedBridge: WalletBridge<*> = {
-  synchronize(initialAccount, { error }) {
-    Promise.resolve(genericError).then(error)
-    return { unsubscribe() {} }
-  },
+  synchronize: () =>
+    Observable.create(o => {
+      o.error(genericError)
+    }),
 
   scanAccountsOnDevice(currency, deviceId, { error }) {
     Promise.resolve(genericError).then(error)

--- a/src/bridge/types.js
+++ b/src/bridge/types.js
@@ -32,6 +32,7 @@ export interface WalletBridge<Transaction> {
   // observer is an Observer of Account object. Account are expected to be `archived` by default because we want to import all and opt-in on what account to use.
   // the scan can stop once all accounts are discovered.
   // the function returns a Subscription and you MUST stop everything if it is unsubscribed.
+  // TODO return Observable
   scanAccountsOnDevice(
     currency: Currency,
     deviceId: DeviceId,
@@ -46,7 +47,7 @@ export interface WalletBridge<Transaction> {
   // operations if there are new ones (prepended), balance, blockHeight, ...
   // the synchronize can stop once everything is up to date. it is the user side responsability to start it again.
   // we should be able to interrupt the Subscription but we'll leave this usecase for later. if you don't support interruption, please `console.warn`
-  synchronize(initialAccount: Account, observer: Observer<(Account) => Account>): Subscription;
+  synchronize(initialAccount: Account): Observable<(Account) => Account>;
 
   // for a given account, UI wants to load more operations in the account.operations
   // if you can't do it or there is no more things to load, just return account,

--- a/src/components/AccountPage/index.js
+++ b/src/components/AccountPage/index.js
@@ -7,6 +7,7 @@ import { translate } from 'react-i18next'
 import { Redirect } from 'react-router'
 import styled from 'styled-components'
 import type { Currency, Account } from '@ledgerhq/live-common/lib/types'
+import SyncOneAccountOnMount from 'components/SyncOneAccountOnMount'
 
 import { MODAL_SEND, MODAL_RECEIVE, MODAL_SETTINGS_ACCOUNT } from 'config/constants'
 
@@ -97,6 +98,7 @@ class AccountPage extends PureComponent<Props, State> {
     return (
       // Force re-render account page, for avoid animation
       <Box key={account.id}>
+        <SyncOneAccountOnMount priority={10} accountId={account.id} />
         <Box horizontal mb={5}>
           <AccountHeader account={account} />
           <Box horizontal alignItems="center" justifyContent="flex-end" grow flow={2}>
@@ -188,4 +190,10 @@ class AccountPage extends PureComponent<Props, State> {
   }
 }
 
-export default compose(connect(mapStateToProps, mapDispatchToProps), translate())(AccountPage)
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+  translate(),
+)(AccountPage)

--- a/src/components/PollCounterValuesOnMount.js
+++ b/src/components/PollCounterValuesOnMount.js
@@ -1,0 +1,21 @@
+// @flow
+
+import React, { Component } from 'react'
+import CounterValues from 'helpers/countervalues'
+
+class Effect extends Component<{ cvPolling: * }> {
+  componentDidMount() {
+    this.props.cvPolling.poll()
+  }
+  render() {
+    return null
+  }
+}
+
+const PollCounterValuesOnMount = () => (
+  <CounterValues.PollingConsumer>
+    {cvPolling => <Effect cvPolling={cvPolling} />}
+  </CounterValues.PollingConsumer>
+)
+
+export default PollCounterValuesOnMount

--- a/src/components/SyncOneAccountOnMount.js
+++ b/src/components/SyncOneAccountOnMount.js
@@ -1,0 +1,39 @@
+// @flow
+
+import React, { Component } from 'react'
+import { BridgeSyncConsumer } from 'bridge/BridgeSyncContext'
+import type { Sync } from 'bridge/BridgeSyncContext'
+
+export class Effect extends Component<{
+  sync: Sync,
+  accountId: string,
+  priority: number,
+}> {
+  componentDidMount() {
+    const { sync, accountId, priority } = this.props
+    sync({ type: 'SYNC_ONE_ACCOUNT', accountId, priority })
+  }
+  componentDidUpdate(prevProps: *) {
+    const { sync, accountId, priority } = this.props
+    if (accountId !== prevProps.accountId) {
+      sync({ type: 'SYNC_ONE_ACCOUNT', accountId, priority })
+    }
+  }
+  render() {
+    return null
+  }
+}
+
+const SyncOneAccountOnMount = ({
+  accountId,
+  priority,
+}: {
+  accountId: string,
+  priority: number,
+}) => (
+  <BridgeSyncConsumer>
+    {sync => <Effect sync={sync} accountId={accountId} priority={priority} />}
+  </BridgeSyncConsumer>
+)
+
+export default SyncOneAccountOnMount

--- a/src/components/SyncSkipUnderPriority.js
+++ b/src/components/SyncSkipUnderPriority.js
@@ -1,0 +1,41 @@
+// @flow
+
+import React, { PureComponent } from 'react'
+import { BridgeSyncConsumer } from 'bridge/BridgeSyncContext'
+import type { Sync } from 'bridge/BridgeSyncContext'
+
+const instances = []
+
+export class Effect extends PureComponent<{
+  sync: Sync,
+  priority: number, // eslint-disable-line
+}> {
+  componentDidMount() {
+    instances.push(this)
+    this.check()
+  }
+  componentDidUpdate() {
+    this.check()
+  }
+  componentWillUnmount() {
+    const i = instances.indexOf(this)
+    if (i !== -1) {
+      instances.splice(i, 1)
+      this.check()
+    }
+  }
+  check() {
+    const { sync } = this.props
+    const priority = instances.length === 0 ? -1 : Math.max(...instances.map(i => i.props.priority))
+    sync({ type: 'SET_SKIP_UNDER_PRIORITY', priority })
+  }
+  render() {
+    return null
+  }
+}
+
+const SyncSkipUnderPriority = ({ priority }: { priority: number }) => (
+  <BridgeSyncConsumer>{sync => <Effect sync={sync} priority={priority} />}</BridgeSyncConsumer>
+)
+
+export default SyncSkipUnderPriority

--- a/src/components/TopBar/ActivityIndicator.js
+++ b/src/components/TopBar/ActivityIndicator.js
@@ -124,7 +124,7 @@ class ActivityIndicatorInner extends Component<Props, State> {
 
 const ActivityIndicator = ({ globalSyncState, t }: { globalSyncState: AsyncState, t: T }) => (
   <BridgeSyncConsumer>
-    {bridgeSync => (
+    {setSyncBehavior => (
       <CounterValues.PollingConsumer>
         {cvPolling => {
           const isPending = cvPolling.pending || globalSyncState.pending
@@ -137,7 +137,7 @@ const ActivityIndicator = ({ globalSyncState, t }: { globalSyncState: AsyncState
               isError={!!isError && !isPending}
               onClick={() => {
                 cvPolling.poll()
-                bridgeSync.syncAll()
+                setSyncBehavior({ type: 'SYNC_ALL_ACCOUNTS', priority: 5 })
               }}
             />
           )

--- a/src/components/modals/ImportAccounts/index.js
+++ b/src/components/modals/ImportAccounts/index.js
@@ -6,6 +6,8 @@ import { connect } from 'react-redux'
 import { translate } from 'react-i18next'
 import { createStructuredSelector } from 'reselect'
 
+import SyncSkipUnderPriority from 'components/SyncSkipUnderPriority'
+
 import type { Currency, Account } from '@ledgerhq/live-common/lib/types'
 
 import type { T, Device } from 'types/common'
@@ -199,6 +201,7 @@ class ImportAccounts extends PureComponent<Props, State> {
         onHide={() => this.setState({ ...INITIAL_STATE })}
         render={({ onClose }) => (
           <ModalBody onClose={onClose}>
+            <SyncSkipUnderPriority priority={100} />
             <ModalTitle onBack={onBack ? () => onBack(stepProps) : void 0}>
               {t('importAccounts:title')}
             </ModalTitle>
@@ -218,7 +221,13 @@ class ImportAccounts extends PureComponent<Props, State> {
   }
 }
 
-export default compose(connect(mapStateToProps, mapDispatchToProps), translate())(ImportAccounts)
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+  translate(),
+)(ImportAccounts)
 
 function idleCallback() {
   return new Promise(resolve => window.requestIdleCallback(resolve))

--- a/src/components/modals/Receive/index.js
+++ b/src/components/modals/Receive/index.js
@@ -9,6 +9,8 @@ import type { T, Device } from 'types/common'
 import { MODAL_RECEIVE } from 'config/constants'
 
 import getAddress from 'commands/getAddress'
+import SyncSkipUnderPriority from 'components/SyncSkipUnderPriority'
+import SyncOneAccountOnMount from 'components/SyncOneAccountOnMount'
 
 import Box from 'components/base/Box'
 import Breadcrumb from 'components/Breadcrumb'
@@ -300,7 +302,7 @@ class ReceiveModal extends PureComponent<Props, State> {
 
   render() {
     const { t } = this.props
-    const { stepsErrors, stepsDisabled, stepIndex } = this.state
+    const { stepsErrors, stepsDisabled, stepIndex, account } = this.state
 
     const canClose = this.canClose()
     const canPrev = this.canPrev()
@@ -313,6 +315,8 @@ class ReceiveModal extends PureComponent<Props, State> {
         preventBackdropClick={!canClose}
         render={({ onClose }) => (
           <ModalBody onClose={canClose ? onClose : undefined}>
+            <SyncSkipUnderPriority priority={9} />
+            {account && <SyncOneAccountOnMount priority={10} accountId={account.id} />}
             <ModalTitle>
               {canPrev && <PrevButton onClick={this.handlePrevStep} />}
               {t('receive:title')}

--- a/src/components/modals/Send/SendModalBody.js
+++ b/src/components/modals/Send/SendModalBody.js
@@ -16,11 +16,15 @@ import { getBridgeForCurrency } from 'bridge'
 import { accountsSelector } from 'reducers/accounts'
 import { updateAccountWithUpdater } from 'actions/accounts'
 
+import PollCounterValuesOnMount from 'components/PollCounterValuesOnMount'
+
 import Breadcrumb from 'components/Breadcrumb'
 import { ModalBody, ModalTitle, ModalContent } from 'components/base/Modal'
 import PrevButton from 'components/modals/PrevButton'
 import StepConnectDevice from 'components/modals/StepConnectDevice'
 import ChildSwitch from 'components/base/ChildSwitch'
+import SyncSkipUnderPriority from 'components/SyncSkipUnderPriority'
+import SyncOneAccountOnMount from 'components/SyncOneAccountOnMount'
 
 import Footer from './Footer'
 import ConfirmationFooter from './ConfirmationFooter'
@@ -271,6 +275,10 @@ class SendModalBody extends PureComponent<Props, State<*>> {
 
     return (
       <ModalBody onClose={onClose}>
+        <PollCounterValuesOnMount />
+        <SyncSkipUnderPriority priority={80} />
+        {account && <SyncOneAccountOnMount priority={81} accountId={account.id} />}
+
         <ModalTitle>
           {canPrev && <PrevButton onClick={this.onPrevStep} />}
           {t('send:title')}

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -1,7 +1,7 @@
 // @flow
 
 export const SYNC_BOOT_DELAY = 2 * 1000
-export const SYNC_INTERVAL = 30 * 1000
+export const SYNC_ALL_INTERVAL = 60 * 1000
 export const CHECK_APP_INTERVAL_WHEN_INVALID = 600
 export const CHECK_APP_INTERVAL_WHEN_VALID = 1200
 export const CHECK_UPDATE_DELAY = 5e3

--- a/src/reducers/bridgeSync.js
+++ b/src/reducers/bridgeSync.js
@@ -12,12 +12,10 @@ export type AsyncState = {
 
 export type BridgeSyncState = {
   syncs: { [accountId: string]: AsyncState },
-  pullMores: { [accountId: string]: AsyncState },
 }
 
-const state: BridgeSyncState = {
+const initialState: BridgeSyncState = {
   syncs: {},
-  pullMores: {},
 }
 
 const handlers: Object = {
@@ -33,16 +31,6 @@ const handlers: Object = {
       [action.accountId]: action.state,
     },
   }),
-
-  SET_ACCOUNT_PULL_MORE_STATE: (
-    state: BridgeSyncState,
-    action: { accountId: string, state: AsyncState },
-  ) => ({
-    pullMores: {
-      ...state.pullMores,
-      [action.accountId]: action.state,
-    },
-  }),
 }
 
 // Selectors
@@ -55,11 +43,6 @@ export const syncStateLocalSelector = (
   bridgeSync: BridgeSyncState,
   { accountId }: { accountId: string },
 ) => bridgeSync.syncs[accountId] || nothingState
-
-export const pullMoreStateLocalSelector = (
-  bridgeSync: BridgeSyncState,
-  { accountId }: { accountId: string },
-) => bridgeSync.pullMores[accountId] || nothingState
 
 export const globalSyncStateSelector = createSelector(
   accountsSelector,
@@ -78,4 +61,4 @@ export const globalSyncStateSelector = createSelector(
   },
 )
 
-export default handleActions(handlers, state)
+export default handleActions(handlers, initialState)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2356,7 +2356,7 @@ async@^1.4.0, async@^1.5.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.2, async@^2.1.4, async@^2.6.0:
+async@^2.1.2, async@^2.1.4, async@^2.6.0, async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
   dependencies:


### PR DESCRIPTION
- a priority queue
- don't sync during critical part of the app
- don't sync more than 2 at same time
- sync when opening a specific account
- sync a selected account in the send/receive modals
- refresh countervalue in send

room for improvment around this:

withLibcore() need to lock less often. typically we lock the whole libcore during a http call triggered by a sync. this blocks the Sign Transaction on device to happen. we also need to be able to interrupt a sync, which is not yet implemented.