### PR TITLE
Better error precision on canBeSpent cases

### DIFF
--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -13,7 +13,10 @@ import { getDerivations } from 'helpers/derivations'
 import getAddressCommand from 'commands/getAddress'
 import signTransactionCommand from 'commands/signTransaction'
 import { getAccountPlaceholderName, getNewAccountPlaceholderName } from 'helpers/accountName'
+import { createCustomErrorClass } from 'helpers/errors'
 import type { EditProps, WalletBridge } from './types'
+
+const NotEnoughBalance = createCustomErrorClass('NotEnoughBalance')
 
 // TODO in future it would be neat to support eip55
 
@@ -363,7 +366,8 @@ const EthereumBridge: WalletBridge<Transaction> = {
 
   EditAdvancedOptions,
 
-  canBeSpent: (a, t) => Promise.resolve(t.amount <= a.balance),
+  checkCanBeSpent: (a, t) =>
+    t.amount <= a.balance ? Promise.resolve() : Promise.reject(new NotEnoughBalance()),
   getTotalSpent: (a, t) => Promise.resolve(t.amount + t.gasPrice * t.gasLimit),
   getMaxAmount: (a, t) => Promise.resolve(a.balance - t.gasPrice * t.gasLimit),
 

--- a/src/bridge/UnsupportedBridge.js
+++ b/src/bridge/UnsupportedBridge.js
@@ -31,7 +31,7 @@ const UnsupportedBridge: WalletBridge<*> = {
 
   getTransactionRecipient: () => '',
 
-  canBeSpent: () => Promise.resolve(false),
+  checkCanBeSpent: () => Promise.resolve(),
 
   getTotalSpent: () => Promise.resolve(0),
 

--- a/src/bridge/makeMockBridge.js
+++ b/src/bridge/makeMockBridge.js
@@ -32,7 +32,7 @@ function makeMockBridge(opts?: Opts): WalletBridge<*> {
     extraInitialTransactionProps,
     getTotalSpent,
     getMaxAmount,
-    canBeSpent,
+    checkCanBeSpent,
   } = {
     ...defaultOpts,
     ...opts,
@@ -145,7 +145,7 @@ function makeMockBridge(opts?: Opts): WalletBridge<*> {
 
     isValidTransaction: (a, t) => (t.amount > 0 && t.recipient && true) || false,
 
-    canBeSpent,
+    checkCanBeSpent,
 
     getTotalSpent,
 

--- a/src/bridge/types.js
+++ b/src/bridge/types.js
@@ -82,7 +82,7 @@ export interface WalletBridge<Transaction> {
   // render the whole advanced part of the form
   EditAdvancedOptions?: *; // React$ComponentType<EditProps<Transaction>>;
 
-  canBeSpent(account: Account, transaction: Transaction): Promise<boolean>;
+  checkCanBeSpent(account: Account, transaction: Transaction): Promise<void>;
 
   getTotalSpent(account: Account, transaction: Transaction): Promise<number>;
 

--- a/src/components/RequestAmount/index.js
+++ b/src/components/RequestAmount/index.js
@@ -21,9 +21,6 @@ import InputCurrency from 'components/base/InputCurrency'
 import Button from 'components/base/Button'
 import Box from 'components/base/Box'
 import type { State } from 'reducers'
-import { createCustomErrorClass } from 'helpers/errors'
-
-const NotEnoughBalance = createCustomErrorClass('NotEnoughBalance')
 
 const InputRight = styled(Box).attrs({
   ff: 'Rubik',
@@ -50,7 +47,7 @@ type OwnProps = {
   // left value (always the one which is returned)
   value: number,
 
-  canBeSpent: boolean,
+  canBeSpentError: ?Error,
 
   // max left value
   max: number,
@@ -141,14 +138,14 @@ export class RequestAmount extends PureComponent<Props> {
 
   renderInputs(containerProps: Object) {
     // TODO move this inlined into render() for less spaghetti
-    const { value, account, rightCurrency, getCounterValue, canBeSpent } = this.props
+    const { value, account, rightCurrency, getCounterValue, canBeSpentError } = this.props
     const right = getCounterValue(value) || 0
     const rightUnit = rightCurrency.units[0]
     // FIXME: no way InputCurrency pure can work here. inlined InputRight (should be static func?), inline containerProps object..
     return (
       <Box horizontal grow shrink>
         <InputCurrency
-          error={canBeSpent ? null : new NotEnoughBalance()}
+          error={canBeSpentError}
           containerProps={containerProps}
           defaultUnit={account.unit}
           value={value}

--- a/src/components/modals/Send/steps/01-step-amount.js
+++ b/src/components/modals/Send/steps/01-step-amount.js
@@ -135,7 +135,9 @@ export class StepAmountFooter extends PureComponent<
     try {
       const totalSpent = await bridge.getTotalSpent(account, transaction)
       if (syncId !== this.syncId) return
-      const canBeSpent = await bridge.canBeSpent(account, transaction)
+      const canBeSpent = await bridge
+        .checkCanBeSpent(account, transaction)
+        .then(() => true, () => false)
       if (syncId !== this.syncId) return
       this.setState({ totalSpent, canBeSpent, isSyncing: false })
     } catch (err) {


### PR DESCRIPTION
- error precision: in case there is an error but it's not a "NotEnoughBalance" error, we display it instead
- canBeSpent(a,t)=>Promise<bool> was replaced by checkCanBeSpent(a,t)=>Promise<void> which will throw if something is wrong (NotEnoughBalance or something else!)
- cache eviction of bad error: in case such an error happen, we clear the cache to allow to always retry the call that fails
- the cache make sure it is always up to date by taking a.blockHeight


### Type

Bugfix

### Context

a bug on hcash made us realize how imprecise our error displayed is

### Parts of the app affected / Test plan

Send, step 1