### PR TITLE
Use libcore major version to prefix the db path

### DIFF
--- a/src/helpers/init-libcore.js
+++ b/src/helpers/init-libcore.js
@@ -13,8 +13,9 @@ const fs = require('fs')
 
 const MAX_RANDOM = 2684869021
 
-// increment this number to "clear" sqlite db (it will use another path :D)
-const DB_VERSION = 1
+const core = new lib.NJSLedgerCore()
+const stringVersion = core.getStringVersion()
+const sqlitePrefix = `v${stringVersion.split('.')[0]}`
 
 const bytesArrayToString = (bytesArray = []) => Buffer.from(bytesArray).toString()
 
@@ -151,15 +152,15 @@ const instanciateWalletPool = ({ dbPath }) => {
   const NJSPathResolver = new lib.NJSPathResolver({
     resolveLogFilePath: pathToResolve => {
       const hash = pathToResolve.replace(/\//g, '__')
-      return path.resolve(dbPath, `./log_file_${DB_VERSION}_${hash}`)
+      return path.resolve(dbPath, `./log_file_${sqlitePrefix}_${hash}`)
     },
     resolvePreferencesPath: pathToResolve => {
       const hash = pathToResolve.replace(/\//g, '__')
-      return path.resolve(dbPath, `./preferences_${DB_VERSION}_${hash}`)
+      return path.resolve(dbPath, `./preferences_${sqlitePrefix}_${hash}`)
     },
     resolveDatabasePath: pathToResolve => {
       const hash = pathToResolve.replace(/\//g, '__')
-      return path.resolve(dbPath, `./database_${DB_VERSION}_${hash}`)
+      return path.resolve(dbPath, `./database_${sqlitePrefix}_${hash}`)
     },
   })
 


### PR DESCRIPTION
this way, we always stick to what libcore major version is. each time there is a breaking change in libcore (db schema / whatever) , it needs to increment its major for our app to automatically migrate the db.

cc @pollastri-pierre  @KhalilBellakrid 


NB: i've intentionally prefixed it with a 'v'. because the current 'v1' has breaking change from yesterday, so in the future, make sure to respect incrementing the libcore major 🙏  