### PR TITLE
Use another representation for op id to fix Details blink

### DIFF
--- a/src/commands/libcoreSignAndBroadcast.js
+++ b/src/commands/libcoreSignAndBroadcast.js
@@ -210,7 +210,7 @@ export async function doSignAndBroadcast({
 
   // NB we don't check isCancelled() because the broadcast is not cancellable now!
   onOperationBroadcasted({
-    id: txHash,
+    id: `${account.xpub}-${txHash}-OUT`,
     hash: txHash,
     type: 'OUT',
     value: transaction.amount,

--- a/src/helpers/libcore.js
+++ b/src/helpers/libcore.js
@@ -428,7 +428,6 @@ function buildOperationRaw({
   op: NJSOperation,
   xpub: string,
 }): OperationRaw {
-  const id = op.getUid()
   const bitcoinLikeOperation = op.asBitcoinLikeOperation()
   const bitcoinLikeTransaction = bitcoinLikeOperation.getTransaction()
   const hash = bitcoinLikeTransaction.getHash()
@@ -448,6 +447,8 @@ function buildOperationRaw({
     value += fee
   }
 
+  const id = `${xpub}-${hash}-${type}`
+
   return {
     id,
     hash,
@@ -458,7 +459,7 @@ function buildOperationRaw({
     recipients: op.getRecipients(),
     blockHeight: op.getBlockHeight(),
     blockHash: null,
-    accountId: xpub,
+    accountId: xpub, // FIXME accountId: xpub  !?
     date: op.getDate().toISOString(),
   }
 }


### PR DESCRIPTION
when broadcasting a transaction and opening the operation detail, it was closing when it was confirmed by a sync. this is because the op disappear from pendingOperations and appear in operations **but with a different id**. so this is now fixed.

Later note: for optimistic updates: we should be able to keep all pendingOperations and by id filtering them out and just maybe a security timeout to make it gone after a while

### Type

Bugfix

### Context

bug recently found

### Parts of the app affected / Test plan

operation related parts