### PR TITLE
errors.yml now have sub field ('title' by default)

### DIFF
--- a/src/components/ManagerPage/AppsList.js
+++ b/src/components/ManagerPage/AppsList.js
@@ -205,7 +205,17 @@ class AppsList extends PureComponent<Props, State> {
                     textAlign="center"
                     style={{ maxWidth: 350 }}
                   >
-                    <TranslatedError error={error} />
+                    <TranslatedError error={error} field="title" />
+                  </Box>
+                  <Box
+                    color="graphite"
+                    mt={4}
+                    fontSize={6}
+                    ff="Open Sans"
+                    textAlign="center"
+                    style={{ maxWidth: 350 }}
+                  >
+                    <TranslatedError error={error} field="description" />
                   </Box>
                 </ModalContent>
                 <ModalFooter horizontal justifyContent="flex-end" style={{ width: '100%' }}>

--- a/src/components/TranslatedError.js
+++ b/src/components/TranslatedError.js
@@ -12,21 +12,24 @@ import type { T } from 'types/common'
 type Props = {
   error: ?Error,
   t: T,
+  field: 'title' | 'description',
 }
 
 class TranslatedError extends PureComponent<Props> {
+  static defaultProps = {
+    field: 'title',
+  }
   render() {
-    const { t, error } = this.props
+    const { t, error, field } = this.props
     if (!error) return null
     if (typeof error === 'string') return error
     if (error.name) {
-      const translation = t(`errors:${error.name}`, error)
-      if (translation) {
-        return translation
-      }
+      const translation = t(`errors:${error.name}.${field}`, error)
+      // FIXME in case the error don't exist in t we should not return and fallback code after. I just don't know how to check this. FIXME
+      return translation
     }
     logger.warn(`TranslatedError: no translation for '${error.name}'`, error)
-    return error.message || error.name || t('errors:generic')
+    return error.message || error.name || t(`errors:generic.${field}`)
   }
 }
 

--- a/static/i18n/en/errors.yml
+++ b/static/i18n/en/errors.yml
@@ -1,32 +1,97 @@
-BtcUnmatchedApp: 'Open the ‘{{currencyName}}’ app on your Ledger device to proceed.'
-DeviceNotGenuine: Device is not genuine
-DeviceSocketFail: Oops, device connection failed. Please try again. [device-fail]
-DeviceSocketNoBulkStatus: Oops, device connection failed. Please try again [bulk].
-DeviceSocketNoHandler: Oops, device connection failed (handler {{query}}). Please try again.
-DisconnectedDevice: 'The device was disconnected.'
-Error: '{{message}}'
-FeeEstimationFailed: 'Fee estimation error. Try again or set a custom fee (status: {{status}})'
-generic: Oops, an unknown error occurred. Please try again or contact Ledger Support.
-HardResetFail: Reset failed. Please try again.
-LatestMCUInstalledError: MCU on device already up to date.
-LedgerAPIError: 'Ledger API error. Try again. (HTTP {{status}})'
-LedgerAPIErrorWithMessage: '{{message}}'
-LedgerAPINotAvailable: 'Ledger API not available for {{currencyName}}.'
-ManagerAPIsFail: Services are unavailable. Please try again.
-ManagerAppAlreadyInstalled: App is already installed
-ManagerAppRelyOnBTC: You must install Bitcoin application first
-ManagerDeviceLocked: Device is locked
-ManagerNotEnoughSpace: Not enough storage on device. Uninstall some apps and try again.
-ManagerUnexpected: Unexpected error occurred ({{msg}}). Please try again.
-ManagerUninstallBTCDep: You must uninstall other altcoins first
-NetworkDown: 'Your internet connection seems down.'
-NoAddressesFound: 'No accounts were found.'
-NotEnoughBalance: 'Insufficient funds to proceed.'
-RangeError: '{{message}}'
-TimeoutError: 'The request timed out.'
-TransportStatusError: '{{message}}'
-UserRefusedOnDevice: Transaction refused on device.
-WebsocketConnectionError: Oops, device connection failed. Please try again. [web-err]
-WebsocketConnectionFailed: Oops, device connection failed. Please try again. [web-fail]
-WrongAppOpened: 'Open the ‘{{currencyName}}’ app on your Ledger device to proceed.'
-WrongDeviceForAccount: 'Use the device associated with the account ‘{{accountName}}’.'
+# the error codes are alphabetically sorted
+BtcUnmatchedApp:
+  title: 'Open the ‘{{currencyName}}’ app on your Ledger device to proceed.'
+  description: ''
+DeviceNotGenuine:
+  title: Device is not genuine
+  description: ''
+DeviceSocketFail:
+  title: Oops, device connection failed. Please try again. [device-fail]
+  description: ''
+DeviceSocketNoBulkStatus:
+  title: Oops, device connection failed. Please try again [bulk].
+  description: ''
+DeviceSocketNoHandler:
+  title: Oops, device connection failed (handler {{query}}). Please try again.
+  description: ''
+DisconnectedDevice:
+  title: 'The device was disconnected.'
+  description: ''
+Error: # as this is a generic unhandled error i think it's ok to have a generic title. but keep description to {{message}}
+  title: 'Oops, an error occurred'
+  description: '{{message}}'
+FeeEstimationFailed:
+  title: 'Fee estimation error. Try again or set a custom fee (status: {{status}})'
+  description: ''
+generic:
+  title: Oops, an unknown error occurred. Please try again or contact Ledger Support.
+  description: ''
+HardResetFail:
+  title: Reset failed. Please try again.
+  description: ''
+LatestMCUInstalledError:
+  title: MCU on device already up to date.
+  description: ''
+LedgerAPIError:
+  title: 'Ledger API error. Try again. (HTTP {{status}})'
+  description: ''
+LedgerAPIErrorWithMessage:
+  title: '{{message}}'
+  description: ''
+LedgerAPINotAvailable:
+  title: 'Ledger API not available for {{currencyName}}.'
+  description: ''
+ManagerAPIsFail:
+  title: Services are unavailable. Please try again.
+  description: ''
+ManagerAppAlreadyInstalled:
+  title: App is already installed
+  description: ''
+ManagerAppRelyOnBTC:
+  title: You must install Bitcoin application first
+  description: ''
+ManagerDeviceLocked:
+  title: Device is locked
+  description: ''
+ManagerNotEnoughSpace:
+  title: Not enough storage on device
+  description: Uninstall some apps and try again.
+ManagerUnexpectedError:
+  title: Unexpected error occurred ({{msg}})
+  description: Please try again.
+ManagerUninstallBTCDep:
+  title: You must uninstall other altcoins first
+  description: ''
+NetworkDown:
+  title: 'Your internet connection seems down.'
+  description: ''
+NoAddressesFound:
+  title: 'No accounts were found.'
+  description: ''
+NotEnoughBalance:
+  title: 'Insufficient funds to proceed.'
+  description: ''
+RangeError:
+  title: '{{message}}'
+  description: ''
+TimeoutError:
+  title: 'The request timed out.'
+  description: ''
+TransportStatusError:
+  title: '{{message}}'
+  description: ''
+UserRefusedOnDevice:
+  title: Transaction refused on device.
+  description: ''
+WebsocketConnectionError:
+  title: Oops, device connection failed. Please try again. [web-err]
+  description: ''
+WebsocketConnectionFailed:
+  title: Oops, device connection failed. Please try again. [web-fail]
+  description: ''
+WrongAppOpened:
+  title: 'Open the ‘{{currencyName}}’ app on your Ledger device to proceed.'
+  description: ''
+WrongDeviceForAccount:
+  title: 'Use the device associated with the account ‘{{accountName}}’.'
+  description: ''


### PR DESCRIPTION
errors.yml are now sub field. by default we use title, but any field can be defined.

we will use for now 2 fields by convention, title (which must remain SHORT!!) that we use most of the time. and description, for a more detailed version.

This is now connected for the manager error modal of applist so feel free to fill in more wording (cc @dasilvarosa )

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Feature Improvment
<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

after discussions with @dasilvarosa , it is clear we need more level of errors. small version (not much space) and bigger version (for description, when we have space to display).
<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

all parts. but it's a non breaking change