### PR TITLE
Correct dynamic library path to be handled by macOS >= 10.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@ledgerhq/hw-app-xrp": "^4.13.0",
     "@ledgerhq/hw-transport": "^4.13.0",
     "@ledgerhq/hw-transport-node-hid": "^4.13.0",
-    "@ledgerhq/ledger-core": "2.0.0-rc.4",
+    "@ledgerhq/ledger-core": "2.0.0-rc.5",
     "@ledgerhq/live-common": "^2.35.0",
     "animated": "^0.2.2",
     "async": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,9 +1521,9 @@
   dependencies:
     events "^2.0.0"
 
-"@ledgerhq/ledger-core@2.0.0-rc.4":
-  version "2.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.4.tgz#0ec80a763c666658bea94bd38b86aa90d5a24906"
+"@ledgerhq/ledger-core@2.0.0-rc.5":
+  version "2.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.5.tgz#ec42f6c3cc265fc5ca82e01d27df38357642d3ed"
   dependencies:
     "@ledgerhq/hw-app-btc" "^4.7.3"
     "@ledgerhq/hw-transport-node-hid" "^4.7.6"


### PR DESCRIPTION
Fixes #1032 event it's already closed LOL. ok reopening it for the lulz.