### PR TITLE
Fix a bug with error.message not exposed to t()

### DIFF
--- a/src/components/TranslatedError.js
+++ b/src/components/TranslatedError.js
@@ -30,14 +30,16 @@ class TranslatedError extends PureComponent<Props> {
       }
       return null
     }
+    // $FlowFixMe
+    const arg: Object = Object.assign({ message: error.message }, error)
     if (error.name) {
-      const translation = t(`errors:${error.name}.${field}`, error)
+      const translation = t(`errors:${error.name}.${field}`, arg)
       if (translation !== `${error.name}.${field}`) {
         // It is translated
         return translation
       }
     }
-    return t(`errors:generic.${field}`, error)
+    return t(`errors:generic.${field}`, arg)
   }
 }
 


### PR DESCRIPTION
This fix is really weird, but some Errors, like the one returned by ripple don't have `message` to be enumerable, meaning `t()` don't work.

to reproduce, simply try to import XRP accounts without network.

**before this PR**

<img width="472" alt="capture d ecran 2018-07-11 a 20 18 47" src="https://user-images.githubusercontent.com/211411/42591716-cd7da0c6-8547-11e8-8868-8b6b7feffb79.png">

**after this PR**

<img width="457" alt="capture d ecran 2018-07-11 a 20 18 27" src="https://user-images.githubusercontent.com/211411/42591711-c9dbc074-8547-11e8-9443-ba64d8c722bc.png">


### Type

bugfix
