### PR TITLE
fixes 963

### DIFF
--- a/src/helpers/SettingsDefaults.js
+++ b/src/helpers/SettingsDefaults.js
@@ -16,7 +16,7 @@ export const currencySettingsDefaults = ({
   let confirmationsNb
   if (blockAvgTime) {
     const def = Math.ceil((30 * 60) / blockAvgTime) // 30 min approx validation
-    confirmationsNb = { min: 1, def, max: 2 * def }
+    confirmationsNb = { min: 1, def, max: 3 * def }
   }
   return {
     confirmationsNb,


### PR DESCRIPTION
Increase number of confirmations globally from factor of 2 to factor of 3 
### Type

Based on the feedback after a discussion 
### Context

Github issue #963 
### Parts of the app affected / Test plan

Number of Confirmations can be seen in the Settings/Currencies