### PR TITLE
Fix edgecase bug when switching fiat and not reseting the exchange

### DIFF
--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -15,7 +15,11 @@ export const setDeveloperMode = (developerMode: boolean) => saveSettings({ devel
 export const setSentryLogs = (sentryLogs: boolean) => saveSettings({ sentryLogs })
 export const setShareAnalytics = (shareAnalytics: boolean) => saveSettings({ shareAnalytics })
 export const setMarketIndicator = (marketIndicator: *) => saveSettings({ marketIndicator })
-export const setCounterValue = (counterValue: string) => saveSettings({ counterValue })
+export const setCounterValue = (counterValue: string) =>
+  saveSettings({
+    counterValue,
+    counterValueExchange: null,
+  })
 export const setLanguage = (language: ?string) => saveSettings({ language })
 export const setRegion = (region: ?string) => saveSettings({ region })
 export const setCounterValueExchange = (counterValueExchange: ?string) =>


### PR DESCRIPTION
bug was:
select USD
it should select BitMEX
now select HKD
it will select nothing in the list

not 100% sure but i suspect that BITMEX used to exist on BTC-HKD but no longer, so it's an accepted choice by our api but it's not present in the list.

the fix is to always reset the exchange to first one (which is the most volume one) when you switch countervalue

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

bugfix (edgecase)

### Context

https://github.com/LedgerHQ/ledger-live-desktop/issues/1138#issuecomment-405091149

### Parts of the app affected / Test plan

settings countervalue / exchange