### PR TITLE
Disable minimize for all bundles

### DIFF
--- a/webpack/internals.config.js
+++ b/webpack/internals.config.js
@@ -47,4 +47,8 @@ module.exports = webpackMain().then(config => ({
   },
 
   plugins: [...plugins('internals'), ...config.plugins],
+
+  optimization: {
+    minimize: false,
+  },
 }))

--- a/webpack/main.config.js
+++ b/webpack/main.config.js
@@ -9,6 +9,9 @@ const config = {
   module: {
     rules,
   },
+  optimization: {
+    minimize: false,
+  },
 }
 
 module.exports = config

--- a/webpack/renderer.config.js
+++ b/webpack/renderer.config.js
@@ -15,7 +15,7 @@ const config = {
     historyApiFallback: true,
   },
   optimization: {
-    minimizer: [],
+    minimize: false,
   },
 }
 


### PR DESCRIPTION
i've checked the "particle blink" bug is not back so this should be good.
uglify-es was actually still used for internal and main threads and we really want to get it out because it is buggy in many ways. this is why we used to have this `can't assign to const` recently too.
let's see if it actually address some existing bugs.