### PR TITLE
Link statically libstdc++ to fix issues on old linux systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ledgerhq/hw-app-xrp": "^4.13.0",
     "@ledgerhq/hw-transport": "^4.13.0",
     "@ledgerhq/hw-transport-node-hid": "^4.13.0",
-    "@ledgerhq/ledger-core": "2.0.0-rc.3",
+    "@ledgerhq/ledger-core": "2.0.0-rc.4",
     "@ledgerhq/live-common": "2.31.0",
     "animated": "^0.2.2",
     "async": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,9 +1521,9 @@
   dependencies:
     events "^2.0.0"
 
-"@ledgerhq/ledger-core@2.0.0-rc.3":
-  version "2.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.3.tgz#21b04239e9ba6b7fdcb89958eea8ad47a4a28a88"
+"@ledgerhq/ledger-core@2.0.0-rc.4":
+  version "2.0.0-rc.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.4.tgz#0ec80a763c666658bea94bd38b86aa90d5a24906"
   dependencies:
     "@ledgerhq/hw-app-btc" "^4.7.3"
     "@ledgerhq/hw-transport-node-hid" "^4.7.6"


### PR DESCRIPTION
So we now support older Linux versions (e.g Ubuntu 16.04) :rocket:
Additionally, libcore dynamic libraries are now prefixed on S3 with the libcore version which will give us more control on what we actually build.

![2018-07-07_2280x1136](https://user-images.githubusercontent.com/315259/42412920-fcbb2de8-8215-11e8-87dd-996261a7f5a5.png)
