### PR TITLE
ETH/ETC: always scan 5 empty accounts ahead for better discoverability

### DIFF
--- a/src/helpers/derivations.js
+++ b/src/helpers/derivations.js
@@ -1,17 +1,21 @@
 // @flow
 import type { CryptoCurrency } from '@ledgerhq/live-common/lib/types'
 
-type Derivation = ({
-  currency: CryptoCurrency,
-  segwit: boolean,
-  x: number,
-}) => string
+type Derivation = {
+  ({
+    currency: CryptoCurrency,
+    segwit: boolean,
+    x: number,
+  }): string,
+
+  mandatoryEmptyAccountSkip?: number,
+}
 
 const ethLegacyMEW: Derivation = ({ x }) => `44'/60'/0'/${x}`
-ethLegacyMEW.mandatoryCount = 5
+ethLegacyMEW.mandatoryEmptyAccountSkip = 10
 
 const etcLegacyMEW: Derivation = ({ x }) => `44'/60'/160720'/${x}'/0`
-etcLegacyMEW.mandatoryCount = 5
+etcLegacyMEW.mandatoryEmptyAccountSkip = 10
 
 const rippleLegacy: Derivation = ({ x }) => `44'/144'/0'/${x}'`
 

--- a/src/logger/logger-storybook.js
+++ b/src/logger/logger-storybook.js
@@ -16,6 +16,8 @@ module.exports = {
   analyticsTrack: noop,
   analyticsPage: noop,
   log: noop,
+  info: noop,
+  debug: noop,
   warn: noop,
   error: noop,
   critical: noop,

--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -350,6 +350,14 @@ export default {
 
   // General functions in case the hooks don't apply
 
+  debug: (...args: any) => {
+    logger.log('debug', ...args)
+  },
+
+  info: (...args: any) => {
+    logger.log('info', ...args)
+  },
+
   log: (...args: any) => {
     logger.log('info', ...args)
   },


### PR DESCRIPTION
fix discoverability of ETH/ETC address that was manually used from MEW in a wrong order (not respecting the top-down scanning)

this will allow more eth accounts to be discovered. if users have left "empty pages" of address, we won't support this, you will have to move your funds from MEW to a new address.

proof:

<img width="277" alt="capture d ecran 2018-07-17 a 15 31 37" src="https://user-images.githubusercontent.com/211411/42820676-febf0a6a-89d6-11e8-8460-8727715a7c15.png">

before this commit, account 5 was discovered, but not account 10.

### Type

polish

### Context

people still complaining about not seeing their account. 
typically because this was not respected:

<img width="1282" alt="out" src="https://user-images.githubusercontent.com/211411/42820662-f420d958-89d6-11e8-9fc8-e71311154984.png">


### Parts of the app affected / Test plan

eth scan account