### PR TITLE
Polish

### DIFF
--- a/src/components/modals/OperationDetails.js
+++ b/src/components/modals/OperationDetails.js
@@ -155,6 +155,7 @@ const OperationDetails = connect(mapStateToProps)((props: Props) => {
               <Box my={4} alignItems="center">
                 <Box>
                   <FormattedVal
+                    color={amount < 0 ? 'smoke' : undefined}
                     unit={unit}
                     alwaysShowSign
                     showCode

--- a/src/components/modals/OperationDetails.js
+++ b/src/components/modals/OperationDetails.js
@@ -243,16 +243,13 @@ const OperationDetails = connect(mapStateToProps)((props: Props) => {
         <GradientBox />
       </ModalContent>
 
-      <ModalFooter horizontal justify="flex-end" flow={2}>
-        <Button padded onClick={onClose}>
-          {t('app:common.cancel')}
-        </Button>
-        {url ? (
+      {url && (
+        <ModalFooter horizontal justify="flex-end" flow={2}>
           <Button primary padded onClick={() => shell.openExternal(url)}>
             {t('app:operationDetails.viewOperation')}
           </Button>
-        ) : null}
-      </ModalFooter>
+        </ModalFooter>
+      )}
     </ModalBody>
   )
 })

--- a/src/components/modals/Send/index.js
+++ b/src/components/modals/Send/index.js
@@ -49,7 +49,6 @@ type State<Transaction> = {
   transaction: ?Transaction,
   optimisticOperation: ?Operation,
   isAppOpened: boolean,
-  disabledSteps: number[],
   errorSteps: number[],
   amount: number,
   error: ?Error,
@@ -126,12 +125,10 @@ const INITIAL_STATE = {
   error: null,
   optimisticOperation: null,
   isAppOpened: false,
-  disabledSteps: [],
   errorSteps: [],
 }
 
 class SendModal extends PureComponent<Props, State<*>> {
-
   state = INITIAL_STATE
 
   componentWillUnmount() {
@@ -170,7 +167,14 @@ class SendModal extends PureComponent<Props, State<*>> {
 
   handleChangeAppOpened = (isAppOpened: boolean) => this.setState({ isAppOpened })
   handleChangeTransaction = transaction => this.setState({ transaction })
-  handleRetry = () => this.setState({ error: null, errorSteps: [] })
+  handleRetry = () => {
+    this.setState({
+      error: null,
+      errorSteps: [],
+      optimisticOperation: null,
+      isAppOpened: false,
+    })
+  }
 
   handleTransactionError = (error: Error) => {
     const stepVerificationIndex = this.STEPS.findIndex(step => step.id === 'verification')
@@ -228,7 +232,6 @@ class SendModal extends PureComponent<Props, State<*>> {
       stepId,
       account,
       isAppOpened,
-      disabledSteps,
       errorSteps,
       bridge,
       transaction,
@@ -269,7 +272,6 @@ class SendModal extends PureComponent<Props, State<*>> {
             onStepChange={this.handleStepChange}
             onClose={onClose}
             steps={this.STEPS}
-            disabledSteps={disabledSteps}
             errorSteps={errorSteps}
             {...addtionnalProps}
           >

--- a/src/components/modals/Send/index.js
+++ b/src/components/modals/Send/index.js
@@ -20,7 +20,7 @@ import type { StepProps as DefaultStepProps } from 'components/base/Stepper'
 
 import { getCurrentDevice } from 'reducers/devices'
 import { accountsSelector } from 'reducers/accounts'
-import { closeModal } from 'reducers/modals'
+import { closeModal, openModal } from 'reducers/modals'
 
 import Modal from 'components/base/Modal'
 import Stepper from 'components/base/Stepper'
@@ -38,6 +38,7 @@ type Props = {
   device: ?Device,
   accounts: Account[],
   closeModal: string => void,
+  openModal: (string, any) => void,
   updateAccountWithUpdater: (string, (Account) => Account) => void,
 }
 
@@ -62,6 +63,7 @@ export type StepProps<Transaction> = DefaultStepProps & {
   error: ?Error,
   optimisticOperation: ?Operation,
   closeModal: void => void,
+  openModal: (string, any) => void,
   isAppOpened: boolean,
   onChangeAccount: (?Account) => void,
   onChangeAppOpened: boolean => void,
@@ -111,6 +113,7 @@ const mapStateToProps = createStructuredSelector({
 
 const mapDispatchToProps = {
   closeModal,
+  openModal,
   updateAccountWithUpdater,
 }
 
@@ -128,16 +131,18 @@ const INITIAL_STATE = {
 }
 
 class SendModal extends PureComponent<Props, State<*>> {
+
   state = INITIAL_STATE
-  STEPS = createSteps({ t: this.props.t })
-  _signTransactionSub = null
-  _isUnmounted = false
 
   componentWillUnmount() {
     if (this._signTransactionSub) {
       this._signTransactionSub.unsubscribe()
     }
   }
+
+  STEPS = createSteps({ t: this.props.t })
+  _signTransactionSub = null
+  _isUnmounted = false
 
   handleReset = () => this.setState({ ...INITIAL_STATE })
 
@@ -218,7 +223,7 @@ class SendModal extends PureComponent<Props, State<*>> {
   }
 
   render() {
-    const { t, device } = this.props
+    const { t, device, openModal } = this.props
     const {
       stepId,
       account,
@@ -239,6 +244,7 @@ class SendModal extends PureComponent<Props, State<*>> {
       isAppOpened,
       error,
       optimisticOperation,
+      openModal,
       closeModal: this.handleCloseModal,
       onChangeAccount: this.handleChangeAccount,
       onChangeAppOpened: this.handleChangeAppOpened,

--- a/src/components/modals/Send/steps/04-step-confirmation.js
+++ b/src/components/modals/Send/steps/04-step-confirmation.js
@@ -55,19 +55,18 @@ export default function StepConfirmation({ t, optimisticOperation, error }: Step
     : error
       ? 'app:send.steps.confirmation.error'
       : 'app:send.steps.confirmation.pending'
+
+  const translatedErrTitle = error ? <TranslatedError error={error} /> || '' : ''
+  const translatedErrDesc = error ? <TranslatedError error={error} field="description" /> || '' : ''
   return (
     <Container>
       <TrackPage category="Send" name="Step4" />
       <span style={{ color: iconColor }}>
         <Icon size={43} />
       </span>
-      <Title>{t(`${tPrefix}.title`)}</Title>
+      <Title>{translatedErrTitle || t(`${tPrefix}.title`)}</Title>
       <Text style={{ userSelect: 'text' }} color="smoke">
-        {optimisticOperation ? (
-          multiline(t(`${tPrefix}.text`))
-        ) : error ? (
-          <TranslatedError error={error} />
-        ) : null}
+        {optimisticOperation ? multiline(t(`${tPrefix}.text`)) : error ? translatedErrDesc : null}
       </Text>
     </Container>
   )

--- a/src/components/modals/Send/steps/04-step-confirmation.js
+++ b/src/components/modals/Send/steps/04-step-confirmation.js
@@ -62,15 +62,12 @@ export default function StepConfirmation({ t, optimisticOperation, error }: Step
         <Icon size={43} />
       </span>
       <Title>{t(`${tPrefix}.title`)}</Title>
-      <Text style={{ userSelect: 'text' }}>
+      <Text style={{ userSelect: 'text' }} color="smoke">
         {optimisticOperation ? (
           multiline(t(`${tPrefix}.text`))
         ) : error ? (
           <TranslatedError error={error} />
         ) : null}
-      </Text>
-      <Text style={{ userSelect: 'text' }}>
-        {optimisticOperation ? optimisticOperation.hash : ''}
       </Text>
     </Container>
   )

--- a/src/components/modals/Send/steps/04-step-confirmation.js
+++ b/src/components/modals/Send/steps/04-step-confirmation.js
@@ -1,10 +1,10 @@
 // @flow
 
 import React, { Fragment } from 'react'
-import { shell } from 'electron'
 import styled from 'styled-components'
 import { getAccountOperationExplorer } from '@ledgerhq/live-common/lib/explorers'
 
+import { MODAL_OPERATION_DETAILS } from 'config/constants'
 import { colors } from 'styles/theme'
 import { multiline } from 'styles/helpers'
 
@@ -83,6 +83,7 @@ export function StepConfirmationFooter({
   onRetry,
   optimisticOperation,
   error,
+  openModal,
   closeModal,
 }: StepProps<*>) {
   const url =
@@ -96,8 +97,13 @@ export function StepConfirmationFooter({
           <Button
             ml={2}
             onClick={() => {
-              shell.openExternal(url)
               closeModal()
+              if (account && optimisticOperation) {
+                openModal(MODAL_OPERATION_DETAILS, {
+                  operationId: optimisticOperation.id,
+                  accountId: account.id,
+                })
+              }
             }}
             primary
           >

--- a/static/i18n/en/app.yml
+++ b/static/i18n/en/app.yml
@@ -284,7 +284,7 @@ send:
       success:
         title: Transaction sent
         text: |
-          The transaction has been signed and sent to the network. Your account balance will update once the blockchain has confirmed the transaction. It has the following Transaction ID:
+          The transaction has been signed and sent to the network. Your account balance will update once the blockchain has confirmed the transaction.
         cta: View operation details
       error:
         title: Transaction canceled


### PR DESCRIPTION
- Modify amount color on operation detail when < 0
- Open OperationDetail modal after transaction success
- Correct reset send modal state when pressing back/retry
- Apparently its a good idea to hide tx hash from user
- Display more precise error on transaction confirmation
