### PR TITLE
Send step1: initial focus on account select if opened from global

### DIFF
--- a/src/components/modals/Send/index.js
+++ b/src/components/modals/Send/index.js
@@ -44,6 +44,7 @@ type Props = {
 
 type State<Transaction> = {
   stepId: string,
+  openedFromAccount: boolean,
   account: ?Account,
   bridge: ?WalletBridge<Transaction>,
   transaction: ?Transaction,
@@ -54,6 +55,7 @@ type State<Transaction> = {
 }
 
 export type StepProps<Transaction> = DefaultStepProps & {
+  openedFromAccount: boolean,
   device: ?Device,
   account: ?Account,
   bridge: ?WalletBridge<Transaction>,
@@ -118,6 +120,7 @@ const mapDispatchToProps = {
 const INITIAL_STATE = {
   stepId: 'amount',
   amount: 0,
+  openedFromAccount: false,
   account: null,
   bridge: null,
   transaction: null,
@@ -151,7 +154,12 @@ class SendModal extends PureComponent<Props, State<*>> {
       const account = (data && data.account) || accounts[0]
       const bridge = account ? getBridgeForCurrency(account.currency) : null
       const transaction = bridge ? bridge.createTransaction(account) : null
-      this.setState({ account, bridge, transaction })
+      this.setState({
+        openedFromAccount: !!(data && data.account),
+        account,
+        bridge,
+        transaction,
+      })
     }
   }
 
@@ -227,6 +235,7 @@ class SendModal extends PureComponent<Props, State<*>> {
     const { t, device, openModal } = this.props
     const {
       stepId,
+      openedFromAccount,
       account,
       isAppOpened,
       bridge,
@@ -237,6 +246,7 @@ class SendModal extends PureComponent<Props, State<*>> {
 
     const addtionnalProps = {
       device,
+      openedFromAccount,
       account,
       bridge,
       transaction,

--- a/src/components/modals/Send/steps/01-step-amount.js
+++ b/src/components/modals/Send/steps/01-step-amount.js
@@ -20,6 +20,7 @@ export default ({
   t,
   account,
   bridge,
+  openedFromAccount,
   transaction,
   onChangeAccount,
   onChangeTransaction,
@@ -35,14 +36,14 @@ export default ({
     <Box flow={4}>
       <Box flow={1}>
         <Label>{t('app:send.steps.amount.selectAccountDebit')}</Label>
-        <SelectAccount onChange={onChangeAccount} value={account} />
+        <SelectAccount autoFocus={!openedFromAccount} onChange={onChangeAccount} value={account} />
       </Box>
 
       {account &&
         bridge &&
         transaction && (
           <RecipientField
-            autoFocus
+            autoFocus={openedFromAccount}
             account={account}
             bridge={bridge}
             transaction={transaction}


### PR DESCRIPTION
if we open with the global Send button, we will focus the accounts select by default instead of the recipient because you actually likely want to change account first.

### Type

polish

### Context

discussion with brian

### Parts of the app affected / Test plan


send