### PR TITLE
Fixes #948 cur.managerAppName for better precision in app to install

### DIFF
--- a/src/components/AccountPage/EmptyStateAccount.js
+++ b/src/components/AccountPage/EmptyStateAccount.js
@@ -45,7 +45,7 @@ class EmptyStateAccount extends PureComponent<Props, *> {
             <Trans i18nKey="app:account.emptyState.desc">
               {'Make sure the'}
               <Text ff="Open Sans|SemiBold" color="dark">
-                {account.currency.name}
+                {account.currency.managerAppName}
               </Text>
               {'app is installed to receive funds.'}
             </Trans>

--- a/src/components/EnsureDeviceApp.js
+++ b/src/components/EnsureDeviceApp.js
@@ -24,7 +24,6 @@ import type { Device } from 'types/common'
 import { createCustomErrorClass } from 'helpers/errors'
 import { getCurrentDevice } from 'reducers/devices'
 
-export const WrongAppOpened = createCustomErrorClass('WrongAppOpened')
 export const WrongDeviceForAccount = createCustomErrorClass('WrongDeviceForAccount')
 
 const usbIcon = <IconUsb size={16} />
@@ -77,9 +76,9 @@ class EnsureDeviceApp extends Component<{
     const cur = account ? account.currency : currency
     invariant(cur, 'No currency given')
     return (
-      <Trans i18nKey="deviceConnect:step2.open" parent="div">
+      <Trans i18nKey="app:deviceConnect.step2.open" parent="div">
         {'Open the '}
-        <Bold>{cur.name}</Bold>
+        <Bold>{cur.managerAppName}</Bold>
         {' app on your device'}
       </Trans>
     )

--- a/src/helpers/getAddressForCurrency/btc.js
+++ b/src/helpers/getAddressForCurrency/btc.js
@@ -27,9 +27,7 @@ export default async (
   if (bitcoinLikeInfo) {
     const { P2SH, P2PKH } = await getBitcoinLikeInfo(transport)
     if (P2SH !== bitcoinLikeInfo.P2SH || P2PKH !== bitcoinLikeInfo.P2PKH) {
-      throw new BtcUnmatchedApp(`BtcUnmatchedApp ${currency.id}`, {
-        currencyName: currency.name,
-      })
+      throw new BtcUnmatchedApp(`BtcUnmatchedApp ${currency.id}`, currency)
     }
   }
 

--- a/static/i18n/en/app.yml
+++ b/static/i18n/en/app.yml
@@ -89,7 +89,7 @@ account:
   lastOperations: Last operations
   emptyState:
     title: No crypto assets yet?
-    desc: Make sure the <1><0>{{currency}}</0></1> app is installed and start receiving
+    desc: Make sure the <1><0>{{managerAppName}}</0></1> app is installed and start receiving
     buttons:
       receiveFunds: Receive
   settings:
@@ -136,6 +136,8 @@ deviceConnect:
     choose: "We detected {{count}} connected devices, please select one:"
     connect: Connect and unlock your <1>Ledger device</1> # remove key: <3>PIN code</3>
     dashboard: Not used. # This key is not used. Still managed in JS.
+  step2:
+    open: 'Open the <1><0>{{managerAppName}}</0></1> app on your device'
 emptyState:
   sidebar:
     text: Press this button to add accounts to your portfolio

--- a/static/i18n/en/errors.yml
+++ b/static/i18n/en/errors.yml
@@ -6,7 +6,7 @@ generic:
 # the error codes are alphabetically sorted
 BtcUnmatchedApp:
   title: That's the wrong app
-  description: Open the ‘{{currencyName}}’ app on your device
+  description: Open the ‘{{managerAppName}}’ app on your device
 DeviceNotGenuine:
   title: Possibly not genuine
   description: 'Request Ledger Support assistance.'
@@ -94,9 +94,6 @@ WebsocketConnectionError:
 WebsocketConnectionFailed:
   title: Sorry, try again (websocket failed).
   description:
-WrongAppOpened:
-  title: Please open the ‘{{currencyName}}’ app
-  description: The wrong app was opened on your device. Please retry.
 WrongDeviceForAccount:
   title: Oops, wrong device for ‘{{accountName}}’.
   description: The connected device is not associated with the account you selected. Please connect the right device.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,8 +1535,8 @@
     prebuild-install "^2.2.2"
 
 "@ledgerhq/live-common@^2.32.0":
-  version "2.33.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-2.33.0.tgz#07ea0244c6afb7892cf04b466ae23807aad8b509"
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-2.34.0.tgz#436ec0816c37f6aabcbca807090f152f1bd3b785"
   dependencies:
     axios "^0.18.0"
     invariant "^2.2.2"


### PR DESCRIPTION

### Type

wording precision

### Context

#948
https://github.com/LedgerHQ/ledger-live-common/pull/51

### Parts of the app affected / Test plan


<img width="493" alt="capture d ecran 2018-07-10 a 19 06 20" src="https://user-images.githubusercontent.com/211411/42525919-b530154a-8474-11e8-95f4-746dc5f35244.png">

For instance, we now correctly say we need to use "Ethereum" app and not "Ethereum Classic".