### PR TITLE
add confirm to hard reset on the crash screen

### DIFF
--- a/src/components/RenderError.js
+++ b/src/components/RenderError.js
@@ -37,15 +37,6 @@ class RenderError extends PureComponent<
   handleOpenHardResetModal = () => this.setState({ isHardResetModalOpened: true })
   handleCloseHardResetModal = () => this.setState({ isHardResetModalOpened: false })
 
-  handleHardReset = async () => {
-    this.setState({ isHardResetting: true })
-    try {
-      await hardReset()
-      remote.getCurrentWindow().webContents.reloadIgnoringCache()
-    } catch (err) {
-      this.setState({ isHardResetting: false })
-    }
-  }
   hardResetIconRender = () => (
     <IconWrapperCircle color="alertRed">
       <IconTriangleWarning width={23} height={21} />

--- a/src/components/SettingsPage/sections/Profile.js
+++ b/src/components/SettingsPage/sections/Profile.js
@@ -263,7 +263,7 @@ export default connect(
 )(TabProfile)
 
 // TODO: need a helper file for common styles across the app
-const IconWrapperCircle = styled(Box).attrs({})`
+export const IconWrapperCircle = styled(Box).attrs({})`
   width: 50px;
   height: 50px;
   border-radius: 50%;

--- a/src/icons/TriangleWarning.js
+++ b/src/icons/TriangleWarning.js
@@ -10,7 +10,7 @@ const path = (
 )
 
 export default ({ height, width, ...p }: { height: number, width: number }) => (
-  <svg viewBox="0 0 19 17" height={height} width={width} {...p}>
+  <svg viewBox="0 0 17 17" height={height} width={width} {...p}>
     {path}
   </svg>
 )


### PR DESCRIPTION
I tested brining up a confirmation modal for the hard reset by throwing an error from the init and 2 components inside the app. see if there are other scenarios to test