### PR TITLE
Fix flow-typed caching

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -11,7 +11,7 @@ function MAIN {
 }
 
 function INSTALL_FLOW_TYPED {
-  LATEST_FLOW_TYPED_COMMIT_HASH=$(curl --silent --header "Accept: application/vnd.github.VERSION.sha" https://api.github.com/repos/flowtype/flow-typed/commits/master)
+  LATEST_FLOW_TYPED_COMMIT_HASH=$(curl --silent --header "Accept: application/vnd.github.VERSION.sha" --location https://api.github.com/repos/flowtype/flow-typed/commits/master)
   CURRENT_FLOW_TYPED_HASH=$(GET_HASH 'flow-typed')
   if [ "$LATEST_FLOW_TYPED_COMMIT_HASH" == "$CURRENT_FLOW_TYPED_HASH" ]; then
     echo "> Flow-typed definitions are up to date. Skipping"


### PR DESCRIPTION
Fix post-install script failing to get the latest `flow-typed` package hash, breaking our caching system.

### Type

Bug fix

### Context

When doing `yarn`, the install script was ending with showing an HTTP redirection message and save it rather than the last `flow-typed` package hash

### Parts of the app affected / Test plan

npm post-install script
