### PR TITLE
Fix a bug where calculated balance could not refresh on UI

### DIFF
--- a/src/components/CalculateBalance.js
+++ b/src/components/CalculateBalance.js
@@ -79,7 +79,9 @@ const mapStateToProps = (state: State, props: OwnProps) => {
     balanceHistory,
     balanceStart: balanceHistory[0].value,
     balanceEnd,
-    hash: `${balanceHistory.length}_${balanceEnd}_${isAvailable.toString()}`,
+    hash: `${props.accounts.length > 0 ? props.accounts[0].id : ''}_${
+      balanceHistory.length
+    }_${balanceEnd}_${isAvailable.toString()}`,
   }
 }
 


### PR DESCRIPTION
to repro, switch between 2 accounts having same balance (this is very rare to have btw)


### Type

bug (minor ui glitch)

### Context

customer support

### Parts of the app affected / Test plan

graphs, balances