### PR TITLE
Lint shell scripts

### DIFF
--- a/scripts/compile.sh
+++ b/scripts/compile.sh
@@ -2,7 +2,8 @@
 
 set -e
 
-export GIT_REVISION=`git rev-parse HEAD`
+GIT_REVISION=$(git rev-parse HEAD)
+export GIT_REVISION
 export SENTRY_URL=https://db8f5b9b021048d4a401f045371701cb@sentry.io/274561
 export JOBS=max
 

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -4,13 +4,13 @@
 # some context:
 #   - https://github.com/electron-userland/electron-builder/issues/2577
 #   - https://github.com/electron-userland/electron-builder/issues/2269
-if [[ `uname` == 'Linux' ]]; then
+if [[ $(uname) == 'Linux' ]]; then
   mv build/icon.png /tmp
 fi
 
 yarn compile && DEBUG=electron-builder electron-builder
 
 # hilarious fix continuation: put back the icon where it was
-if [[ `uname` == 'Linux' ]]; then
+if [[ $(uname) == 'Linux' ]]; then
   mv /tmp/icon.png build
 fi

--- a/scripts/download-analytics.sh
+++ b/scripts/download-analytics.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-if [ -z $ANALYTICS_KEY ]; then
+if [ -z "$ANALYTICS_KEY" ]; then
   echo 'ANALYTICS_KEY must be set'
   exit 1
 fi
 
-cd `dirname $0`/..
+cd "$(dirname "$0")/.." || exit
 
-wget https://cdn.segment.com/analytics.js/v1/$ANALYTICS_KEY/analytics.min.js -O static/analytics.min.js
+wget https://cdn.segment.com/analytics.js/v1/"$ANALYTICS_KEY"/analytics.min.js -O static/analytics.min.js

