### PR TITLE
Reviewed error messages

### DIFF
--- a/static/i18n/en/errors.json
+++ b/static/i18n/en/errors.json
@@ -37,7 +37,7 @@
   },
   "EnpointConfig": {
     "title": "Invalid endpoint",
-    "description": "Please provide with a valid endpoint"
+    "description": "Please provide a valid endpoint"
   },
   "FeeEstimationFailed": {
     "title": "Sorry, fee estimation failed",
@@ -116,11 +116,11 @@
     "description": "It took too long for the server to respond."
   },
   "TransportError": {
-    "title": "Something went wrong. Please replug your device.",
+    "title": "Something went wrong. Please reconnect your device.",
     "description": "{{message}}"
   },
   "TransportStatusError": {
-    "title": "Something went wrong. Please replug your device.",
+    "title": "Something went wrong. Please reconnect your device.",
     "description": "{{message}}"
   },
   "UserRefusedFirmwareUpdate": {


### PR DESCRIPTION
UI Polish.

### Type

Wording 

### Context

Some error messages were written as "replug" instead of "reconnect".

### Parts of the app affected / Test plan

Error messages 