### PR TITLE
don't disable the displayName of styled components

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -24,7 +24,7 @@ module.exports = () => ({
     [
       require('babel-plugin-styled-components'),
       {
-        displayName: NODE_ENV === 'development',
+        displayName: true,
         ssr: __TEST__,
       },
     ],


### PR DESCRIPTION
this will allow better understanding of Sentry errors.
