### PR TITLE
a few adjustments after design meeting on selectables

### DIFF
--- a/src/components/DashboardPage/index.js
+++ b/src/components/DashboardPage/index.js
@@ -108,7 +108,7 @@ class DashboardPage extends PureComponent<Props> {
           totalOperations={totalOperations}
           totalCurrencies={totalCurrencies}
         />
-        <Box flow={7} selectable>
+        <Box flow={7}>
           {totalAccounts > 0 ? (
             <Fragment>
               <Box horizontal alignItems="flex-end">

--- a/src/components/ExchangePage/ExchangeCard.js
+++ b/src/components/ExchangePage/ExchangeCard.js
@@ -26,14 +26,14 @@ export default class ExchangeCard extends PureComponent<{ t: T, card: CardType }
       t,
     } = this.props
     return (
-      <Card horizontal py={5} px={6} style={{ cursor: 'pointer' }} onClick={this.onClick}>
+      <Card horizontal py={5} px={6}>
         <Box justify="center" style={{ width: 200 }}>
           {logo}
         </Box>
         <Box shrink ff="Open Sans|Regular" fontSize={4} flow={3}>
           <Box>{t(`app:exchange.${id}`)}</Box>
           <Box horizontal align="center" color="wallet" flow={1}>
-            <FakeLink>{t('app:exchange.visitWebsite')}</FakeLink>
+            <FakeLink onClick={this.onClick}>{t('app:exchange.visitWebsite')}</FakeLink>
             <ExternalLinkIcon size={14} />
           </Box>
         </Box>

--- a/src/components/base/Modal/ModalBody.js
+++ b/src/components/base/Modal/ModalBody.js
@@ -77,7 +77,6 @@ const Body = styled(Box).attrs({
   bg: p => p.theme.colors.white,
   relative: true,
   borderRadius: 1,
-  selectable: true,
 })`
   box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.2);
 `

--- a/src/components/base/Modal/index.js
+++ b/src/components/base/Modal/index.js
@@ -241,6 +241,7 @@ export const ModalFooter = styled(Box).attrs({
 export const ModalContent = styled(Box).attrs({
   px: 5,
   pb: 5,
+  selectable: true,
 })``
 
 export default connect(

--- a/src/components/base/SideBar/SideBarList.js
+++ b/src/components/base/SideBar/SideBarList.js
@@ -35,7 +35,7 @@ class SideBarList extends Component<Props> {
             {children}
           </ListWrapper>
         ) : emptyState ? (
-          <Box px={4} ff="Open Sans|Regular" fontSize={3} color="grey">
+          <Box px={4} ff="Open Sans|Regular" selectable fontSize={3} color="grey">
             {emptyState}
           </Box>
         ) : null}


### PR DESCRIPTION
A few adjustments after meeting with design on the selectables
Exchanges cards clickable effect removed
Selectable effect removed on the Portfolio

Selectable on the Box is rather a fast short term solution since it lets to select content of a whole div instead of a specific block of text. 
### Type

Polish

### Context

Github issue #1210 
### Parts of the app affected / Test plan

exchange page
sidebar empty state
modal content 