### PR TITLE
Add missing App Starts event

### DIFF
--- a/src/analytics/Track.js
+++ b/src/analytics/Track.js
@@ -7,6 +7,7 @@ class Track extends PureComponent<{
   onUnmount?: boolean,
   onUpdate?: boolean,
   event: string,
+  mandatory?: boolean,
 }> {
   componentDidMount() {
     if (typeof this.props.event !== 'string') {
@@ -21,8 +22,8 @@ class Track extends PureComponent<{
     if (this.props.onUnmount) this.track()
   }
   track = () => {
-    const { event, onMount, onUnmount, onUpdate, ...properties } = this.props
-    track(event, properties)
+    const { event, onMount, onUnmount, onUpdate, mandatory, ...properties } = this.props
+    track(event, properties, mandatory)
   }
   render() {
     return null

--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -72,9 +72,9 @@ export const stop = () => {
   analytics.reset()
 }
 
-export const track = (event: string, properties: ?Object) => {
+export const track = (event: string, properties: ?Object, mandatory: ?boolean) => {
   logger.analyticsTrack(event, properties)
-  if (!storeInstance || !shareAnalyticsSelector(storeInstance.getState())) {
+  if (!storeInstance || (!mandatory && !shareAnalyticsSelector(storeInstance.getState()))) {
     return
   }
   const { analytics } = window

--- a/src/components/layout/Default.js
+++ b/src/components/layout/Default.js
@@ -13,6 +13,7 @@ import type { Location } from 'react-router'
 import * as modals from 'components/modals'
 import Box from 'components/base/Box'
 import GrowScroll from 'components/base/GrowScroll'
+import Track from 'analytics/Track'
 
 import AccountPage from 'components/AccountPage'
 import DashboardPage from 'components/DashboardPage'
@@ -84,6 +85,7 @@ class Default extends Component<Props> {
         <TriggerAppReady />
         {process.platform === 'darwin' && <AppRegionDrag />}
         <ExportLogsBtn hookToShortcut />
+        <Track onMount event="App Starts" />
 
         <OnboardingOrElse>
           <IsUnlocked>

--- a/src/components/layout/Default.js
+++ b/src/components/layout/Default.js
@@ -85,7 +85,7 @@ class Default extends Component<Props> {
         <TriggerAppReady />
         {process.platform === 'darwin' && <AppRegionDrag />}
         <ExportLogsBtn hookToShortcut />
-        <Track onMount event="App Starts" />
+        <Track mandatory onMount event="App Starts" />
 
         <OnboardingOrElse>
           <IsUnlocked>


### PR DESCRIPTION
add analytics event 'App Starts'

### Type

analytics

### Context

@pollastri-pierre 

### Parts of the app affected / Test plan

app boot