### PR TITLE
Prevent locks to happen during scanning

### DIFF
--- a/src/commands/libcoreScanAccounts.js
+++ b/src/commands/libcoreScanAccounts.js
@@ -17,6 +17,7 @@ const cmd: Command<Input, Result> = createCommand(
   'libcoreScanAccounts',
   ({ devicePath, currencyId }) =>
     Observable.create(o => {
+      let unsubscribed = false
       // TODO scanAccountsOnDevice should directly return a Observable so we just have to pass-in
       withLibcore(core =>
         scanAccountsOnDevice({
@@ -26,6 +27,7 @@ const cmd: Command<Input, Result> = createCommand(
           onAccountScanned: account => {
             o.next(account)
           },
+          isUnsubscribed: () => unsubscribed,
         }).then(
           () => {
             o.complete()
@@ -37,7 +39,7 @@ const cmd: Command<Input, Result> = createCommand(
       )
 
       function unsubscribe() {
-        // FIXME not implemented
+        unsubscribed = true
       }
 
       return unsubscribe

--- a/src/components/DeviceBusyIndicator.js
+++ b/src/components/DeviceBusyIndicator.js
@@ -14,10 +14,10 @@ const Indicator = styled.div`
 `
 
 // NB this is done like this to be extremely performant. we don't want redux for this..
-const perPaths = {}
+let globalBusy = false
 const instances = []
-export const onSetDeviceBusy = (path, busy) => {
-  perPaths[path] = busy
+export const onSetDeviceBusy = busy => {
+  globalBusy = busy
   instances.forEach(i => i.forceUpdate())
 }
 
@@ -30,8 +30,7 @@ class DeviceBusyIndicator extends PureComponent<{}> {
     instances.splice(i, 1)
   }
   render() {
-    const busy = Object.values(perPaths).reduce((busy, b) => busy || b, false)
-    return <Indicator busy={busy} />
+    return <Indicator busy={globalBusy} />
   }
 }
 

--- a/src/helpers/withLibcore.js
+++ b/src/helpers/withLibcore.js
@@ -14,7 +14,8 @@ export default async function withLibcore<A>(job: Job<A>): Promise<A> {
         busy: true,
       })
     }
-    return job(core)
+    const res = await job(core)
+    return res
   } finally {
     if (--counter === 0) {
       process.send({

--- a/src/renderer/events.js
+++ b/src/renderer/events.js
@@ -105,8 +105,8 @@ export default ({ store }: { store: Object }) => {
       onSetLibcoreBusy(busy)
     })
 
-    ipcRenderer.on('setDeviceBusy', (event: any, { busy, devicePath }) => {
-      onSetDeviceBusy(devicePath, busy)
+    ipcRenderer.on('setDeviceBusy', (event: any, { busy }) => {
+      onSetDeviceBusy(busy)
     })
   }
 


### PR DESCRIPTION
this is probably the reason of device/scanning locked and needed you to reboot the app in some cases.

we will need to carefully test this fix, but it's important to get it in. seems to work fine on my side.

### Type

bugfix

### Context

testing the app in a Train. app gets locked (no longer can scan the device, stuck on step2 like many people reproduced) with bad network.

### Parts of the app affected / Test plan

scan app