### PR TITLE
translated error wired into receive modal and the Upgrade Firmware ca…

### DIFF
--- a/src/commands/getAddress.js
+++ b/src/commands/getAddress.js
@@ -6,6 +6,11 @@ import { fromPromise } from 'rxjs/observable/fromPromise'
 import { withDevice } from 'helpers/deviceAccess'
 import getAddressForCurrency from 'helpers/getAddressForCurrency'
 
+import { createCustomErrorClass } from 'helpers/errors'
+
+const DeviceAppVerifyNotSupported = createCustomErrorClass('DeviceAppVerifyNotSupported')
+const UserRefusedAddress = createCustomErrorClass('UserRefusedAddress')
+
 type Input = {
   currencyId: string,
   devicePath: string,
@@ -26,7 +31,17 @@ const cmd: Command<Input, Result> = createCommand(
     fromPromise(
       withDevice(devicePath)(transport =>
         getAddressForCurrency(transport, getCryptoCurrencyById(currencyId), path, options),
-      ),
+      ).catch(e => {
+        if (e && e.name === 'TransportStatusError') {
+          if (e.statusCode === 0x6b00 && options.verify) {
+            throw new DeviceAppVerifyNotSupported()
+          }
+          if (e.statusCode === 0x6985) {
+            throw new UserRefusedAddress()
+          }
+        }
+        throw e
+      }),
     ),
 )
 

--- a/src/components/SettingsPage/ResetButton.js
+++ b/src/components/SettingsPage/ResetButton.js
@@ -75,7 +75,7 @@ export const IconWrapperCircle = styled(Box)`
   height: 50px;
   border-radius: 50%;
   background: #ea2e4919;
-  text-align: center;
+  align-items: center;
   justify-content: center;
 `
 

