### PR TITLE
Fix GrowScroll style (fixes onboarding step 1 centering)

### DIFF
--- a/src/components/base/GrowScroll/index.js
+++ b/src/components/base/GrowScroll/index.js
@@ -52,6 +52,8 @@ class GrowScroll extends PureComponent<Props> {
       overflowY: 'scroll',
       marginRight: `-${80 + scrollbarWidth}px`,
       paddingRight: `80px`,
+      display: 'flex',
+      flexDirection: 'column',
       ...(maxHeight
         ? {
             maxHeight,
@@ -68,7 +70,7 @@ class GrowScroll extends PureComponent<Props> {
     return (
       <div style={rootStyles}>
         <div style={scrollContainerStyles} ref={this.onScrollContainerRef}>
-          <Box {...props}>
+          <Box grow {...props}>
             <GrowScrollContext.Provider value={this.valueProvider}>
               {children}
             </GrowScrollContext.Provider>


### PR DESCRIPTION
set the inner container to be flex column displayed.
that allow children to grow, so it gives vertical centering + scroll for free to children

### Type

not really a bug fix, not really an improvement

### Context

whole app. but done for onboarding step 1