### PR TITLE
disable analytics by default and reposition, reword analytics

### DIFF
--- a/src/components/Onboarding/steps/Analytics.js
+++ b/src/components/Onboarding/steps/Analytics.js
@@ -26,7 +26,7 @@ type State = {
 }
 
 const INITIAL_STATE = {
-  analyticsToggle: true,
+  analyticsToggle: false,
   sentryLogsToggle: true,
 }
 
@@ -75,21 +75,26 @@ class Analytics extends PureComponent<StepProps, State> {
           <Box mt={5}>
             <Container>
               <Box>
-                <Box mb={1}>
-                  <AnalyticsTitle>{t('onboarding:analytics.sentryLogs.title')}</AnalyticsTitle>
+                <Box horizontal mb={1}>
+                  <AnalyticsTitle>{t('onboarding:analytics.technicalData.title')}</AnalyticsTitle>
+                  <FakeLink
+                    underline
+                    fontSize={3}
+                    color="smoke"
+                    ml={2}
+                    onClick={this.handleTechnicalDataModal}
+                  >
+                    {t('app:common.learnMore')}
+                  </FakeLink>
                 </Box>
-                <AnalyticsText>{t('onboarding:analytics.sentryLogs.desc')}</AnalyticsText>
+                <TechnicalData />
+                <AnalyticsText>{t('onboarding:analytics.technicalData.desc')}</AnalyticsText>
+                <MandatoryText>
+                  {t('onboarding:analytics.technicalData.mandatoryText')}
+                </MandatoryText>
               </Box>
               <Box justifyContent="center">
-                <Track
-                  onUpdate
-                  event={
-                    sentryLogsToggle
-                      ? 'Sentry Logs Enabled Onboarding'
-                      : 'Sentry Logs Disabled Onboarding'
-                  }
-                />
-                <Switch isChecked={sentryLogsToggle} onChange={this.handleSentryLogsToggle} />
+                <Switch disabled isChecked />
               </Box>
             </Container>
             <Container>
@@ -123,26 +128,21 @@ class Analytics extends PureComponent<StepProps, State> {
             </Container>
             <Container>
               <Box>
-                <Box horizontal mb={1}>
-                  <AnalyticsTitle>{t('onboarding:analytics.technicalData.title')}</AnalyticsTitle>
-                  <FakeLink
-                    underline
-                    fontSize={3}
-                    color="smoke"
-                    ml={2}
-                    onClick={this.handleTechnicalDataModal}
-                  >
-                    {t('app:common.learnMore')}
-                  </FakeLink>
+                <Box mb={1}>
+                  <AnalyticsTitle>{t('onboarding:analytics.sentryLogs.title')}</AnalyticsTitle>
                 </Box>
-                <TechnicalData />
-                <AnalyticsText>{t('onboarding:analytics.technicalData.desc')}</AnalyticsText>
-                <MandatoryText>
-                  {t('onboarding:analytics.technicalData.mandatoryText')}
-                </MandatoryText>
+                <AnalyticsText>{t('onboarding:analytics.sentryLogs.desc')}</AnalyticsText>
               </Box>
               <Box justifyContent="center">
-                <Switch disabled isChecked />
+                <Track
+                  onUpdate
+                  event={
+                    sentryLogsToggle
+                      ? 'Sentry Logs Enabled Onboarding'
+                      : 'Sentry Logs Disabled Onboarding'
+                  }
+                />
+                <Switch isChecked={sentryLogsToggle} onChange={this.handleSentryLogsToggle} />
               </Box>
             </Container>
           </Box>

--- a/src/components/modals/TechnicalData.js
+++ b/src/components/modals/TechnicalData.js
@@ -38,10 +38,6 @@ class TechnicalData extends PureComponent<Props, *> {
         key: 'item5',
         desc: t('onboarding:analytics.technicalData.mandatoryContextual.item5'),
       },
-      {
-        key: 'item6',
-        desc: t('onboarding:analytics.technicalData.mandatoryContextual.item6'),
-      },
     ]
 
     return (

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -76,7 +76,7 @@ const INITIAL_STATE: SettingsState = {
   currenciesSettings: {},
   developerMode: !!process.env.__DEV__,
   loaded: false,
-  shareAnalytics: true,
+  shareAnalytics: false,
   sentryLogs: true,
   lastUsedVersion: __APP_VERSION__,
 }

--- a/static/i18n/en/onboarding.yml
+++ b/static/i18n/en/onboarding.yml
@@ -129,8 +129,8 @@ analytics:
   title: Analytics and bug reports
   desc: Share anonymous usage and diagnostics data to help improve Ledger products, services and security features.
   shareAnalytics:
-    title: Share usage data
-    desc: Enable analytics of anonymous data to help Ledger improve the user experience. This includes the operating system, language, firmware versions and the number of added accounts.
+    title: Share analytics
+    desc: Enable analytics to help Ledger understand how to improve the user experience.
     mandatoryContextual:
       item1: Page visits
       item2: Actions (send, receive, logout)
@@ -147,16 +147,15 @@ analytics:
     desc: Automatically send reports to help Ledger fix bugs
   technicalData:
      title: Technical data *
-     desc: Ledger will automatically collect technical information to help improve user experience. This information is fully anonymized.
+     desc: Ledger will automatically collect technical information to get basic feedback on usage. This information is anonymous and does not contain personal data.
      mandatoryText: '* mandatory'
      mandatoryContextual:
        title: Technical data
-       item1: Active unique users
-       item2: OS name
-       item3: OS versions
-       item4: Ledger Live application version
-       item5: App Language/Region
-       item6: OS Language/Region
+       item1: Anonymous unique application ID
+       item2: OS name and version
+       item3: Ledger Live version
+       item4: Application language or region
+       item5: OS Language/Region
 finish:
   title: Your device is ready!
   desc: Proceed to your portfolio and start adding your accounts...


### PR DESCRIPTION
Analytics disabled by default by request 
Items on the Analytics Page on Onboarding repositioned and reworded 

### Type

UI Polish
### Context
Following all the meetings this is the final version so far 

### Parts of the app affected / Test plan

Onboarding/Analytics 
General Analytics across the app