### PR TITLE
Stepper component

### DIFF
--- a/src/components/base/Stepper/index.js
+++ b/src/components/base/Stepper/index.js
@@ -1,0 +1,81 @@
+// @flow
+
+import React, { PureComponent } from 'react'
+import invariant from 'invariant'
+import { translate } from 'react-i18next'
+
+import type { T } from 'types/common'
+
+import { ModalContent, ModalTitle, ModalFooter, ModalBody } from 'components/base/Modal'
+import Breadcrumb from 'components/Breadcrumb'
+
+type Props = {
+  t: T,
+  title: string,
+  initialStepId: string,
+  onClose: void => void,
+  steps: Step[],
+  children: any,
+}
+
+export type Step = {
+  id: string,
+  label: string,
+  component: StepProps => React$Node,
+  footer: StepProps => React$Node,
+  preventClose?: boolean,
+  onBack?: StepProps => void,
+}
+
+type State = {
+  stepId: string,
+}
+
+export type StepProps = {
+  t: T,
+  transitionTo: string => void,
+}
+
+class Stepper extends PureComponent<Props, State> {
+  state = {
+    stepId: this.props.initialStepId,
+  }
+
+  transitionTo = stepId => this.setState({ stepId })
+
+  render() {
+    const { t, steps, title, onClose, children, ...props } = this.props
+    const { stepId } = this.state
+
+    const stepIndex = steps.findIndex(s => s.id === stepId)
+    const step = steps[stepIndex]
+
+    invariant(step, `Stepper: step ${stepId} doesn't exists`)
+
+    const { component: StepComponent, footer: StepFooter, onBack, preventClose } = step
+
+    const stepProps: StepProps = {
+      t,
+      transitionTo: this.transitionTo,
+      ...props,
+    }
+
+    return (
+      <ModalBody onClose={preventClose ? undefined : onClose}>
+        <ModalTitle onBack={onBack ? () => onBack(stepProps) : undefined}>{title}</ModalTitle>
+        <ModalContent>
+          <Breadcrumb mb={6} currentStep={stepIndex} items={steps} />
+          <StepComponent {...stepProps} />
+          {children}
+        </ModalContent>
+        {StepFooter && (
+          <ModalFooter horizontal align="center" justify="flex-end">
+            <StepFooter {...stepProps} />
+          </ModalFooter>
+        )}
+      </ModalBody>
+    )
+  }
+}
+
+export default translate()(Stepper)

--- a/src/components/base/Stepper/stories.js
+++ b/src/components/base/Stepper/stories.js
@@ -1,0 +1,50 @@
+// @flow
+
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
+
+import Stepper from 'components/base/Stepper'
+import Button from 'components/base/Button'
+
+import type { StepProps, Step } from 'components/base/Stepper'
+
+const stories = storiesOf('Components/base', module)
+
+const steps: Step[] = [
+  {
+    id: 'first',
+    label: 'first step',
+    component: () => <div>first step</div>,
+    footer: ({ transitionTo }: StepProps) => (
+      <div>
+        <Button primary onClick={() => transitionTo('second')}>
+          Click to go next
+        </Button>
+      </div>
+    ),
+  },
+  {
+    id: 'second',
+    label: 'second step',
+    preventClose: true,
+    onBack: ({ transitionTo }: StepProps) => transitionTo('first'),
+    component: () => <div>second step (you cant close on this one)</div>,
+    footer: ({ transitionTo }: StepProps) => (
+      <div>
+        <Button primary onClick={() => transitionTo('first')}>
+          Click to go prev
+        </Button>
+      </div>
+    ),
+  },
+]
+
+stories.add('Stepper', () => (
+  <Stepper
+    onClose={action('onClose')}
+    title="Stepper component"
+    steps={steps}
+    initialStepId="first"
+  />
+))

--- a/src/components/modals/AddAccounts/steps/01-step-choose-currency.js
+++ b/src/components/modals/AddAccounts/steps/01-step-choose-currency.js
@@ -9,13 +9,7 @@ import CurrencyBadge from 'components/base/CurrencyBadge'
 import type { StepProps } from '../index'
 
 function StepChooseCurrency({ currency, setCurrency }: StepProps) {
-  return (
-    <SelectCurrency
-      autoFocus
-      onChange={setCurrency}
-      value={currency}
-    />
-  )
+  return <SelectCurrency autoFocus onChange={setCurrency} value={currency} />
 }
 
 export function StepChooseCurrencyFooter({ transitionTo, currency, t }: StepProps) {

--- a/src/components/modals/AddAccounts/steps/01-step-choose-currency.js
+++ b/src/components/modals/AddAccounts/steps/01-step-choose-currency.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { Fragment } from 'react'
-import isArray from 'lodash/isArray'
 
 import SelectCurrency from 'components/SelectCurrency'
 import Button from 'components/base/Button'
@@ -9,15 +8,11 @@ import CurrencyBadge from 'components/base/CurrencyBadge'
 
 import type { StepProps } from '../index'
 
-function StepChooseCurrency({ currency, setState }: StepProps) {
+function StepChooseCurrency({ currency, setCurrency }: StepProps) {
   return (
     <SelectCurrency
       autoFocus
-      onChange={currency => {
-        setState({
-          currency: isArray(currency) && currency.length === 0 ? null : currency,
-        })
-      }}
+      onChange={setCurrency}
       value={currency}
     />
   )

--- a/src/components/modals/AddAccounts/steps/02-step-connect-device.js
+++ b/src/components/modals/AddAccounts/steps/02-step-connect-device.js
@@ -11,7 +11,7 @@ import { CurrencyCircleIcon } from 'components/base/CurrencyBadge'
 
 import type { StepProps } from '../index'
 
-function StepConnectDevice({ t, currency, currentDevice, setState }: StepProps) {
+function StepConnectDevice({ t, currency, device, setAppOpened }: StepProps) {
   invariant(currency, 'No currency given')
 
   return (
@@ -30,11 +30,11 @@ function StepConnectDevice({ t, currency, currentDevice, setState }: StepProps) 
       </Box>
       <ConnectDevice
         t={t}
-        deviceSelected={currentDevice}
+        deviceSelected={device}
         currency={currency}
         onStatusChange={(deviceStatus, appStatus) => {
           if (appStatus === 'success') {
-            setState({ isAppOpened: true })
+            setAppOpened(true)
           }
         }}
       />

--- a/src/helpers/promise.js
+++ b/src/helpers/promise.js
@@ -27,3 +27,7 @@ export function retry<A>(f: () => Promise<A>, options?: $Shape<typeof defaults>)
     })
   }
 }
+
+export function idleCallback() {
+  return new Promise(resolve => window.requestIdleCallback(resolve))
+}


### PR DESCRIPTION
The `Stepper` component will -in the near future- be used in all our "steps" flows. This PR make uses of it in the AddAccounts modal, for the whole import account flow, as a POC (because it requires many states changes, retries, etc).

When this will be merged, I will continue on DeviceInteraction branch, which I will use to refacto SendModal, ReceiveModal, and after all, Manager stuff.