### PR TITLE
Report internal crashes

### DIFF
--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -11,6 +11,14 @@ require('../env')
 
 process.title = 'Internal'
 
+process.on('uncaughtException', err => {
+  process.send({
+    type: 'uncaughtException',
+    error: serializeError(err),
+  })
+  process.exit(1)
+})
+
 const defers = {}
 
 let sentryEnabled = process.env.INITIAL_SENTRY_ENABLED || false

--- a/src/main/bridge.js
+++ b/src/main/bridge.js
@@ -7,8 +7,9 @@ import { ipcMain, app } from 'electron'
 import { ipcMainListenReceiveCommands } from 'helpers/ipc'
 import path from 'path'
 import logger from 'logger'
-import sentry from 'sentry/node'
+import sentry, { captureException } from 'sentry/node'
 import user from 'helpers/user'
+import { deserializeError } from 'helpers/errors'
 
 import setupAutoUpdater, { quitAndInstall } from './autoUpdate'
 import { setInternalProcessPID } from './terminator'
@@ -100,6 +101,11 @@ ipcMainListenReceiveCommands({
 
 function handleGlobalInternalMessage(payload) {
   switch (payload.type) {
+    case 'uncaughtException': {
+      const err = deserializeError(payload.error)
+      captureException(err)
+      break
+    }
     case 'setLibcoreBusy':
     case 'setDeviceBusy':
     case 'executeHttpQueryOnRenderer': {


### PR DESCRIPTION
capture the uncaughtException event of the internal process to report to sentry

### Type

crash logs improvement

### Context

#811 
