### PR TITLE
Fix duplicates between pending & non pending in Ripple

### DIFF
--- a/src/bridge/RippleJSBridge.js
+++ b/src/bridge/RippleJSBridge.js
@@ -417,6 +417,7 @@ const RippleJSBridge: WalletBridge<Transaction> = {
             const [last] = operations
             const pendingOperations = a.pendingOperations.filter(
               o =>
+                !operations.some(op => o.hash === op.hash) &&
                 last &&
                 last.transactionSequenceNumber &&
                 o.transactionSequenceNumber &&


### PR DESCRIPTION
if you was sending twice Ripple in a row, before a sync, it would have potentially make pending ops staying forever.

### Type

bugfix
