### PR TITLE
Receive modal should go to step device is account is given

### DIFF
--- a/src/components/modals/Receive/index.js
+++ b/src/components/modals/Receive/index.js
@@ -114,7 +114,7 @@ class ReceiveModal extends PureComponent<Props, State> {
 
     if (!account) {
       if (data && data.account) {
-        this.setState({ account: data.account })
+        this.setState({ account: data.account, stepId: 'device' })
       } else {
         this.setState({ account: accounts[0] })
       }


### PR DESCRIPTION
### Type

fix regression inducted by receive modal refacto

### Context

when we receive open modal from account page, it should appear on device step, not account selection step like it's actually

### Parts of the app affected / Test plan

receive modal opened from account page