### PR TITLE
Prevent ticker animation when changing account page at lower level

### DIFF
--- a/src/components/AccountPage/AccountBalanceSummaryHeader.js
+++ b/src/components/AccountPage/AccountBalanceSummaryHeader.js
@@ -28,7 +28,7 @@ type OwnProps = {
   totalBalance: number,
   sinceBalance: number,
   refBalance: number,
-  accountId: string, // eslint-disable-line
+  accountId: string,
 }
 
 type Props = OwnProps & {
@@ -57,6 +57,7 @@ class AccountBalanceSummaryHeader extends PureComponent<Props> {
   render() {
     const {
       account,
+      accountId,
       t,
       counterValue,
       selectedTimeRange,
@@ -76,6 +77,7 @@ class AccountBalanceSummaryHeader extends PureComponent<Props> {
             unit={account.unit}
           >
             <FormattedVal
+              key={accountId}
               animateTicker
               disableRounding
               alwaysShowSign={false}

--- a/src/components/AccountPage/index.js
+++ b/src/components/AccountPage/index.js
@@ -68,8 +68,7 @@ class AccountPage extends PureComponent<Props> {
     }
 
     return (
-      // `key` forces re-render account page when going an another account (skip animations)
-      <Box key={account.id}>
+      <Box>
         <TrackPage
           category="Account"
           currency={account.currency.id}


### PR DESCRIPTION
this reduce amount of nodes to be fully re-rendered
this key purpose was only to prevent ticker animation