### PR TITLE
Use user-defined countervalue in account page chart tooltip

### DIFF
--- a/src/components/BalanceSummary/index.js
+++ b/src/components/BalanceSummary/index.js
@@ -73,6 +73,7 @@ const BalanceSummary = ({
                 }
                 height={200}
                 currency={counterValue}
+                cvCode={counterValue.ticker}
                 tickXScale={selectedTimeRange}
                 renderTickY={
                   isAvailable ? val => formatShort(counterValue.units[0], val) : () => ''

--- a/src/components/base/Chart/handleMouseEvents.js
+++ b/src/components/base/Chart/handleMouseEvents.js
@@ -96,7 +96,7 @@ export default function handleMouseEvents({
                 unit={props.unit}
                 renderTooltip={renderTooltip}
                 item={d.ref}
-                counterValue={getFiatCurrencyByTicker('USD')}
+                counterValue={getFiatCurrencyByTicker(props.cvCode || 'USD')}
               />
             </ThemeProvider>
           </Provider>,

--- a/src/components/base/Chart/index.js
+++ b/src/components/base/Chart/index.js
@@ -48,6 +48,7 @@ import type { Data } from './types'
 export type Props = {
   data: Data, // eslint-disable-line react/no-unused-prop-types
   unit?: ?Unit, // eslint-disable-line react/no-unused-prop-types
+  cvCode?: string, // eslint-disable-line react/no-unused-prop-types
   id?: string, // eslint-disable-line react/no-unused-prop-types
   height?: number,
   tickXScale: string, // eslint-disable-line react/no-unused-prop-types


### PR DESCRIPTION
closes #965

![2018-07-11-171147_2560x1440_escrotum](https://user-images.githubusercontent.com/315259/42581934-2d88ed96-852e-11e8-8ef4-57c506eb02a4.png)
