### PR TITLE
More robust implementation of Error fallback

### DIFF
--- a/src/components/TranslatedError.js
+++ b/src/components/TranslatedError.js
@@ -22,14 +22,19 @@ class TranslatedError extends PureComponent<Props> {
   render() {
     const { t, error, field } = this.props
     if (!error) return null
-    if (typeof error === 'string') return error
+    if (typeof error !== 'object') {
+      // this case should not happen (it is supposed to be a ?Error)
+      logger.critical(error)
+      return null
+    }
     if (error.name) {
       const translation = t(`errors:${error.name}.${field}`, error)
-      // FIXME in case the error don't exist in t we should not return and fallback code after. I just don't know how to check this. FIXME
-      return translation
+      if (translation !== `${error.name}.${field}`) {
+        // It is translated
+        return translation
+      }
     }
-    logger.warn(`TranslatedError: no translation for '${error.name}'`, error)
-    return error.message || error.name || t(`errors:generic.${field}`)
+    return t(`errors:generic.${field}`, error)
   }
 }
 

--- a/static/i18n/en/errors.yml
+++ b/static/i18n/en/errors.yml
@@ -1,3 +1,8 @@
+# this error is used when we don't want specific wording or as fallback
+generic:
+  title: '{{message}}'
+  description: Something went wrong. Please retry or contact us.
+
 # the error codes are alphabetically sorted
 BtcUnmatchedApp:
   title: That's the wrong app
@@ -20,27 +25,9 @@ DeviceSocketNoHandler:
 DisconnectedDevice:
   title: Oops, device was disconnected
   description: The connection to the device was lost, so please try again.
-Error:
-  title: '{{message}}'
-  description: Something went wrong. Please retry or contact us.
-"Invariant Violation":
-  title: '{{message}}'
-  description: Something went wrong. Please retry or contact us.
-InternalError:
-  title: '{{message}}'
-  description: Something went wrong. Please retry or contact us.
-TypeError:
-  title: '{{message}}'
-  description: Something went wrong. Please retry or contact us.
-ReferenceError:
-  title: '{{message}}'
-  description: Something went wrong. Please retry or contact us.
 FeeEstimationFailed:
   title: Sorry, fee estimation failed
   description: 'Try setting a custom fee (status: {{status}})'
-generic:
-  title: Sorry, that's an unexpected bug
-  description: Please retry or contact Ledger Support.
 HardResetFail:
   title: Oops, could not reset
   description: Please retry or contact Ledger Support.
@@ -83,9 +70,6 @@ NoAddressesFound:
 NotEnoughBalance:
   title: Oops, not enough balance
   description: Make sure the account to debit has sufficient balance
-RangeError:
-  title: '{{message}}'
-  description:
 TimeoutError:
   title: Oops, a time out occurred
   description: It took too long for the server to respond.


### PR DESCRIPTION
- in future we won't anymore see "unworded" error cases
- it will always fallback to the generic case if error is not worded which is what we want (like the previous Error wording)

### Type

improvement

### Context

this is to avoid this kind of weird error:

![image 2 2](https://user-images.githubusercontent.com/211411/42521332-d802ee82-8468-11e8-93ab-dbe721e036e8.png)

### Parts of the app affected / Test plan

all errors