### PR TITLE
Fixes 'Ledger Sequence too high'

### DIFF
--- a/src/bridge/RippleJSBridge.js
+++ b/src/bridge/RippleJSBridge.js
@@ -69,6 +69,7 @@ async function signAndBroadcast({ a, t, deviceId, isCancelled, onSigned, onOpera
     }
     const instruction = {
       fee: formatAPICurrencyXRP(t.fee).value,
+      maxLedgerVersionOffset: 12,
     }
 
     const prepared = await api.preparePayment(a.freshAddress, payment, instruction)


### PR DESCRIPTION
this error was related to when you don't sign on the device fast enough. this should increase the accepted time.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

improvment

### Context

#1186 

### Parts of the app affected / Test plan

ripple send