### PR TITLE
Better actions in the crash screen

### DIFF
--- a/src/components/RenderError.js
+++ b/src/components/RenderError.js
@@ -4,9 +4,9 @@ import React, { PureComponent } from 'react'
 import styled from 'styled-components'
 import { openURL } from 'helpers/linking'
 import { remote } from 'electron'
-import qs from 'querystring'
 import { translate } from 'react-i18next'
 
+import { urls } from 'config/urls'
 import { i } from 'helpers/staticPath'
 import hardReset from 'helpers/hardReset'
 
@@ -47,21 +47,12 @@ class RenderError extends PureComponent<
     </IconWrapperCircle>
   )
 
-  handleCreateIssue = () => {
-    const { error } = this.props
-    if (!error) {
-      return
-    }
-    const q = qs.stringify({
-      title: `Error: ${error.message}`,
-      body: `Error was thrown:
+  github = () => {
+    openURL(urls.githubIssues)
+  }
 
-\`\`\`
-${error.stack}
-\`\`\`
-`,
-    })
-    openURL(`https://github.com/LedgerHQ/ledger-live-desktop/issues/new?${q}`)
+  contact = () => {
+    openURL(urls.contactSupport)
   }
 
   handleRestart = () => {
@@ -105,8 +96,11 @@ ${error.stack}
             {t('app:crash.restart')}
           </Button>
           <ExportLogsBtn withoutAppData={withoutAppData} />
-          <Button small primary onClick={this.handleCreateIssue}>
-            {t('app:crash.createTicket')}
+          <Button small primary onClick={this.contact}>
+            {t('app:crash.support')}
+          </Button>
+          <Button small primary onClick={this.github}>
+            {t('app:crash.github')}
           </Button>
           <Button small danger onClick={this.handleOpenHardResetModal}>
             {t('app:crash.reset')}

--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -18,6 +18,9 @@ export const urls = {
   recipientAddressInfo: 'https://support.ledgerwallet.com/hc/en-us/articles/360006433934',
   privacyPolicy: 'https://www.ledgerwallet.com/privacy-policy',
 
+  githubIssues:
+    'https://github.com/LedgerHQ/ledger-live-desktop/issues?q=is%3Aopen+is%3Aissue+label%3Abug',
+
   // Exchanges
   coinbase: 'https://www.coinhouse.com/r/157530',
   changelly: 'https://changelly.com/?ref_id=aac789605a01',

--- a/static/i18n/en/app.yml
+++ b/static/i18n/en/app.yml
@@ -426,7 +426,8 @@ crash:
   uselessText: You may try again by restarting Ledger Live. Please export your logs and contact Ledger Support if the problem persists.
   restart: Restart
   reset: Reset
-  createTicket: Contact us
+  support: Contact Support
+  github: GitHub
   showDetails: Show details
   showError: Show error
 disclaimerModal:


### PR DESCRIPTION
the previous "Contact us" was opening an issue on Github from the error stacktrace. This is not useful because we have sentry.

- instead there is a Github button that link to issues tagged as bug.
- there is a dedicated Contact Support button that point to tech support.

![capture d ecran 2018-07-10 a 10 33 15](https://user-images.githubusercontent.com/211411/42498649-0349b7a6-842d-11e8-818d-956ddc149c04.png)
