### PR TITLE
Deprecate usage of Account#isSegwit field

### DIFF
--- a/src/commands/libcoreSignAndBroadcast.js
+++ b/src/commands/libcoreSignAndBroadcast.js
@@ -5,6 +5,7 @@ import type { AccountRaw, OperationRaw } from '@ledgerhq/live-common/lib/types'
 import Btc from '@ledgerhq/hw-app-btc'
 import { Observable } from 'rxjs'
 import { getCryptoCurrencyById } from '@ledgerhq/live-common/lib/helpers/currencies'
+import { isSegwitAccount } from 'helpers/bip32'
 
 import withLibcore from 'helpers/withLibcore'
 import { createCommand, Command } from 'helpers/ipc'
@@ -158,7 +159,7 @@ export async function doSignAndBroadcast({
 
     const WALLET_IDENTIFIER = await getWalletIdentifier({
       hwApp,
-      isSegwit: !!account.isSegwit,
+      isSegwit: isSegwitAccount(account),
       currencyId: account.currencyId,
       devicePath: deviceId,
     })
@@ -197,7 +198,7 @@ export async function doSignAndBroadcast({
       transaction: builded,
       sigHashType: parseInt(sigHashType, 16),
       supportsSegwit: !!currency.supportsSegwit,
-      isSegwit: !!account.isSegwit,
+      isSegwit: isSegwitAccount(account),
       hasTimestamp,
     })
   })

--- a/src/components/EnsureDeviceApp/index.js
+++ b/src/components/EnsureDeviceApp/index.js
@@ -2,6 +2,7 @@
 import { PureComponent } from 'react'
 import { connect } from 'react-redux'
 import logger from 'logger'
+import { isSegwitAccount } from 'helpers/bip32'
 
 import type { Account, CryptoCurrency } from '@ledgerhq/live-common/lib/types'
 import type { Device } from 'types/common'
@@ -121,7 +122,7 @@ class EnsureDeviceApp extends PureComponent<Props, State> {
             devicePath: deviceSelected.path,
             currencyId: account.currency.id,
             path: account.freshAddressPath,
-            segwit: !!account.isSegwit,
+            segwit: isSegwitAccount(account),
           })
           .toPromise()
         const { freshAddress } = account

--- a/src/components/modals/Receive/index.js
+++ b/src/components/modals/Receive/index.js
@@ -7,6 +7,7 @@ import type { Account } from '@ledgerhq/live-common/lib/types'
 import type { T, Device } from 'types/common'
 
 import { MODAL_RECEIVE } from 'config/constants'
+import { isSegwitAccount } from 'helpers/bip32'
 
 import getAddress from 'commands/getAddress'
 import SyncSkipUnderPriority from 'components/SyncSkipUnderPriority'
@@ -202,7 +203,7 @@ class ReceiveModal extends PureComponent<Props, State> {
             currencyId: account.currency.id,
             devicePath: device.path,
             path: account.freshAddressPath,
-            segwit: !!account.isSegwit,
+            segwit: isSegwitAccount(account),
             verify: true,
           })
           .toPromise()

--- a/src/helpers/bip32.js
+++ b/src/helpers/bip32.js
@@ -1,0 +1,7 @@
+// @flow
+import type { Account, AccountRaw } from '@ledgerhq/live-common/lib/types'
+
+export const isSegwitPath = (path: string): boolean => path.startsWith("49'")
+
+export const isSegwitAccount = (account: Account | AccountRaw): boolean =>
+  isSegwitPath(account.freshAddressPath)

--- a/src/helpers/libcore.js
+++ b/src/helpers/libcore.js
@@ -8,6 +8,7 @@ import { getCryptoCurrencyById } from '@ledgerhq/live-common/lib/helpers/currenc
 import type { AccountRaw, OperationRaw, OperationType } from '@ledgerhq/live-common/lib/types'
 import type { NJSAccount, NJSOperation } from '@ledgerhq/ledger-core/src/ledgercore_doc'
 
+import { isSegwitAccount } from 'helpers/bip32'
 import * as accountIdHelper from 'helpers/accountId'
 
 import { getAccountPlaceholderName, getNewAccountPlaceholderName } from './accountName'
@@ -368,7 +369,7 @@ export async function syncAccount({
 
   const syncedRawAccount = await buildAccountRaw({
     njsAccount,
-    isSegwit: rawAccount.isSegwit === true,
+    isSegwit: isSegwitAccount(rawAccount),
     accountIndex: rawAccount.index,
     wallet: njsWallet,
     currencyId: rawAccount.currencyId,


### PR DESCRIPTION
in future, we probably even want to go farther: introducing a purpose field as in `m/purpose'/coinType'/index'`

after this PR we can drop Account#isSegwit . later we'll probably need to come back to this segwit bool idea we have all over the place, because there will be more `purpose` in the future