### PR TITLE
Refresh circleci cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,13 @@ jobs:
       - restore_cache:
           name: Restore Yarn Package Cache
           keys:
-            - v1-yarn-packages-{{ checksum "yarn.lock" }}
+            - v2-yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: bash scripts/install-ci-deps.sh
       - save_cache:
           name: Save Yarn Package Cache
-          key: v1-yarn-packages-{{ checksum "yarn.lock" }}
+          key: v2-yarn-packages-{{ checksum "yarn.lock" }}
           paths:
             - node_modules/
       - run:


### PR DESCRIPTION
For (still) unknown reasons, stored/used cache keys are desynchronized
Incrementing this number will solve the pb.
We need a better solution eheh. But that would fix for now.