### PR TITLE
fixes #1169

### DIFF
--- a/src/components/base/Chart/handleMouseEvents.js
+++ b/src/components/base/Chart/handleMouseEvents.js
@@ -65,7 +65,7 @@ export default function handleMouseEvents({
     NODES.tooltip
       .style('transition', '100ms cubic-bezier(.61,1,.53,1) opacity')
       .style('opacity', 1)
-      .style('transform', `translate3d(${MARGINS.left + x(d.parsedDate)}px, 0, 0)`)
+      .style('left', `${Math.floor(MARGINS.left + x(d.parsedDate))}px`)
     NODES.focus.style('opacity', 1)
     NODES.xBar.style('opacity', 1)
   }
@@ -102,7 +102,7 @@ export default function handleMouseEvents({
           </Provider>,
         ),
       )
-      .style('transform', `translate3d(${MARGINS.left + x(d.parsedDate)}px, 0, 0)`)
+      .style('left', `${Math.floor(MARGINS.left + x(d.parsedDate))}px`)
     NODES.xBar
       .attr('x1', x(d.parsedDate))
       .attr('x2', x(d.parsedDate))

--- a/src/styles/reset.js
+++ b/src/styles/reset.js
@@ -1,5 +1,6 @@
 module.exports = `* {
   -webkit-font-smoothing: antialiased;
+  backface-visibility: hidden;
   box-sizing: border-box;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
On non-retina screen some text in the tooltip of the chart was blur. It was caused by the way the webkit treats transform translate3d on those screens.
### Type

Bug fix
### Context

Github issue #1169 
### Parts of the app affected / Test plan

Tooltip text on charts. Test on non-retina screen