### PR TITLE
uncaughtException: no longer exit(1)

### DIFF
--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -16,7 +16,10 @@ process.on('uncaughtException', err => {
     type: 'uncaughtException',
     error: serializeError(err),
   })
-  process.exit(1)
+  // FIXME we should ideally do this:
+  // process.exit(1)
+  // but for now, until we kill all exceptions:
+  logger.critical(err, 'uncaughtException')
 })
 
 const defers = {}

--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -364,7 +364,13 @@ export default {
     logger.log('error', ...args)
   },
 
-  critical: (error: Error) => {
+  critical: (error: Error, context?: string) => {
+    if (context) {
+      captureBreadcrumb({
+        category: 'context',
+        message: context,
+      })
+    }
     logger.log('error', error)
     if (!process.env.STORYBOOK_ENV) {
       try {


### PR DESCRIPTION
to investigate an ongoing issue on Windows, we will logger.critical but temporarily no longer exit on a uncaughtException

this already appear to fix the bug and struggle regarding "can't enter my app, spin forever" on windows. we'll learn more about it as soon as we have report logs.


### Type

bug

### Context

investigation with @NastiaS 

### Parts of the app affected / Test plan

all interactions involving the internal process (device / scanning)