### PR TITLE
Drop error called ManagerUnexpectedError

### DIFF
--- a/src/helpers/apps/installApp.js
+++ b/src/helpers/apps/installApp.js
@@ -9,7 +9,6 @@ import type { LedgerScriptParams } from 'helpers/common'
 
 import { createCustomErrorClass } from '../errors'
 
-const ManagerUnexpectedError = createCustomErrorClass('ManagerUnexpected')
 const ManagerNotEnoughSpaceError = createCustomErrorClass('ManagerNotEnoughSpace')
 const ManagerDeviceLockedError = createCustomErrorClass('ManagerDeviceLocked')
 const ManagerAppAlreadyInstalledError = createCustomErrorClass('ManagerAppAlreadyInstalled')
@@ -27,7 +26,7 @@ function remapError(promise) {
       case e.message.endsWith('6a83'):
         throw new ManagerAppRelyOnBTCError()
       default:
-        throw new ManagerUnexpectedError(e.message, { msg: e.message })
+        throw e
     }
   })
 }

--- a/src/helpers/apps/uninstallApp.js
+++ b/src/helpers/apps/uninstallApp.js
@@ -8,7 +8,6 @@ import { createDeviceSocket } from 'helpers/socket'
 import type { LedgerScriptParams } from 'helpers/common'
 import { createCustomErrorClass } from '../errors'
 
-const ManagerUnexpectedError = createCustomErrorClass('ManagerUnexpectedError')
 const ManagerDeviceLockedError = createCustomErrorClass('ManagerDeviceLocked')
 const ManagerUninstallBTCDep = createCustomErrorClass('ManagerUninstallBTCDep')
 
@@ -20,7 +19,7 @@ function remapError(promise) {
       case e.message.endsWith('6a83'):
         throw new ManagerUninstallBTCDep()
       default:
-        throw new ManagerUnexpectedError(e.message, { msg: e.message })
+        throw e
     }
   })
 }

--- a/static/i18n/en/errors.yml
+++ b/static/i18n/en/errors.yml
@@ -65,9 +65,6 @@ ManagerDeviceLocked:
 ManagerNotEnoughSpace:
   title: Sorry, insufficient device storage
   description: Uninstall some apps to increase available storage and try again.
-ManagerUnexpected:
-  title: That's unexpected ({{msg}}) #(Manager: {{msg}})
-  description: Please try again.
 ManagerUninstallBTCDep:
   title: Sorry, Bitcoin is required # include {{currencyName}}
   description: First uninstall apps that depend on Bitcoin.


### PR DESCRIPTION
this make error uglier and actually lose precision of what the actual error is. when we remap errors we shouldn't abstract them out but only "differenciate" them.

meaning that we don't merge 2 errors cases into 1, instead we split 1 error case into many. That way we have the best possible precision of the error. If technically we want to hide things and not show to user the actual thing, well then it's a matter of UI, but in the code we do not abstract them to still allow precision.

### Type

polish

### Context

<img width="379" alt="capture d ecran 2018-07-05 a 17 52 52" src="https://user-images.githubusercontent.com/211411/42333898-443d5ee8-807c-11e8-8fde-15225465fe74.png">

is a wrong error, we need to use the actual error of errors.yml by keeping the initial error

### Parts of the app affected / Test plan

manager