### PR TITLE
Fixes #1181

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -32,7 +32,9 @@ export const GENUINE_TIMEOUT = intFromEnv('GENUINE_TIMEOUT', 120 * 1000)
 export const GET_CALLS_RETRY = intFromEnv('GET_CALLS_RETRY', 2)
 export const GET_CALLS_TIMEOUT = intFromEnv('GET_CALLS_TIMEOUT', 30 * 1000)
 export const LISTEN_DEVICES_POLLING_INTERVAL = intFromEnv('LISTEN_DEVICES_POLLING_INTERVAL', 1000)
-export const OUTDATED_CONSIDERED_DELAY = intFromEnv('OUTDATED_CONSIDERED_DELAY', 5 * 60 * 1000)
+// NB: technically speaking OUTDATED_CONSIDERED_DELAY should be set to ZERO.
+// but we'll only do that when we're sure the sync is performant and all is working smoothly
+export const OUTDATED_CONSIDERED_DELAY = intFromEnv('OUTDATED_CONSIDERED_DELAY', 2 * 60 * 1000)
 export const SYNC_ALL_INTERVAL = 120 * 1000
 export const SYNC_BOOT_DELAY = 2 * 1000
 export const SYNC_PENDING_INTERVAL = 10 * 1000


### PR DESCRIPTION
improvement of the Sync reload system: it will always sync again if you left a critical modal that was pausing the system.

we'll need to give some testing session to this new system, but it should make `Paused` display to goes away when you are not in a modal basically.

also reduced the "extra data" that consider things outdated to 2mn. (nb, the extra delay is actually added to the block avg time of each currency. so in future, we would like to actually make it zero)

![always_reload](https://user-images.githubusercontent.com/211411/42991819-1123cb0a-8c07-11e8-996e-d88ae859e70a.gif)

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

improvement

### Context

#1181

### Parts of the app affected / Test plan

you must be in a modal for more than 2minutes to start seeing the "paused" state, then you can try to reproduce it