### PR TITLE
Optimize CI builds by caching dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,18 @@ jobs:
         - gh-pages
     steps:
       - checkout
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - v1-yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
-          name: Dependencies
-          command: SKIP_REBUILD=1 yarn
+          name: Install Dependencies
+          command: bash scripts/install-ci-deps.sh
+      - save_cache:
+          name: Save Yarn Package Cache
+          key: v1-yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules/
       - run:
           name: Lint
           command: yarn lint

--- a/scripts/hash-utils.sh
+++ b/scripts/hash-utils.sh
@@ -1,0 +1,26 @@
+#/bin/bash
+
+function GET_HASH_PATH {
+  HASH_NAME=$1
+  echo "./node_modules/.cache/LEDGER_HASH_$HASH_NAME.hash"
+}
+
+function GET_HASH {
+  HASH_NAME=$1
+  HASH_PATH=`GET_HASH_PATH $HASH_NAME`
+  if [ ! -e "$HASH_PATH" ]; then
+    echo ''
+  else
+    HASH_CONTENT=`cat "$HASH_PATH"`
+    echo $HASH_CONTENT
+  fi
+}
+
+function SET_HASH {
+  HASH_NAME=$1
+  HASH_CONTENT=$2
+  echo "setting hash $HASH_NAME to $HASH_CONTENT"
+  HASH_PATH=`GET_HASH_PATH $HASH_NAME`
+  mkdir -p ./node_modules/.cache
+  echo $HASH_CONTENT > $HASH_PATH
+}

--- a/scripts/install-ci-deps.sh
+++ b/scripts/install-ci-deps.sh
@@ -1,0 +1,13 @@
+#/bin/bash
+
+source scripts/hash-utils.sh
+
+PACKAGE_JSON_HASH=`md5sum package.json | cut -d ' ' -f 1`
+CACHED_PACKAGE_JSON_HASH=`GET_HASH 'package.json'`
+
+if [ "$CACHED_PACKAGE_JSON_HASH" == "$PACKAGE_JSON_HASH" ]; then
+  echo "> Skipping yarn install"
+else
+  yarn install
+  SET_HASH 'package.json' $PACKAGE_JSON_HASH
+fi

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,33 +1,12 @@
 #/bin/bash
 
+source scripts/hash-utils.sh
+
 function MAIN {
-  REBUILD_ELECTRON_NATIVE_DEPS
-  INSTALL_FLOW_TYPED
-}
-
-function GET_HASH_PATH {
-  HASH_NAME=$1
-  echo "./node_modules/.cache/LEDGER_HASH_$HASH_NAME.hash"
-}
-
-function GET_HASH {
-  HASH_NAME=$1
-  HASH_PATH=`GET_HASH_PATH $HASH_NAME`
-  if [ ! -e "$HASH_PATH" ]; then
-    echo ''
-  else
-    HASH_CONTENT=`cat "$HASH_PATH"`
-    echo $HASH_CONTENT
+  if ! $CI; then
+    REBUILD_ELECTRON_NATIVE_DEPS
   fi
-}
-
-function SET_HASH {
-  HASH_NAME=$1
-  HASH_CONTENT=$2
-  echo "setting hash $HASH_NAME to $HASH_CONTENT"
-  HASH_PATH=`GET_HASH_PATH $HASH_NAME`
-  mkdir -p ./node_modules/.cache
-  echo $HASH_CONTENT > $HASH_PATH
+  INSTALL_FLOW_TYPED
 }
 
 function INSTALL_FLOW_TYPED {


### PR DESCRIPTION
Now it takes ~1 minute instead of more than 5 minutes :tada:

![2018-06-21_648x403](https://user-images.githubusercontent.com/315259/41720008-001d945a-7562-11e8-923a-2d44a5cda6be.png)
