### PR TITLE
Fixes #1199

### DIFF
--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -63,14 +63,16 @@ const txToOps = (account: Account) => (tx: Tx): Operation[] => {
   const sending = freshAddress === from
   const receiving = freshAddress === to
   const ops = []
-  const fee = tx.gas_price * tx.gas_used
+  // FIXME problem with our api, precision lost here...
+  const value = BigNumber(tx.value)
+  const fee = BigNumber(tx.gas_price * tx.gas_used)
   if (sending) {
     ops.push({
       id: `${account.id}-${tx.hash}-OUT`,
       hash: tx.hash,
       type: 'OUT',
-      value: BigNumber(tx.value), // FIXME problem with our api, precision lost here...
-      fee: BigNumber(fee), // FIXME problem with our api, precision lost here...
+      value: value.plus(fee),
+      fee,
       blockHeight: tx.block && tx.block.height,
       blockHash: tx.block && tx.block.hash,
       accountId: account.id,
@@ -84,8 +86,8 @@ const txToOps = (account: Account) => (tx: Tx): Operation[] => {
       id: `${account.id}-${tx.hash}-IN`,
       hash: tx.hash,
       type: 'IN',
-      value: BigNumber(tx.value), // FIXME problem with our api, precision lost here...
-      fee: BigNumber(fee), // FIXME problem with our api, precision lost here...
+      value,
+      fee,
       blockHeight: tx.block && tx.block.height,
       blockHash: tx.block && tx.block.hash,
       accountId: account.id,


### PR DESCRIPTION
fix amount calculation for ethereum to include fees for the 'Sending out' operations, like is the case for XRP & libcore backed coins

### Type

bug

### Context

#1199

### Parts of the app affected / Test plan

users will have to manually do a Clear Cache for the operations to re-update.