### PR TITLE
Fixes #1153

### DIFF
--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -16,12 +16,6 @@ export const removeAccount: RemoveAccount = payload => ({
   payload,
 })
 
-export type ReorderAccounts = (string[]) => { type: string, payload: string[] }
-export const reorderAccounts: ReorderAccounts = payload => ({
-  type: 'DB:REORDER_ACCOUNTS',
-  payload,
-})
-
 export type FetchAccounts = () => *
 export const fetchAccounts: FetchAccounts = () => {
   db.init('accounts', []) // FIXME the "init" pattern to drop imo. a simple get()||[] is enough

--- a/src/actions/general.js
+++ b/src/actions/general.js
@@ -1,0 +1,43 @@
+// @flow
+
+import { createSelector, createStructuredSelector } from 'reselect'
+import CounterValues from 'helpers/countervalues'
+import {
+  intermediaryCurrency,
+  currencySettingsForAccountSelector,
+  getOrderAccounts,
+} from 'reducers/settings'
+import { accountsSelector } from 'reducers/accounts'
+import { sortAccounts } from 'helpers/accountOrdering'
+
+const accountsBtcBalanceSelector = createSelector(
+  accountsSelector,
+  state => state,
+  (accounts, state) =>
+    accounts.map(account => {
+      const { exchange } = currencySettingsForAccountSelector(state, { account })
+      return CounterValues.calculateSelector(state, {
+        from: account.currency,
+        to: intermediaryCurrency,
+        exchange,
+        value: account.balance,
+      })
+    }),
+)
+
+const selectAccountsBalanceAndOrder = createStructuredSelector({
+  accounts: accountsSelector,
+  accountsBtcBalance: accountsBtcBalanceSelector,
+  orderAccounts: getOrderAccounts,
+})
+
+export const refreshAccountsOrdering = () => (dispatch: *, getState: *) => {
+  const all = selectAccountsBalanceAndOrder(getState())
+  const allRatesAvailable = all.accountsBtcBalance.every(b => typeof b === 'number')
+  if (allRatesAvailable) {
+    dispatch({
+      type: 'DB:REORDER_ACCOUNTS',
+      payload: sortAccounts(all),
+    })
+  }
+}

--- a/src/components/DashboardPage/index.js
+++ b/src/components/DashboardPage/index.js
@@ -24,10 +24,10 @@ import {
 } from 'reducers/settings'
 import type { TimeRange } from 'reducers/settings'
 
-import { reorderAccounts } from 'actions/accounts'
 import { saveSettings } from 'actions/settings'
 
 import TrackPage from 'analytics/TrackPage'
+import RefreshAccountsOrdering from 'components/RefreshAccountsOrdering'
 import UpdateNotifier from 'components/UpdateNotifier'
 import BalanceInfos from 'components/BalanceSummary/BalanceInfos'
 import BalanceSummary from 'components/BalanceSummary'
@@ -51,7 +51,6 @@ const mapStateToProps = createStructuredSelector({
 
 const mapDispatchToProps = {
   push,
-  reorderAccounts,
   saveSettings,
   openModal,
 }
@@ -102,6 +101,7 @@ class DashboardPage extends PureComponent<Props> {
     return (
       <Fragment>
         <UpdateNotifier />
+        <RefreshAccountsOrdering onMount />
         <TrackPage
           category="Portfolio"
           totalAccounts={totalAccounts}

--- a/src/components/RefreshAccountsOrdering.js
+++ b/src/components/RefreshAccountsOrdering.js
@@ -1,0 +1,38 @@
+// @flow
+
+import { Component } from 'react'
+import { connect } from 'react-redux'
+import { refreshAccountsOrdering } from 'actions/general'
+
+const mapStateToProps = null
+
+const mapDispatchToProps = {
+  refreshAccountsOrdering,
+}
+
+class RefreshAccountsOrdering extends Component<{
+  refreshAccountsOrdering: () => *,
+  onMount?: boolean,
+  onUnmount?: boolean,
+}> {
+  componentDidMount() {
+    if (this.props.onMount) {
+      this.props.refreshAccountsOrdering()
+    }
+  }
+
+  componentWillUnmount() {
+    if (this.props.onUnmount) {
+      this.props.refreshAccountsOrdering()
+    }
+  }
+
+  render() {
+    return null
+  }
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(RefreshAccountsOrdering)

--- a/src/components/modals/AddAccounts/steps/04-step-finish.js
+++ b/src/components/modals/AddAccounts/steps/04-step-finish.js
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import TrackPage from 'analytics/TrackPage'
 import Box from 'components/base/Box'
 import Button from 'components/base/Button'
+import RefreshAccountsOrdering from 'components/RefreshAccountsOrdering'
 import IconCheckFull from 'icons/CheckFull'
 import { CurrencyCircleIcon } from '../../../base/CurrencyBadge'
 import type { StepProps } from '../index'
@@ -30,6 +31,10 @@ const Text = styled(Box).attrs({
 function StepFinish({ currency, t, checkedAccountsIds }: StepProps) {
   return (
     <Box align="center" py={6}>
+      <RefreshAccountsOrdering onMount onUnmount />
+      {/* onMount because if we already have the countervalues we want to sort it straightaway
+          onUnmount because if not, it is useful to trigger a second refresh to ensure it get sorted */}
+
       <TrackPage category="AddAccounts" name="Step4" />
       {currency ? (
         <Box color="positiveGreen" style={{ position: 'relative' }}>

--- a/src/helpers/accountOrdering.js
+++ b/src/helpers/accountOrdering.js
@@ -1,0 +1,37 @@
+// @flow
+
+import type { Account } from '@ledgerhq/live-common/lib/types'
+
+type Param = {
+  accounts: Account[],
+  accountsBtcBalance: number[],
+  orderAccounts: string,
+}
+
+type SortMethod = 'name' | 'balance'
+
+const sortMethod: { [_: SortMethod]: (Param) => string[] } = {
+  balance: ({ accounts, accountsBtcBalance }) =>
+    accounts
+      .map((a, i) => [a.id, accountsBtcBalance[i]])
+      .sort((a, b) => a[1] - b[1])
+      .map(o => o[0]),
+
+  name: ({ accounts }) =>
+    accounts
+      .slice(0)
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(a => a.id),
+}
+
+export function sortAccounts(param: Param) {
+  const [order, sort] = param.orderAccounts.split('|')
+  if (order === 'name' || order === 'balance') {
+    const ids = sortMethod[order](param)
+    if (sort === 'asc') {
+      ids.reverse()
+    }
+    return ids
+  }
+  return null
+}


### PR DESCRIPTION
- trigger a reorder on Portfolio page access. 
- trigger reorder in step 4 of add accounts (before AND after)

also don't do a reorder if countervalues are not ready

### Type

polish

### Context

#1153

### Parts of the app affected / Test plan

sorting of accounts