### PR TITLE
some corrections for crowdin english version

### DIFF
--- a/src/components/Onboarding/steps/GenuineCheck/index.js
+++ b/src/components/Onboarding/steps/GenuineCheck/index.js
@@ -61,12 +61,12 @@ class GenuineCheck extends PureComponent<StepProps, State> {
     const { t } = this.props
     return [
       {
-        label: t('app:common.yes'),
+        label: t('app:common.labelYes'),
         key: 'yes',
         pass: true,
       },
       {
-        label: t('app:common.no'),
+        label: t('app:common.labelNo'),
         key: 'no',
         pass: false,
       },

--- a/src/components/SettingsPage/PasswordForm.js
+++ b/src/components/SettingsPage/PasswordForm.js
@@ -44,7 +44,6 @@ class PasswordForm extends PureComponent<Props> {
               </Label>
               <InputPassword
                 autoFocus
-                placeholder={t('app:password.inputFields.currentPassword.placeholder')}
                 id="currentPassword"
                 onChange={onChange('currentPassword')}
                 value={currentPassword}
@@ -57,7 +56,6 @@ class PasswordForm extends PureComponent<Props> {
             <InputPassword
               style={{ mt: 4, width: 240 }}
               autoFocus={!isPasswordEnabled}
-              placeholder={t('app:password.inputFields.newPassword.placeholder')}
               id="newPassword"
               onChange={onChange('newPassword')}
               value={newPassword}
@@ -69,7 +67,6 @@ class PasswordForm extends PureComponent<Props> {
             </Label>
             <InputPassword
               style={{ width: 240 }}
-              placeholder={t('app:password.inputFields.confirmPassword.placeholder')}
               id="confirmPassword"
               onChange={onChange('confirmPassword')}
               value={confirmPassword}

--- a/static/i18n/en/app.yml
+++ b/static/i18n/en/app.yml
@@ -1,7 +1,7 @@
 common:
   ok: OK
-  yes: Yes
-  no: No
+  labelYes: Yes
+  labelNo: No
   apply: Apply
   confirm: Confirm
   cancel: Cancel
@@ -63,11 +63,7 @@ buttons:
 operation:
   type:
     IN: Received
-#      conf: Received
-#      unconf: Receiving...
     OUT: Sent
-#      conf: Sent
-#      unconf: Sending...
 time:
   day: Day
   week: Week
@@ -134,8 +130,7 @@ currentAddress:
 deviceConnect:
   step1:
     choose: "We detected {{count}} connected devices, please select one:"
-    connect: Connect and unlock your <1>Ledger device</1> # remove key: <3>PIN code</3>
-    dashboard: Not used. # This key is not used. Still managed in JS.
+    connect: Connect and unlock your <1>Ledger device</1>
   step2:
     open: 'Open the <1><0>{{managerAppName}}</0></1> app on your device'
 emptyState:
@@ -279,7 +274,7 @@ send:
     amount:
       title: Details
       selectAccountDebit: Select an account to debit
-      recipientAddress: Recipient address # can't control the tooltip!
+      recipientAddress: Recipient address
       amount: Amount
       max: Max
       fees: Network fees
@@ -312,7 +307,7 @@ send:
 releaseNotes:
   title: Release notes
   version: Ledger Live {{versionNb}}
-settings: # Always ensure descriptions carry full stops (.)
+settings:
   title: Settings
   tabs:
     display: General
@@ -337,9 +332,9 @@ settings: # Always ensure descriptions carry full stops (.)
     exchange: Rate provider ({{ticker}} → BTC)
     exchangeDesc: Choose the provider of the rate between {{currencyName}} and Bitcoin. The indicative total value of your portfolio is calculated by converting your {{currencyName}} to Bitcoin, which is then converted to your base currency.
     confirmationsToSpend: Number of confirmations required to spend
-    confirmationsToSpendDesc: Set the number of network confirmations required for your crypto assets to be spendable. # A higher number of confirmations decreases the probability that a transaction is rejected.
+    confirmationsToSpendDesc: Set the number of network confirmations required for your crypto assets to be spendable.
     confirmationsNb: Number of confirmations
-    confirmationsNbDesc: Set the number of network confirmations for a transaction to be marked as confirmed. # A higher number of confirmations increases the certainty that a transaction cannot be reversed.
+    confirmationsNbDesc: Set the number of network confirmations for a transaction to be marked as confirmed.
     transactionsFees: Default transaction fees
     transactionsFeesDesc: Select your default transaction fees. The higher the fee, the faster the transaction will be processed.
     explorer: Blockchain explorer
@@ -368,7 +363,7 @@ settings: # Always ensure descriptions carry full stops (.)
   help:
     desc: Learn about Ledger Live features or get help.
     version: Version
-    releaseNotesBtn: Details # Close button instead of continue.
+    releaseNotesBtn: Details
     faq: Ledger Support
     faqDesc: A problem? Get help with Ledger Live, Ledger devices, supported crypto assets and apps.
     terms: Terms and conditions
@@ -401,13 +396,10 @@ password:
   inputFields:
     newPassword:
       label: New password
-      placeholder: #remove
     confirmPassword:
       label: Confirm password
-      placeholder: #remove
-    currentPassword: #remove
+    currentPassword:
       label: Current password
-      placeholder:
   changePassword:
     title: Password lock
     subTitle: Change your password

--- a/static/i18n/en/errors.yml
+++ b/static/i18n/en/errors.yml
@@ -45,13 +45,13 @@ LedgerAPINotAvailable:
   description: Please retry or contact Ledger Support.
 ManagerAPIsFail:
   title: Oops, Manager services unavailable.
-  description: Please check the network status. #link to status.ledger.fr ?
+  description: Please check the network status.
 ManagerAppAlreadyInstalled:
-   title: Oops, that's already installed. # include {{currencyName}}
+   title: Oops, that's already installed.
    description: Check your device to see which apps are already installed.
 ManagerAppRelyOnBTC:
   title: Bitcoin app required
-  description: Install the Bitcoin app before installing this app. # include {{currencyName}}
+  description: Install the Bitcoin app before installing this app.
 ManagerDeviceLocked:
   title: Please unlock your device
   description: Your device was locked. Please unlock it.
@@ -59,7 +59,7 @@ ManagerNotEnoughSpace:
   title: Sorry, insufficient device storage
   description: Uninstall some apps to increase available storage and try again.
 ManagerUninstallBTCDep:
-  title: Sorry, Bitcoin is required # include {{currencyName}}
+  title: Sorry, Bitcoin is required
   description: First uninstall apps that depend on Bitcoin.
 NetworkDown:
   title: Oops, internet seems down
@@ -90,7 +90,7 @@ UserRefusedAddress:
   description: Please try again or contact Ledger Support
 WebsocketConnectionError:
   title: Sorry, try again (websocket error).
-  description:  #context
+  description: 
 WebsocketConnectionFailed:
   title: Sorry, try again (websocket failed).
   description:

--- a/static/i18n/en/onboarding.yml
+++ b/static/i18n/en/onboarding.yml
@@ -35,7 +35,7 @@ selectDevice:
     title: Ledger Blue
 selectPIN:
   disclaimer:
-    note1: 'Choose your own PIN code, this code will unlock your device.' # dotted line should be in red. Increase size of the hand (+50%?)
+    note1: 'Choose your own PIN code, this code will unlock your device.'
     note2: An 8-digit PIN code offers an optimum level of security.
     note3: Never use a device supplied with a PIN code or a 24-word recovery phrase.
   initialize:
@@ -68,7 +68,7 @@ writeSeed:
     desc: Your device will generate a 24-word recovery phrase to back up your private keys
     nano:
       step1: 'Copy the word displayed below <1><0>Word #1</0></1> in position 1 on a blank Recovery sheet.'
-      step2: 'Press the right button to display <1><0>Word #2</0></1> and repeat the process until all 24 words are copied on the Recovery sheet.' #<italic>Recovery sheet</italic>
+      step2: 'Press the right button to display <1><0>Word #2</0></1> and repeat the process until all 24 words are copied on the Recovery sheet.'
       step3: 'Confirm your recovery phrase: select each requested word and press both buttons to validate it.'
     blue:
       step1: Copy each word of the recovery phrase on a blank Recovery sheet. Copy the words in the same order.
@@ -146,21 +146,17 @@ analytics:
     title: Report bugs
     desc: Automatically send reports to help Ledger fix bugs.
   technicalData:
-     title: Technical data *
-     desc: Ledger will automatically collect technical information to get basic feedback on usage. This information is anonymous and does not contain personal data.
-     mandatoryText: '* mandatory'
-     mandatoryContextual:
-       title: Technical data
-       item1: Anonymous unique application ID
-       item2: OS name and version
-       item3: Ledger Live version
-       item4: Application language or region
-       item5: OS language or region
+    title: Technical data *
+    desc: Ledger will automatically collect technical information to get basic feedback on usage. This information is anonymous and does not contain personal data.
+    mandatoryText: '* mandatory'
+    mandatoryContextual:
+      title: Technical data
+      item1: Anonymous unique application ID
+      item2: OS name and version
+      item3: Ledger Live version
+      item4: Application language or region
+      item5: OS language or region
 finish:
   title: Your device is ready!
   desc: Proceed to your portfolio and start adding your accounts...
   openAppButton: Open Ledger Live
-  #tooltip:
-    # twitter: Twitter
-    # github: GitHub
-    # reddit: Reddit


### PR DESCRIPTION
Some corrections for Crowdin to be able to have all English text available for translation directly from Crowdin platform vs from the yml 
### Type

Enhancement 
### Context

Internal need to have an access to wording from non-tech 
### Parts of the app affected / Test plan

This PR removes some comments (I transferred comments to Crowdin directly), fixes some indentation, removes unused keys 