### PR TITLE
Fix 'Export Logs' to work without the .gz feature (buggy)

### DIFF
--- a/src/components/ExportLogsBtn.js
+++ b/src/components/ExportLogsBtn.js
@@ -33,6 +33,7 @@ class ExportLogsBtn extends Component<{
       environment: __DEV__ ? 'development' : 'production',
       userAgent: window.navigator.userAgent,
     })
+    const date = new Date() // we don't want all the logs that happen after the Export was pressed ^^
     const path = remote.dialog.showSaveDialog({
       title: 'Export logs',
       defaultPath: `ledgerlive-export-${moment().format(
@@ -46,7 +47,7 @@ class ExportLogsBtn extends Component<{
       ],
     })
     if (path) {
-      const logs = await logger.queryAllLogs()
+      const logs = await logger.queryAllLogs(date)
       const json = JSON.stringify(logs)
       await writeToFile(path, json)
     }

--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -32,23 +32,22 @@ function createDailyRotateFile(processName) {
   return new winston.transports.DailyRotateFile({
     dirname: resolveLogsDirectory(),
     json: true,
-    zippedArchive: true,
     filename: `ledger-live-${processName}-%DATE%.log`,
     datePattern: 'YYYY-MM-DD',
-    maxSize: '10m',
-    maxFiles: '14d',
+    maxSize: '20m',
+    maxFiles: '7d',
   })
 }
 
 const transports = [createDailyRotateFile(pname)]
 
-const queryLogs = (processName: string) =>
+const queryLogs = (processName: string, date: Date) =>
   new Promise((resolve, reject) => {
     const dailyRotateFile = createDailyRotateFile(processName)
     const options = {
-      from: new Date() - 60 * 60 * 1000,
-      until: new Date(),
-      limit: 100,
+      from: date - 10 * 60 * 1000,
+      until: date,
+      limit: 500,
       start: 0,
       order: 'desc',
     }
@@ -61,10 +60,10 @@ const queryLogs = (processName: string) =>
     })
   })
 
-const queryAllLogs = async () => {
-  const internal = await queryLogs('internal')
-  const main = await queryLogs('main')
-  const renderer = await queryLogs('renderer')
+const queryAllLogs = async (date: Date = new Date()) => {
+  const internal = await queryLogs('internal', date)
+  const main = await queryLogs('main', date)
+  const renderer = await queryLogs('renderer', date)
   const all = internal
     .concat(main)
     .concat(renderer)


### PR DESCRIPTION
there were a recent regression in export logs, was not working if more than 10Mb of logs because it rotate in .gz and `query` have a bug with it.

some changes:
- increase max file of log to 20m
- only keep 7d of logs
- when exporting, only taking the 10 last minutes. but increase a bit the max nb of logs to take.

Future notes:

we don't really need to complexity of rotate file logs.. we just only want 3 log files at a time, and probably we can trash the log files each time you open app again 🤔  

### Type

bugfix
