### PR TITLE
Fix for issue #932 - UI polish sideBar

### DIFF
--- a/src/components/MainSideBar/index.js
+++ b/src/components/MainSideBar/index.js
@@ -68,8 +68,8 @@ class MainSideBar extends PureComponent<Props> {
 
   ADD_ACCOUNT_EMPTY_STATE = (
     <Box relative>
-      <img style={{ position: 'absolute', top: 0, right: 5 }} alt="" src={i('arrow-add.svg')} />
-      {this.props.t('app:emptyState.sidebar.text')}
+      <img style={{ position: 'absolute', top: -10, right: 5 }} alt="" src={i('arrow-add.svg')} />
+      <Box pr={3}>{this.props.t('app:emptyState.sidebar.text')}</Box>
     </Box>
   )
 

--- a/src/components/MainSideBar/index.js
+++ b/src/components/MainSideBar/index.js
@@ -67,9 +67,9 @@ class MainSideBar extends PureComponent<Props> {
   }
 
   ADD_ACCOUNT_EMPTY_STATE = (
-    <Box relative>
+    <Box relative pr={3}>
       <img style={{ position: 'absolute', top: -10, right: 5 }} alt="" src={i('arrow-add.svg')} />
-      <Box pr={3}>{this.props.t('app:emptyState.sidebar.text')}</Box>
+      {this.props.t('app:emptyState.sidebar.text')}
     </Box>
   )
 


### PR DESCRIPTION
Fix for the UI regression (Arrow over text) after wording adjustment on the Empty State sideBar under Add account
### Type

UI polish regression
### Context

Issue #932 
### Parts of the app affected / Test plan

Empty state - no accounts
![screen shot 2018-07-09 at 14 10 03](https://user-images.githubusercontent.com/10082039/42449982-fc1db9aa-8382-11e8-98e7-cfcdd9374106.png)
