### PR TITLE
Update balance summary hash to be refreshed after fetching cv

### DIFF
--- a/src/components/CalculateBalance.js
+++ b/src/components/CalculateBalance.js
@@ -79,7 +79,7 @@ const mapStateToProps = (state: State, props: OwnProps) => {
     balanceHistory,
     balanceStart: balanceHistory[0].value,
     balanceEnd,
-    hash: `${balanceHistory.length}_${balanceEnd}`,
+    hash: `${balanceHistory.length}_${balanceEnd}_${isAvailable.toString()}`,
   }
 }
 


### PR DESCRIPTION
include `isAvailable` in balance summary hash, so the chart/other stuff is correctly refreshed after you fetch countervalues for the first time