### PR TITLE
Proposal of wording for sync

### DIFF
--- a/static/i18n/en/app.yml
+++ b/static/i18n/en/app.yml
@@ -46,8 +46,8 @@ common:
     lostPassword: I lost my password
   sync:
     syncing: Synchronizing...
-    upToDate: Up to date
-    outdated: Outdated
+    upToDate: Synchronized
+    outdated: Paused
     error: Synchronization error
     refresh: Refresh
     ago: Synced {{time}}


### PR DESCRIPTION
- Synchronized (instead of Up to date, because up to date is not clear if it means app is up to date (or device is up to date) )
- Paused (instead of Outdated) because it's what it really is. it should only really happen when you open a critical modal like send flow / add account, because we pause the sync of all accounts to leave room for libcore to do more important stuff

### Type

wording

### Context

last week discussions

### Parts of the app affected / Test plan

sync header
