### PR TITLE
Fixes #1186

### DIFF
--- a/src/api/Ripple.js
+++ b/src/api/Ripple.js
@@ -41,6 +41,7 @@ export const formatAPICurrencyXRP = (amount: BigNumber) => {
   const value = formatCurrencyUnit(rippleUnit, amount, {
     showAllDigits: true,
     disableRounding: true,
+    useGrouping: false,
   })
   return { currency: 'XRP', value }
 }


### PR DESCRIPTION
Fixes #1186

app was failing to send more than 1000 XRP because was formatting numbers as 1,000.000 to the ripple-lib / API during the transaction preparation.

### Type

bug

### Context

 #1186

### Parts of the app affected / Test plan

i had to buy 1000 XRP to reproduce the problem 🤣