### PR TITLE
Correct date format for chart Tooltip

### DIFF
--- a/src/components/BalanceSummary/index.js
+++ b/src/components/BalanceSummary/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Fragment } from 'react'
+import moment from 'moment'
 import { formatShort } from '@ledgerhq/live-common/lib/helpers/currencies'
 import type { Currency, Account } from '@ledgerhq/live-common/lib/types'
 
@@ -90,7 +91,7 @@ const BalanceSummary = ({
                             val={d.value}
                           />
                           <Box ff="Open Sans|Regular" color="grey" fontSize={3} mt={2}>
-                            {d.date.toISOString().substr(0, 10)}
+                            {moment(d.date).format('L')}
                           </Box>
                         </Fragment>
                       )

--- a/src/components/base/Chart/Tooltip.js
+++ b/src/components/base/Chart/Tooltip.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Fragment } from 'react'
+import moment from 'moment'
 import styled from 'styled-components'
 
 import type { Unit, Currency } from '@ledgerhq/live-common/lib/types'
@@ -68,7 +69,7 @@ const Tooltip = ({
               />
             )}
             <Box ff="Open Sans|Regular" color="grey" fontSize={3} mt={2}>
-              {item.date.toISOString().substr(0, 10)}
+              {moment(item.date).format('L')}
             </Box>
           </Fragment>
         )}


### PR DESCRIPTION
### Type

bugfix

### Context

following discussion on #917 
let's at least use the correct date format for the chart tooltip, that will display... THE CORRECT DATE MAYBE?

### Parts of the app affected / Test plan

graphs, both in Dashboard and account page