### PR TITLE
react-select: use menuPlacement="auto"

### DIFF
--- a/src/components/base/Select/index.js
+++ b/src/components/base/Select/index.js
@@ -75,6 +75,7 @@ class Select extends PureComponent<Props> {
         isLoading={isLoading}
         isClearable={isClearable}
         isSearchable={isSearchable}
+        menuPlacement="auto"
         blurInputOnSelect={false}
         backspaceRemovesValue
         menuShouldBlockScroll


### PR DESCRIPTION
so the region select opens up instead of down

### Type

polish

### Parts of the app affected / Test plan

all selects