### PR TITLE
Amount field must remount when account changes

### DIFF
--- a/src/components/modals/Send/steps/01-step-amount.js
+++ b/src/components/modals/Send/steps/01-step-amount.js
@@ -58,6 +58,7 @@ export default ({
         bridge &&
         transaction && (
           <AmountField
+            key={account.id}
             account={account}
             bridge={bridge}
             transaction={transaction}


### PR DESCRIPTION
Fixes a critical bug where if you open an Ethereum account, hit send and then switch crypto, you can end up in very weird amount state.

### Type

Bug


### Parts of the app affected / Test plan

Send, step 1