### PR TITLE
Fix error imprecision in Add Accounts

### DIFF
--- a/src/components/modals/AddAccounts/steps/03-step-import.js
+++ b/src/components/modals/AddAccounts/steps/03-step-import.js
@@ -160,7 +160,7 @@ class StepImport extends PureComponent<StepProps> {
   }
 
   renderError() {
-    const { err, t } = this.props
+    const { err } = this.props
     invariant(err, 'Trying to render inexisting error')
     return (
       <Box
@@ -172,9 +172,11 @@ class StepImport extends PureComponent<StepProps> {
         color="alertRed"
       >
         <IconExclamationCircleThin size={43} />
-        <Box mt={4}>{t('app:addAccounts.somethingWentWrong')}</Box>
         <Box mt={4}>
-          <TranslatedError error={err} />
+          <TranslatedError error={err} field="title" />
+        </Box>
+        <Box mt={4}>
+          <TranslatedError error={err} field="description" />
         </Box>
       </Box>
     )

--- a/static/i18n/en/app.yml
+++ b/static/i18n/en/app.yml
@@ -183,7 +183,6 @@ addAccounts:
     title: Add a new account
     noOperationOnLastAccount: "No transactions found on your last new account <1><0>{{accountName}}</0></1>. You can add a new account after you've started transacting on that account."
     noAccountToCreate: No <1><0>{{currencyName}}</0></1> account was found to create
-  somethingWentWrong: Something went wrong during synchronization, please try again.
   cta:
     addMore: 'Add more'
     add: 'Add account'


### PR DESCRIPTION
error screenshot are getting raised to us for scan accounts but the error is imprecise and we have no clue of the actual bug.

### Type

bug precision

### Context

this is not exploitable

![context](https://user-images.githubusercontent.com/211411/42502735-246adda2-8437-11e8-99dc-135180da98af.png)

### Parts of the app affected / Test plan

Add Accounts / step 3