### PR TITLE
Fix a bug in Ripple that make ops disappear after a clean

### DIFF
--- a/src/bridge/RippleJSBridge.js
+++ b/src/bridge/RippleJSBridge.js
@@ -351,7 +351,12 @@ const RippleJSBridge: WalletBridge<Transaction> = {
       return unsubscribe
     }),
 
-  synchronize: ({ endpointConfig, freshAddress, blockHeight }) =>
+  synchronize: ({
+    endpointConfig,
+    freshAddress,
+    blockHeight,
+    operations: { length: currentOpsLength },
+  }) =>
     Observable.create(o => {
       let finished = false
       const unsubscribe = () => {
@@ -394,7 +399,10 @@ const RippleJSBridge: WalletBridge<Transaction> = {
           o.next(a => ({ ...a, balance }))
 
           const transactions = await api.getTransactions(freshAddress, {
-            minLedgerVersion: Math.max(blockHeight, minLedgerVersion),
+            minLedgerVersion: Math.max(
+              currentOpsLength === 0 ? 0 : blockHeight, // if there is no ops, it might be after a clear and we prefer to pull from the oldest possible history
+              minLedgerVersion,
+            ),
             maxLedgerVersion,
           })
 

--- a/src/components/AccountPage/AccountHeaderActions.js
+++ b/src/components/AccountPage/AccountHeaderActions.js
@@ -62,7 +62,7 @@ class AccountHeaderActions extends PureComponent<Props> {
     const { account, openModal, t } = this.props
     return (
       <Box horizontal alignItems="center" justifyContent="flex-end" flow={2}>
-        {account.operations.length > 0 && (
+        {account.operations.length > 0 || account.balance > 0 ? (
           <Fragment>
             <Button small primary onClick={() => openModal(MODAL_SEND, { account })}>
               <Box horizontal flow={1} alignItems="center">
@@ -78,7 +78,7 @@ class AccountHeaderActions extends PureComponent<Props> {
               </Box>
             </Button>
           </Fragment>
-        )}
+        ) : null}
         <Tooltip render={() => t('app:account.settings.title')}>
           <ButtonSettings onClick={() => openModal(MODAL_SETTINGS_ACCOUNT, { account })}>
             <Box justifyContent="center">

--- a/src/components/AccountPage/index.js
+++ b/src/components/AccountPage/index.js
@@ -82,7 +82,7 @@ class AccountPage extends PureComponent<Props> {
           <AccountHeaderActions account={account} />
         </Box>
 
-        {account.operations.length > 0 ? (
+        {account.operations.length > 0 || account.balance > 0 ? (
           <Fragment>
             <Box mb={7}>
               <BalanceSummary


### PR DESCRIPTION
- Fix #914
- Don't render Empty account placeholder if there is a balance (it shouldn't happen anymore but still better to not render empty in this case)

### Type

bugfix

### Context

#914

### Parts of the app affected / Test plan

account