--- a/scripts/hash-utils.sh
+++ b/scripts/hash-utils.sh
@@ -7,12 +7,12 @@ function GET_HASH_PATH {
 
 function GET_HASH {
   HASH_NAME=$1
-  HASH_PATH=`GET_HASH_PATH $HASH_NAME`
+  HASH_PATH=$(GET_HASH_PATH "$HASH_NAME")
   if [ ! -e "$HASH_PATH" ]; then
     echo ''
   else
-    HASH_CONTENT=`cat "$HASH_PATH"`
-    echo $HASH_CONTENT
+    HASH_CONTENT=$(cat "$HASH_PATH")
+    echo "$HASH_CONTENT"
   fi
 }
 
@@ -20,7 +20,7 @@ function SET_HASH {
   HASH_NAME=$1
   HASH_CONTENT=$2
   echo "setting hash $HASH_NAME to $HASH_CONTENT"
-  HASH_PATH=`GET_HASH_PATH $HASH_NAME`
+  HASH_PATH=$(GET_HASH_PATH "$HASH_NAME")
   mkdir -p ./node_modules/.cache
-  echo $HASH_CONTENT > $HASH_PATH
+  echo "$HASH_CONTENT" > "$HASH_PATH"
 }

--- a/scripts/install-ci-deps.sh
+++ b/scripts/install-ci-deps.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
 source scripts/hash-utils.sh
 
-PACKAGE_JSON_HASH=`md5sum package.json | cut -d ' ' -f 1`
-CACHED_PACKAGE_JSON_HASH=`GET_HASH 'package.json'`
+PACKAGE_JSON_HASH=$(md5sum package.json | cut -d ' ' -f 1)
+CACHED_PACKAGE_JSON_HASH=$(GET_HASH 'package.json')
 
 if [ "$CACHED_PACKAGE_JSON_HASH" == "$PACKAGE_JSON_HASH" ]; then
   echo "> Skipping yarn install"
 else
   yarn install
-  SET_HASH 'package.json' $PACKAGE_JSON_HASH
+  SET_HASH 'package.json' "$PACKAGE_JSON_HASH"
 fi

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# shellcheck disable=SC1091
 source scripts/hash-utils.sh
 
 function MAIN {
@@ -10,8 +11,8 @@ function MAIN {
 }
 
 function INSTALL_FLOW_TYPED {
-  LATEST_FLOW_TYPED_COMMIT_HASH=`curl --silent --header "Accept: application/vnd.github.VERSION.sha" https://api.github.com/repos/flowtype/flow-typed/commits/master`
-  CURRENT_FLOW_TYPED_HASH=`GET_HASH 'flow-typed'`
+  LATEST_FLOW_TYPED_COMMIT_HASH=$(curl --silent --header "Accept: application/vnd.github.VERSION.sha" https://api.github.com/repos/flowtype/flow-typed/commits/master)
+  CURRENT_FLOW_TYPED_HASH=$(GET_HASH 'flow-typed')
   if [ "$LATEST_FLOW_TYPED_COMMIT_HASH" == "$CURRENT_FLOW_TYPED_HASH" ]; then
     echo "> Flow-typed definitions are up to date. Skipping"
   else
@@ -19,25 +20,25 @@ function INSTALL_FLOW_TYPED {
     flow-typed install -s --overwrite
     echo "> Removing broken flow definitions"
     rm flow-typed/npm/{react-i18next_v7.x.x.js,styled-components_v3.x.x.js,redux_*,winston*}
-    SET_HASH 'flow-typed' $LATEST_FLOW_TYPED_COMMIT_HASH
+    SET_HASH 'flow-typed' "$LATEST_FLOW_TYPED_COMMIT_HASH"
   fi
 }
 
 function REBUILD_ELECTRON_NATIVE_DEPS {
   # for strange/fancy os-es
-  if [[ `uname` == 'Darwin' ]]; then
-    PACKAGE_JSON_HASH=`md5 package.json | cut -d ' ' -f 1`
+  if [[ $(uname) == 'Darwin' ]]; then
+    PACKAGE_JSON_HASH=$(md5 package.json | cut -d ' ' -f 1)
   else
     # for normal os-es
-    PACKAGE_JSON_HASH=`md5sum package.json | cut -d ' ' -f 1`
+    PACKAGE_JSON_HASH=$(md5sum package.json | cut -d ' ' -f 1)
   fi
-  CACHED_PACKAGE_JSON_HASH=`GET_HASH 'package.json'`
+  CACHED_PACKAGE_JSON_HASH=$(GET_HASH 'package.json')
   if [ "$CACHED_PACKAGE_JSON_HASH" == "$PACKAGE_JSON_HASH" ]; then
     echo "> Electron native deps are up to date. Skipping"
   else
     echo "> Installing electron native deps"
     DEBUG=electron-builder electron-builder install-app-deps
-    SET_HASH 'package.json' $PACKAGE_JSON_HASH
+    SET_HASH 'package.json' "$PACKAGE_JSON_HASH"
   fi
 }
 

--- a/scripts/reset-files.sh
+++ b/scripts/reset-files.sh
@@ -4,24 +4,24 @@ set -e
 
 echo "> Getting user data folder..."
 
-TMP_FILE=`mktemp`
-cat <<EOF > $TMP_FILE
+TMP_FILE=$(mktemp)
+cat <<EOF > "$TMP_FILE"
 const { app } = require('electron')
 console.log(app.getPath('userData'))
 EOF
-USER_DATA_FOLDER=`timeout 0.5 electron $TMP_FILE || echo` # echo used to ensure status 0
+USER_DATA_FOLDER=$(timeout 0.5 electron "$TMP_FILE" || echo) # echo used to ensure status 0
 
 if [ "$USER_DATA_FOLDER" == "" ]; then
   echo "You probably are on a slow computer. Be patient..."
-  USER_DATA_FOLDER=`timeout 3 electron $TMP_FILE || echo` # echo used to ensure status 0
+  USER_DATA_FOLDER=$(timeout 3 electron "$TMP_FILE" || echo) # echo used to ensure status 0
 fi
 
 if [ "$USER_DATA_FOLDER" == "" ]; then
   echo "Apparently, very very slow computer..."
-  USER_DATA_FOLDER=`timeout 6 electron $TMP_FILE || echo` # echo used to ensure status 0
+  USER_DATA_FOLDER=$(timeout 6 electron "$TMP_FILE" || echo) # echo used to ensure status 0
 fi
 
-rm $TMP_FILE
+rm "$TMP_FILE"
 
 if [ "$USER_DATA_FOLDER" == "" ]; then
   echo "Could not find the data folder. Bye"


### PR DESCRIPTION
Fix linting in shell scripts to conform to [ShellCheck](https://github.com/koalaman/shellcheck) standards. ShellCheck is a static analysis tool that offers suggestions to catch potential warnings and errors. 

Specifically, the following rules have been fixed: [SC1091](https://github.com/koalaman/shellcheck/wiki/SC1091),  [SC2006](https://github.com/koalaman/shellcheck/wiki/SC2006), [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086), [SC2155](https://github.com/koalaman/shellcheck/wiki/SC2155) and [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164)

### Type

Code Quality Improvement

### Context

None

### Parts of the app affected / Test plan

Most shell scripts in the `/scripts` directory. No test plan