--- a/src/components/modals/Receive/index.js
+++ b/src/components/modals/Receive/index.js
@@ -41,6 +41,7 @@ type State = {
   isAddressVerified: ?boolean,
   disabledSteps: number[],
   errorSteps: number[],
+  verifyAddressError: ?Error,
 }
 
 export type StepProps = DefaultStepProps & {
@@ -49,12 +50,13 @@ export type StepProps = DefaultStepProps & {
   closeModal: void => void,
   isAppOpened: boolean,
   isAddressVerified: ?boolean,
+  verifyAddressError: ?Error,
   onRetry: void => void,
   onSkipConfirm: void => void,
   onResetSkip: void => void,
   onChangeAccount: (?Account) => void,
   onChangeAppOpened: boolean => void,
-  onChangeAddressVerified: (?boolean) => void,
+  onChangeAddressVerified: (?boolean, ?Error) => void,
 }
 
 const createSteps = ({ t }: { t: T }) => [
@@ -102,6 +104,7 @@ const INITIAL_STATE = {
   isAddressVerified: null,
   disabledSteps: [],
   errorSteps: [],
+  verifyAddressError: null,
 }
 
 class ReceiveModal extends PureComponent<Props, State> {
@@ -127,16 +130,17 @@ class ReceiveModal extends PureComponent<Props, State> {
   handleStepChange = step => this.setState({ stepId: step.id })
   handleChangeAccount = (account: ?Account) => this.setState({ account })
   handleChangeAppOpened = (isAppOpened: boolean) => this.setState({ isAppOpened })
-  handleChangeAddressVerified = (isAddressVerified: boolean) => {
+  handleChangeAddressVerified = (isAddressVerified: boolean, err: ?Error) => {
     if (isAddressVerified) {
-      this.setState({ isAddressVerified })
+      this.setState({ isAddressVerified, verifyAddressError: err })
     } else if (isAddressVerified === null) {
-      this.setState({ isAddressVerified: null, errorSteps: [] })
+      this.setState({ isAddressVerified: null, errorSteps: [], verifyAddressError: err })
     } else {
       const confirmStepIndex = this.STEPS.findIndex(step => step.id === 'confirm')
       if (confirmStepIndex > -1) {
         this.setState({
           isAddressVerified,
+          verifyAddressError: err,
           errorSteps: [confirmStepIndex],
         })
       }
@@ -161,6 +165,7 @@ class ReceiveModal extends PureComponent<Props, State> {
       isAddressVerified,
       disabledSteps,
       errorSteps,
+      verifyAddressError,
     } = this.state
 
     const addtionnalProps = {
@@ -168,6 +173,7 @@ class ReceiveModal extends PureComponent<Props, State> {
       account,
       isAppOpened,
       isAddressVerified,
+      verifyAddressError,
       closeModal: this.handleCloseModal,
       onRetry: this.handleRetry,
       onSkipConfirm: this.handleSkipConfirm,

--- a/src/components/modals/Receive/steps/03-step-confirm-address.js
+++ b/src/components/modals/Receive/steps/03-step-confirm-address.js
@@ -15,6 +15,7 @@ import CurrentAddressForAccount from 'components/CurrentAddressForAccount'
 import { WrongDeviceForAccount } from 'components/EnsureDeviceApp'
 
 import type { StepProps } from '../index'
+import TranslatedError from '../../../TranslatedError'
 
 export default class StepConfirmAddress extends PureComponent<StepProps> {
   componentDidMount() {
@@ -43,12 +44,12 @@ export default class StepConfirmAddress extends PureComponent<StepProps> {
       onChangeAddressVerified(true)
       transitionTo('receive')
     } catch (err) {
-      onChangeAddressVerified(false)
+      onChangeAddressVerified(false, err)
     }
   }
 
   render() {
-    const { t, device, account, isAddressVerified } = this.props
+    const { t, device, account, isAddressVerified, verifyAddressError } = this.props
     invariant(account, 'No account given')
     invariant(device, 'No device given')
     return (
@@ -56,8 +57,12 @@ export default class StepConfirmAddress extends PureComponent<StepProps> {
         <TrackPage category="Receive" name="Step3" />
         {isAddressVerified === false ? (
           <Fragment>
-            <Title>{t('app:receive.steps.confirmAddress.error.title')}</Title>
-            <Text mb={5}>{t('app:receive.steps.confirmAddress.error.text')}</Text>
+            <Title>
+              <TranslatedError error={verifyAddressError} />
+            </Title>
+            <Text mb={5}>
+              <TranslatedError error={verifyAddressError} field="description" />
+            </Text>
             <DeviceConfirm error />
           </Fragment>
         ) : (

--- a/static/i18n/en/app.yml
+++ b/static/i18n/en/app.yml
@@ -250,9 +250,6 @@ receive:
       action: Confirm address on device
       text: Verify that the address below matches the address displayed on your device
       support: Contact us
-      error:
-        title: Receive address rejected
-        text: Please try again or contact Support when in doubt
     receiveFunds:
       title: Receive
       label: Amount (optional)

--- a/static/i18n/en/errors.yml
+++ b/static/i18n/en/errors.yml
@@ -99,5 +99,5 @@ WrongDeviceForAccount:
   title: Oops, wrong device for ‘{{accountName}}’.
   description: The connected device is not associated with the account you selected. Please connect the right device.
 DeviceAppVerifyNotSupported:
-  title: Open Manager to update firmware
+  title: Open Manager to update this App
   description: The app verification is not supported

--- a/static/i18n/en/errors.yml
+++ b/static/i18n/en/errors.yml
@@ -83,6 +83,9 @@ TransportStatusError:
 UserRefusedOnDevice:
   title: Transaction refused on device
   description: Please retry or contact Ledger Support in case of doubt.
+UserRefusedAddress:
+  title: Receive address rejected
+  description: Please try again or contact Support
 WebsocketConnectionError:
   title: Sorry, try again (websocket error).
   description:  #context
@@ -95,3 +98,6 @@ WrongAppOpened:
 WrongDeviceForAccount:
   title: Oops, wrong device for ‘{{accountName}}’.
   description: The connected device is not associated with the account you selected. Please connect the right device.
+DeviceAppVerifyNotSupported:
+  title: Open Manager to update firmware
+  description: The app verification is not supported


### PR DESCRIPTION
1) Hardcoded error on Receive removed, translated error added with a few cases handled (reject operation and upgrade firmware)
2) Small centering polish for the confirmModal icon
### Type

Bug Fix, Code Quality Improvement

### Context

Testing with Blue showed a non descriptive error which was a hardcoded generic error
### Parts of the app affected

Test plan

Receive Modal