### PR TITLE
Prevent check recipient valid if empty

### DIFF
--- a/src/bridge/LibcoreBridge.js
+++ b/src/bridge/LibcoreBridge.js
@@ -52,6 +52,7 @@ const isRecipientValid = (currency, recipient) => {
   const key = `${currency.id}_${recipient}`
   let promise = recipientValidLRU.get(key)
   if (promise) return promise
+  if (!recipient) return Promise.resolve(false)
   promise = libcoreValidAddress
     .send({
       address: recipient,

--- a/src/components/modals/Send/fields/RecipientField.js
+++ b/src/components/modals/Send/fields/RecipientField.js
@@ -3,7 +3,6 @@ import React, { Component } from 'react'
 import type { Account } from '@ledgerhq/live-common/lib/types'
 import type { T } from 'types/common'
 import type { WalletBridge } from 'bridge/types'
-import logger from 'logger'
 import Box from 'components/base/Box'
 import Label from 'components/base/Label'
 import LabelInfoTooltip from 'components/base/LabelInfoTooltip'
@@ -40,16 +39,12 @@ class RecipientField<Transaction> extends Component<Props<Transaction>, { isVali
   async resync() {
     const { account, bridge, transaction } = this.props
     const syncId = ++this.syncId
-    try {
-      const isValid = await bridge.isRecipientValid(
-        account.currency,
-        bridge.getTransactionRecipient(account, transaction),
-      )
-      if (syncId !== this.syncId) return
-      this.setState({ isValid })
-    } catch (err) {
-      logger.warn(`Can't check if recipient is valid`, err)
-    }
+    const isValid = await bridge.isRecipientValid(
+      account.currency,
+      bridge.getTransactionRecipient(account, transaction),
+    )
+    if (syncId !== this.syncId) return
+    this.setState({ isValid })
   }
 
   onChange = (recipient: string, maybeExtra: ?Object) => {

--- a/src/components/modals/Send/fields/RecipientField.js
+++ b/src/components/modals/Send/fields/RecipientField.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import type { Account } from '@ledgerhq/live-common/lib/types'
 import type { T } from 'types/common'
 import type { WalletBridge } from 'bridge/types'
+import logger from 'logger'
 import Box from 'components/base/Box'
 import Label from 'components/base/Label'
 import LabelInfoTooltip from 'components/base/LabelInfoTooltip'
@@ -39,12 +40,16 @@ class RecipientField<Transaction> extends Component<Props<Transaction>, { isVali
   async resync() {
     const { account, bridge, transaction } = this.props
     const syncId = ++this.syncId
-    const isValid = await bridge.isRecipientValid(
-      account.currency,
-      bridge.getTransactionRecipient(account, transaction),
-    )
-    if (syncId !== this.syncId) return
-    this.setState({ isValid })
+    try {
+      const isValid = await bridge.isRecipientValid(
+        account.currency,
+        bridge.getTransactionRecipient(account, transaction),
+      )
+      if (syncId !== this.syncId) return
+      this.setState({ isValid })
+    } catch (err) {
+      logger.warn(`Can't check if recipient is valid`, err)
+    }
   }
 
   onChange = (recipient: string, maybeExtra: ?Object) => {


### PR DESCRIPTION
And add a catch to fallback + warning if check throwed

### Type

bug fix

### Context

on opening the send modal, a check was done directly to see if recipient is valid. at least on linux, this check - when done by libcore - is making internal process crash (SIGSEGV)

this commit only prevent checking empty recipient, and also add warning if this case occur (it will, in case of bad address)