### PR TITLE
Fix and improve logs (redux file size, add apdu dump)

### DIFF
--- a/src/commands/libcoreSignAndBroadcast.js
+++ b/src/commands/libcoreSignAndBroadcast.js
@@ -19,12 +19,14 @@ type BitcoinLikeTransaction = {
 }
 
 type Input = {
-  account: AccountRaw,
+  account: AccountRaw, // FIXME there is no reason we send the whole AccountRaw
   transaction: BitcoinLikeTransaction,
   deviceId: string,
 }
 
 type Result = { type: 'signed' } | { type: 'broadcasted', operation: OperationRaw }
+
+// FIXME this command should be unified with 'signTransaction' command
 
 const cmd: Command<Input, Result> = createCommand(
   'libcoreSignAndBroadcast',

--- a/src/commands/libcoreSyncAccount.js
+++ b/src/commands/libcoreSyncAccount.js
@@ -8,7 +8,7 @@ import { syncAccount } from 'helpers/libcore'
 import withLibcore from 'helpers/withLibcore'
 
 type Input = {
-  rawAccount: AccountRaw,
+  rawAccount: AccountRaw, // FIXME there is no reason we send the whole AccountRaw
 }
 
 type Result = AccountRaw

--- a/src/helpers/deviceAccess.js
+++ b/src/helpers/deviceAccess.js
@@ -1,7 +1,7 @@
 // @flow
+import logger from 'logger'
 import type Transport from '@ledgerhq/hw-transport'
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
-import { DEBUG_DEVICE } from 'config/constants'
 import { retry } from './promise'
 import { createCustomErrorClass } from './errors'
 
@@ -31,9 +31,7 @@ export const withDevice: WithDevice = devicePath => job => {
     busy = true
     try {
       const t = await retry(() => TransportNodeHid.open(devicePath), { maxRetry: 1 })
-      if (DEBUG_DEVICE) {
-        t.setDebugMode(true)
-      }
+      t.setDebugMode(logger.apdu)
       try {
         const res = await job(t).catch(mapError)
         return res

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,10 +1475,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.7.1.tgz#e44e596d03c9f16ba3b127ad333a8a072bcb5a0a"
 
 "@ledgerhq/hw-app-btc@^4.13.0":
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-4.17.0.tgz#8f9e138446ea4b4c19c1584160f0333bbdfd48ae"
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-4.19.0.tgz#0fdce47ad71df7783c6bf881e6a9bc8b4c84de52"
   dependencies:
-    "@ledgerhq/hw-transport" "^4.15.0"
+    "@ledgerhq/hw-transport" "^4.19.0"
     create-hash "^1.1.3"
 
 "@ledgerhq/hw-app-btc@^4.7.3":
@@ -1489,23 +1489,23 @@
     create-hash "^1.1.3"
 
 "@ledgerhq/hw-app-eth@^4.14.0":
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.15.0.tgz#16e520793d27d6daf9edfb6f08138aad14f2ce4f"
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.19.0.tgz#2a76556172b4e9522a9b92357a48b39e10e003a6"
   dependencies:
-    "@ledgerhq/hw-transport" "^4.15.0"
+    "@ledgerhq/hw-transport" "^4.19.0"
 
 "@ledgerhq/hw-app-xrp@^4.13.0":
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-xrp/-/hw-app-xrp-4.15.0.tgz#a6d553ad89559465d7bcce3b34d56a131722166d"
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-xrp/-/hw-app-xrp-4.19.0.tgz#67fc53e5ab7791f28481ed5406adcf7d92c7ca9b"
   dependencies:
-    "@ledgerhq/hw-transport" "^4.15.0"
+    "@ledgerhq/hw-transport" "^4.19.0"
     bip32-path "0.4.2"
 
 "@ledgerhq/hw-transport-node-hid@^4.13.0":
-  version "4.18.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-4.18.0.tgz#39ab0f9300c755f6b33f28dda22e30677882b6be"
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-4.19.1.tgz#bc2cda4db0b4e8a3e26682bf5b81011f8eb53d82"
   dependencies:
-    "@ledgerhq/hw-transport" "^4.15.0"
+    "@ledgerhq/hw-transport" "^4.19.0"
     node-hid "^0.7.2"
 
 "@ledgerhq/hw-transport-node-hid@^4.7.6":
@@ -1515,9 +1515,9 @@
     "@ledgerhq/hw-transport" "^4.15.0"
     node-hid "^0.7.2"
 
-"@ledgerhq/hw-transport@^4.13.0", "@ledgerhq/hw-transport@^4.15.0":
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.15.0.tgz#ec99436c2662e70fb6f9c72f7bb5d1f3a051c4e3"
+"@ledgerhq/hw-transport@^4.13.0", "@ledgerhq/hw-transport@^4.15.0", "@ledgerhq/hw-transport@^4.19.0":
+  version "4.19.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.19.0.tgz#19a804aee1bfc4abac1dc9a2a7a582e79273f991"
   dependencies:
     events "^2.0.0"
 


### PR DESCRIPTION
- bugfix that if your log file reach 20Mb the exported log is not the correct one
- make the log files rotate to a gzip
- include APDU in logs
- blacklist some commands that was producing way too intensive logs
- don't log the redux action anymore. it's not that useful and way too verbose to log

fixes https://github.com/LedgerHQ/ledger-live-desktop/issues/916