### PR TITLE
fixes #1210

### DIFF
--- a/src/components/AccountPage/EmptyStateAccount.js
+++ b/src/components/AccountPage/EmptyStateAccount.js
@@ -32,7 +32,7 @@ class EmptyStateAccount extends PureComponent<Props, *> {
   render() {
     const { t, account, openModal } = this.props
     return (
-      <Box mt={7} alignItems="center">
+      <Box mt={7} alignItems="center" selectable>
         <img
           alt="emptyState Dashboard logo"
           src={i('logos/emptyStateAccount.png')}

--- a/src/components/DashboardPage/index.js
+++ b/src/components/DashboardPage/index.js
@@ -108,7 +108,7 @@ class DashboardPage extends PureComponent<Props> {
           totalOperations={totalOperations}
           totalCurrencies={totalCurrencies}
         />
-        <Box flow={7}>
+        <Box flow={7} selectable>
           {totalAccounts > 0 ? (
             <Fragment>
               <Box horizontal alignItems="flex-end">

--- a/src/components/ExchangePage/index.js
+++ b/src/components/ExchangePage/index.js
@@ -57,7 +57,7 @@ class ExchangePage extends PureComponent<Props> {
   render() {
     const { t } = this.props
     return (
-      <Box pb={6}>
+      <Box pb={6} selectable>
         <TrackPage category="Exchange" />
         <Box ff="Museo Sans|Regular" fontSize={7} color="dark">
           {t('app:exchange.title')}

--- a/src/components/ManagerPage/Dashboard.js
+++ b/src/components/ManagerPage/Dashboard.js
@@ -23,7 +23,7 @@ type Props = {
 }
 
 const Dashboard = ({ device, deviceInfo, t, handleHelpRequest }: Props) => (
-  <Box flow={4} pb={8}>
+  <Box flow={4} pb={8} selectable>
     <TrackPage category="Manager" name="Dashboard" />
     <Box>
       <Text ff="Museo Sans|Regular" fontSize={7} color="dark">

--- a/src/components/ManagerPage/ManagerGenuineCheck.js
+++ b/src/components/ManagerPage/ManagerGenuineCheck.js
@@ -22,7 +22,7 @@ class ManagerGenuineCheck extends PureComponent<Props> {
   render() {
     const { t, onSuccess } = this.props
     return (
-      <Box align="center" py={7}>
+      <Box align="center" py={7} selectable>
         <TrackPage category="Manager" name="Genuine Check" />
         <Box align="center" style={{ maxWidth: 460 }}>
           <img

--- a/src/components/Onboarding/index.js
+++ b/src/components/Onboarding/index.js
@@ -202,6 +202,7 @@ class Onboarding extends PureComponent<Props> {
 const Container = styled(Box).attrs({
   bg: 'white',
   p: 60,
+  selectable: true,
 })`
   position: fixed;
   top: 0;

--- a/src/components/SettingsPage/index.js
+++ b/src/components/SettingsPage/index.js
@@ -105,7 +105,7 @@ class SettingsPage extends PureComponent<Props, State> {
     const items = this._items.filter(item => item.key !== 'currencies' || accountsCount > 0)
 
     return (
-      <Box pb={4}>
+      <Box pb={4} selectable>
         <Box ff="Museo Sans|Regular" color="dark" fontSize={7} mb={5}>
           {t('app:settings.title')}
         </Box>

--- a/src/components/base/Modal/ModalBody.js
+++ b/src/components/base/Modal/ModalBody.js
@@ -77,6 +77,7 @@ const Body = styled(Box).attrs({
   bg: p => p.theme.colors.white,
   relative: true,
   borderRadius: 1,
+  selectable: true,
 })`
   box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.2);
 `

--- a/src/styles/reset.js
+++ b/src/styles/reset.js
@@ -6,7 +6,8 @@ module.exports = `* {
   padding: 0;
   font: inherit;
   color: inherit;
-  user-select: none;
+  user-select: inherit;
+  cursor: inherit;
   min-width: 0;
   outline: none;
 
@@ -21,6 +22,8 @@ body {
   font-size: 16px;
   font-weight: 300;
   line-height: 1.5;
+  user-select: none;
+  cursor: default;
 }
 
 #app {


### PR DESCRIPTION
It should give non-English speakers a quick way to translate info chunks by copying and pasting the text
### Type

Enhancement 
### Context

Github issue #1210 
### Parts of the app affected / Test plan

- Onboarding screens with all instructions 

- Application settings 

- All modals, including warnings, confirmation modals, modals with additional info during onboarding

- Manager: both Dashboard and Genuine check 

- Exchanges 

All elements (like cards) that were clickable and had text inside retain their behavior. You might copy the text using shortcuts but it would still navigate as before.