### PR TITLE
fix old regression on the onboarding breadcrumb

### DIFF
--- a/src/components/Onboarding/OnboardingBreadcrumb.js
+++ b/src/components/Onboarding/OnboardingBreadcrumb.js
@@ -51,7 +51,7 @@ function OnboardingBreadcrumb(props: Props) {
 
   return (
     <Breadcrumb
-      stepsErrors={genuine.isGenuineFail ? [genuineStepIndex] : undefined}
+      stepsErrors={genuine.displayErrorScreen ? [genuineStepIndex] : undefined}
       currentStep={stepIndex}
       items={filteredSteps}
     />


### PR DESCRIPTION
There was an old regression on the breadcrumb of the onboarding. It wouldn't change to the error case and turn red in case of entering the Error screen unless it is specifically Genuine check failed case.
### Type

Bug Fix
### Context

No existing issue
### Parts of the app affected / Test plan

Onboarding Breadcrumb - Genuine check step. Answering 'No' on any question or Failing the genuine check now will display properly the error state of the breadcrumb