### PR TITLE
Ask users to install latest btc app version when installing altcoins

### DIFF
--- a/static/i18n/en/errors.json
+++ b/static/i18n/en/errors.json
@@ -73,7 +73,7 @@
   },
   "ManagerAppRelyOnBTC": {
     "title": "Bitcoin app required",
-    "description": "Install the Bitcoin app before installing this app."
+    "description": "Install the latest version of the Bitcoin app before installing this app."
   },
   "ManagerDeviceLocked": {
     "title": "Please unlock your device",


### PR DESCRIPTION
Prompt users to install latest version of bitcoin app.

### Type

UI polish / wording

### Context

1. User has older btc app version installed.
2. Tries to install altcoin app
3. Error message: First install the bitcoin app before installing [altcoin].
4. BTC app already installed --> confusion.

### Parts of the app affected / Test plan

Manager