### PR TITLE
fixes #1005

### DIFF
--- a/src/components/ManagerPage/ManagerApp.js
+++ b/src/components/ManagerPage/ManagerApp.js
@@ -30,6 +30,7 @@ const AppIcon = styled.img`
   display: block;
   width: 36px;
   height: 36px;
+  pointer-events: none;
 `
 
 const AppName = styled(Box).attrs({


### PR DESCRIPTION
Removing draggable effect of the app icons on the manager page
### Type

Bug Fix
### Context

Github issue #1005 
### Parts of the app affected / Test plan

Manager Page/App Icons
