### PR TITLE
Fix error imprecision in all Manager calls

### DIFF
--- a/src/helpers/apps/listAppVersions.js
+++ b/src/helpers/apps/listAppVersions.js
@@ -7,25 +7,19 @@ import getDeviceVersion from 'helpers/devices/getDeviceVersion'
 import getCurrentFirmware from 'helpers/devices/getCurrentFirmware'
 
 export default async (deviceInfo: DeviceInfo) => {
-  try {
-    const deviceData = await getDeviceVersion(deviceInfo.targetId, deviceInfo.providerId)
-    const firmwareData = await getCurrentFirmware({
-      deviceId: deviceData.id,
-      fullVersion: deviceInfo.fullVersion,
-      provider: deviceInfo.providerId,
-    })
-    const params = {
-      provider: deviceInfo.providerId,
-      current_se_firmware_final_version: firmwareData.id,
-      device_version: deviceData.id,
-    }
-    const {
-      data: { application_versions },
-    } = await network({ method: 'POST', url: APPLICATIONS_BY_DEVICE, data: params })
-    return application_versions.length > 0 ? application_versions : []
-  } catch (err) {
-    const error = Error(err.message)
-    error.stack = err.stack
-    throw err
+  const deviceData = await getDeviceVersion(deviceInfo.targetId, deviceInfo.providerId)
+  const firmwareData = await getCurrentFirmware({
+    deviceId: deviceData.id,
+    fullVersion: deviceInfo.fullVersion,
+    provider: deviceInfo.providerId,
+  })
+  const params = {
+    provider: deviceInfo.providerId,
+    current_se_firmware_final_version: firmwareData.id,
+    device_version: deviceData.id,
   }
+  const {
+    data: { application_versions },
+  } = await network({ method: 'POST', url: APPLICATIONS_BY_DEVICE, data: params })
+  return application_versions.length > 0 ? application_versions : []
 }

--- a/src/helpers/apps/listApps.js
+++ b/src/helpers/apps/listApps.js
@@ -4,12 +4,6 @@ import network from 'api/network'
 import { GET_APPLICATIONS } from 'helpers/urls'
 
 export default async () => {
-  try {
-    const { data } = await network({ method: 'GET', url: GET_APPLICATIONS })
-    return data.length > 0 ? data : []
-  } catch (err) {
-    const error = Error(err.message)
-    error.stack = err.stack
-    throw err
-  }
+  const { data } = await network({ method: 'GET', url: GET_APPLICATIONS })
+  return data.length > 0 ? data : []
 }

--- a/src/helpers/apps/listCategories.js
+++ b/src/helpers/apps/listCategories.js
@@ -4,12 +4,6 @@ import network from 'api/network'
 import { GET_CATEGORIES } from 'helpers/urls'
 
 export default async () => {
-  try {
-    const { data } = await network({ method: 'GET', url: GET_CATEGORIES })
-    return data.length > 0 ? data : []
-  } catch (err) {
-    const error = Error(err.message)
-    error.stack = err.stack
-    throw err
-  }
+  const { data } = await network({ method: 'GET', url: GET_CATEGORIES })
+  return data.length > 0 ? data : []
 }

--- a/src/helpers/common.js
+++ b/src/helpers/common.js
@@ -27,44 +27,38 @@ export type LedgerScriptParams = {
  * Retrieve targetId and firmware version from device
  */
 export async function getFirmwareInfo(transport: Transport<*>) {
-  try {
-    const res = await transport.send(...APDUS.GET_FIRMWARE)
-    const byteArray = [...res]
-    const data = byteArray.slice(0, byteArray.length - 2)
-    const targetIdStr = Buffer.from(data.slice(0, 4))
-    const targetId = targetIdStr.readUIntBE(0, 4)
-    const seVersionLength = data[4]
-    const seVersion = Buffer.from(data.slice(5, 5 + seVersionLength)).toString()
-    const flagsLength = data[5 + seVersionLength]
-    const flags = Buffer.from(
-      data.slice(5 + seVersionLength + 1, 5 + seVersionLength + 1 + flagsLength),
-    ).toString()
+  const res = await transport.send(...APDUS.GET_FIRMWARE)
+  const byteArray = [...res]
+  const data = byteArray.slice(0, byteArray.length - 2)
+  const targetIdStr = Buffer.from(data.slice(0, 4))
+  const targetId = targetIdStr.readUIntBE(0, 4)
+  const seVersionLength = data[4]
+  const seVersion = Buffer.from(data.slice(5, 5 + seVersionLength)).toString()
+  const flagsLength = data[5 + seVersionLength]
+  const flags = Buffer.from(
+    data.slice(5 + seVersionLength + 1, 5 + seVersionLength + 1 + flagsLength),
+  ).toString()
 
-    const mcuVersionLength = data[5 + seVersionLength + 1 + flagsLength]
-    let mcuVersion = Buffer.from(
-      data.slice(
-        7 + seVersionLength + flagsLength,
-        7 + seVersionLength + flagsLength + mcuVersionLength,
-      ),
-    )
-    if (mcuVersion[mcuVersion.length - 1] === 0) {
-      mcuVersion = mcuVersion.slice(0, mcuVersion.length - 1)
-    }
-    mcuVersion = mcuVersion.toString()
-
-    if (!seVersionLength) {
-      return {
-        targetId,
-        seVersion: '0.0.0',
-        flags: '',
-        mcuVersion: '',
-      }
-    }
-
-    return { targetId, seVersion, flags, mcuVersion }
-  } catch (err) {
-    const error = new Error(err.message)
-    error.stack = err.stack
-    throw error
+  const mcuVersionLength = data[5 + seVersionLength + 1 + flagsLength]
+  let mcuVersion = Buffer.from(
+    data.slice(
+      7 + seVersionLength + flagsLength,
+      7 + seVersionLength + flagsLength + mcuVersionLength,
+    ),
+  )
+  if (mcuVersion[mcuVersion.length - 1] === 0) {
+    mcuVersion = mcuVersion.slice(0, mcuVersion.length - 1)
   }
+  mcuVersion = mcuVersion.toString()
+
+  if (!seVersionLength) {
+    return {
+      targetId,
+      seVersion: '0.0.0',
+      flags: '',
+      mcuVersion: '',
+    }
+  }
+
+  return { targetId, seVersion, flags, mcuVersion }
 }

--- a/src/helpers/devices/getCurrentFirmware.js
+++ b/src/helpers/devices/getCurrentFirmware.js
@@ -9,22 +9,15 @@ type Input = {
   provider: number,
 }
 
-let error
 export default async (input: Input): Promise<*> => {
-  try {
-    const { data } = await network({
-      method: 'POST',
-      url: GET_CURRENT_FIRMWARE,
-      data: {
-        device_version: input.deviceId,
-        version_name: input.fullVersion,
-        provider: input.provider,
-      },
-    })
-    return data
-  } catch (err) {
-    error = Error(err.message)
-    error.stack = err.stack
-    throw error
-  }
+  const { data } = await network({
+    method: 'POST',
+    url: GET_CURRENT_FIRMWARE,
+    data: {
+      device_version: input.deviceId,
+      version_name: input.fullVersion,
+      provider: input.provider,
+    },
+  })
+  return data
 }

--- a/src/helpers/devices/getLatestFirmwareForDevice.js
+++ b/src/helpers/devices/getLatestFirmwareForDevice.js
@@ -10,53 +10,47 @@ import getCurrentFirmware from './getCurrentFirmware'
 import getDeviceVersion from './getDeviceVersion'
 
 export default async (deviceInfo: DeviceInfo) => {
-  try {
-    // Get device infos from targetId
-    const deviceVersion = await getDeviceVersion(deviceInfo.targetId, deviceInfo.providerId)
+  // Get device infos from targetId
+  const deviceVersion = await getDeviceVersion(deviceInfo.targetId, deviceInfo.providerId)
 
-    // Get firmware infos with firmware name and device version
-    const seFirmwareVersion = await getCurrentFirmware({
-      fullVersion: deviceInfo.fullVersion,
-      deviceId: deviceVersion.id,
+  // Get firmware infos with firmware name and device version
+  const seFirmwareVersion = await getCurrentFirmware({
+    fullVersion: deviceInfo.fullVersion,
+    deviceId: deviceVersion.id,
+    provider: deviceInfo.providerId,
+  })
+
+  // Fetch next possible firmware
+  const { data } = await network({
+    method: 'POST',
+    url: GET_LATEST_FIRMWARE,
+    data: {
+      current_se_firmware_final_version: seFirmwareVersion.id,
+      device_version: deviceVersion.id,
       provider: deviceInfo.providerId,
-    })
+    },
+  })
 
-    // Fetch next possible firmware
-    const { data } = await network({
-      method: 'POST',
-      url: GET_LATEST_FIRMWARE,
-      data: {
-        current_se_firmware_final_version: seFirmwareVersion.id,
-        device_version: deviceVersion.id,
-        provider: deviceInfo.providerId,
-      },
-    })
-
-    if (data.result === 'null') {
-      return null
-    }
-
-    const { se_firmware_osu_version } = data
-    const { next_se_firmware_final_version } = se_firmware_osu_version
-    const seFirmwareFinalVersion = await getFinalFirmwareById(next_se_firmware_final_version)
-
-    const mcus = await getMcus()
-
-    const currentMcuVersionId = mcus
-      .filter(mcu => mcu.name === deviceInfo.mcuVersion)
-      .map(mcu => mcu.id)
-
-    if (!seFirmwareFinalVersion.mcu_versions.includes(...currentMcuVersionId)) {
-      return {
-        ...se_firmware_osu_version,
-        shouldFlashMcu: true,
-      }
-    }
-
-    return { ...se_firmware_osu_version, shouldFlashMcu: false }
-  } catch (err) {
-    const error = Error(err.message)
-    error.stack = err.stack
-    throw error
+  if (data.result === 'null') {
+    return null
   }
+
+  const { se_firmware_osu_version } = data
+  const { next_se_firmware_final_version } = se_firmware_osu_version
+  const seFirmwareFinalVersion = await getFinalFirmwareById(next_se_firmware_final_version)
+
+  const mcus = await getMcus()
+
+  const currentMcuVersionId = mcus
+    .filter(mcu => mcu.name === deviceInfo.mcuVersion)
+    .map(mcu => mcu.id)
+
+  if (!seFirmwareFinalVersion.mcu_versions.includes(...currentMcuVersionId)) {
+    return {
+      ...se_firmware_osu_version,
+      shouldFlashMcu: true,
+    }
+  }
+
+  return { ...se_firmware_osu_version, shouldFlashMcu: false }
 }

--- a/src/helpers/devices/isDashboardOpen.js
+++ b/src/helpers/devices/isDashboardOpen.js
@@ -7,16 +7,10 @@ import { getFirmwareInfo } from 'helpers/common'
 type Result = boolean
 
 export default async (transport: Transport<*>): Promise<Result> => {
-  try {
-    const { targetId, seVersion } = await getFirmwareInfo(transport)
-    if (targetId && seVersion) {
-      return true
-    }
-
-    return false
-  } catch (err) {
-    const error = Error(err.message)
-    error.stack = err.stack
-    throw error
+  const { targetId, seVersion } = await getFirmwareInfo(transport)
+  if (targetId && seVersion) {
+    return true
   }
+
+  return false
 }

--- a/src/helpers/devices/shouldFlashMcu.js
+++ b/src/helpers/devices/shouldFlashMcu.js
@@ -10,46 +10,40 @@ import getOsuFirmware from './getOsuFirmware'
 import getDeviceVersion from './getDeviceVersion'
 
 export default async (deviceInfo: DeviceInfo): Promise<boolean> => {
-  try {
-    // Get device infos from targetId
-    const deviceVersion = await getDeviceVersion(deviceInfo.targetId, deviceInfo.providerId)
+  // Get device infos from targetId
+  const deviceVersion = await getDeviceVersion(deviceInfo.targetId, deviceInfo.providerId)
 
-    // Get firmware infos with firmware name and device version
-    const seFirmwareVersion = await getOsuFirmware({
-      version: deviceInfo.fullVersion,
-      deviceId: deviceVersion.id,
+  // Get firmware infos with firmware name and device version
+  const seFirmwareVersion = await getOsuFirmware({
+    version: deviceInfo.fullVersion,
+    deviceId: deviceVersion.id,
+    provider: deviceInfo.providerId,
+  })
+
+  // Fetch next possible firmware
+  const { data } = await network({
+    method: 'POST',
+    url: GET_LATEST_FIRMWARE,
+    data: {
+      current_se_firmware_final_version: seFirmwareVersion.id,
+      device_version: deviceVersion.id,
       provider: deviceInfo.providerId,
-    })
+    },
+  })
 
-    // Fetch next possible firmware
-    const { data } = await network({
-      method: 'POST',
-      url: GET_LATEST_FIRMWARE,
-      data: {
-        current_se_firmware_final_version: seFirmwareVersion.id,
-        device_version: deviceVersion.id,
-        provider: deviceInfo.providerId,
-      },
-    })
-
-    if (data.result === 'null') {
-      return false
-    }
-
-    const { se_firmware_osu_version } = data
-    const { next_se_firmware_final_version } = se_firmware_osu_version
-    const seFirmwareFinalVersion = await getFinalFirmwareById(next_se_firmware_final_version)
-
-    const mcus = await getMcus()
-
-    const currentMcuVersionId = mcus
-      .filter(mcu => mcu.name === deviceInfo.mcuVersion)
-      .map(mcu => mcu.id)
-
-    return !seFirmwareFinalVersion.mcu_versions.includes(...currentMcuVersionId)
-  } catch (err) {
-    const error = Error(err.message)
-    error.stack = err.stack
-    throw error
+  if (data.result === 'null') {
+    return false
   }
+
+  const { se_firmware_osu_version } = data
+  const { next_se_firmware_final_version } = se_firmware_osu_version
+  const seFirmwareFinalVersion = await getFinalFirmwareById(next_se_firmware_final_version)
+
+  const mcus = await getMcus()
+
+  const currentMcuVersionId = mcus
+    .filter(mcu => mcu.name === deviceInfo.mcuVersion)
+    .map(mcu => mcu.id)
+
+  return !seFirmwareFinalVersion.mcu_versions.includes(...currentMcuVersionId)
 }

--- a/src/helpers/firmware/getMcus.js
+++ b/src/helpers/firmware/getMcus.js
@@ -4,16 +4,10 @@ import network from 'api/network'
 import { GET_MCUS } from 'helpers/urls'
 
 export default async (): Promise<*> => {
-  try {
-    const { data } = await network({
-      method: 'GET',
-      url: GET_MCUS,
-    })
+  const { data } = await network({
+    method: 'GET',
+    url: GET_MCUS,
+  })
 
-    return data
-  } catch (err) {
-    const error = Error(err.message)
-    error.stack = err.stack
-    throw err
-  }
+  return data
 }

--- a/src/helpers/firmware/getNextMCU.js
+++ b/src/helpers/firmware/getNextMCU.js
@@ -7,24 +7,18 @@ import { createCustomErrorClass } from 'helpers/errors'
 const LatestMCUInstalledError = createCustomErrorClass('LatestMCUInstalledError')
 
 export default async (bootloaderVersion: string): Promise<*> => {
-  try {
-    const { data } = await network({
-      method: 'POST',
-      url: GET_NEXT_MCU,
-      data: {
-        bootloader_version: bootloaderVersion,
-      },
-    })
+  const { data } = await network({
+    method: 'POST',
+    url: GET_NEXT_MCU,
+    data: {
+      bootloader_version: bootloaderVersion,
+    },
+  })
 
-    // FIXME: nextVersion will not be able to "default" when
-    // Error handling is standardize on the API side
-    if (data === 'default' || !data.name) {
-      throw new LatestMCUInstalledError('there is no next mcu version to install')
-    }
-    return data
-  } catch (err) {
-    const error = Error(err.message)
-    error.stack = err.stack
-    throw err
+  // FIXME: nextVersion will not be able to "default" when
+  // Error handling is standardize on the API side
+  if (data === 'default' || !data.name) {
+    throw new LatestMCUInstalledError('there is no next mcu version to install')
   }
+  return data
 }

--- a/src/helpers/urls.js
+++ b/src/helpers/urls.js
@@ -14,6 +14,8 @@ const wsURLBuilder = (endpoint: string) => (params?: Object) =>
 // const wsURLBuilderProxy = (endpoint: string) => (params?: Object) =>
 //   `ws://manager.ledger.fr:3501/${endpoint}${params ? `?${qs.stringify(params)}` : ''}`
 
+// FIXME we shouldn't do this here. we should just collocate these where it's used.
+
 export const GET_FINAL_FIRMWARE: string = managerUrlbuilder('firmware_final_versions')
 export const GET_DEVICE_VERSION: string = managerUrlbuilder('get_device_version')
 export const APPLICATIONS_BY_DEVICE: string = managerUrlbuilder('get_apps')


### PR DESCRIPTION
the code is equivalent except errors thrown don't get decorated back into an 'Error' leading to imprecision
we'll need to double check all is fine but this will *make errors great again*.
this is really an antipattern we have to avoid.
