### PR TITLE
Fix logger to get logs from libcore

### DIFF
--- a/src/helpers/init-libcore.js
+++ b/src/helpers/init-libcore.js
@@ -122,7 +122,7 @@ const NJSLogPrinter = new lib.NJSLogPrinter({
   printWarning: message => logger.libcore('Warning', message),
   printApdu: message => logger.libcore('Apdu', message),
   printCriticalError: message => logger.libcore('CriticalError', message),
-  getContext: () => NJSThreadDispatcher.getMainExecutionContext(),
+  getContext: () => new lib.NJSExecutionContext(NJSExecutionContextImpl),
 })
 
 const NJSRandomNumberGenerator = new lib.NJSRandomNumberGenerator({


### PR DESCRIPTION
Fix logger to get logs from libcore, getting a new instance of execution context for custom logger

### Type

Improvement

### Context

Discussion: get logs from libcore

### Parts of the app affected / Test plan

Initialization of libcore
