### PR TITLE
fixes #1228

### DIFF
--- a/src/bridge/index.js
+++ b/src/bridge/index.js
@@ -1,17 +1,24 @@
 // @flow
 import type { Currency } from '@ledgerhq/live-common/lib/types'
 import invariant from 'invariant'
+import { USE_MOCK_DATA } from 'config/constants'
 import { WalletBridge } from './types'
 import LibcoreBridge from './LibcoreBridge'
 import EthereumJSBridge from './EthereumJSBridge'
 import RippleJSBridge from './RippleJSBridge'
+import makeMockBridge from './makeMockBridge'
 
 const perFamily = {
   bitcoin: LibcoreBridge,
   ripple: RippleJSBridge,
   ethereum: EthereumJSBridge,
 }
-
+if (USE_MOCK_DATA) {
+  const mockBridge = makeMockBridge()
+  perFamily.bitcoin = mockBridge
+  perFamily.ethereum = mockBridge
+  perFamily.ripple = mockBridge
+}
 export const getBridgeForCurrency = (currency: Currency): WalletBridge<any> => {
   const bridge = perFamily[currency.family]
   invariant(bridge, `${currency.id} currency is not supported`)

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -5,6 +5,13 @@ const intFromEnv = (key: string, def: number): number => {
   if (!isNaN(v)) return parseInt(v, 10)
   return def
 }
+
+const floatFromEnv = (key: string, def: number): number => {
+  const v = process.env[key]
+  if (!isNaN(v)) return parseFloat(v)
+  return def
+}
+
 const boolFromEnv = (key: string, def: boolean = false): boolean => {
   const v = process.env[key]
   if (typeof v === 'string') return !(v === '0' || v === 'false')
@@ -87,6 +94,7 @@ export const EXPERIMENTAL_TOOLS_SETTINGS = boolFromEnv('EXPERIMENTAL_TOOLS_SETTI
 export const EXPERIMENTAL_MARKET_INDICATOR_SETTINGS = boolFromEnv(
   'EXPERIMENTAL_MARKET_INDICATOR_SETTINGS',
 )
+export const USE_MOCK_DATA = boolFromEnv('USE_MOCK_DATA')
 
 // Other constants
 
@@ -103,3 +111,4 @@ export const MODAL_TECHNICAL_DATA = 'MODAL_TECHNICAL_DATA'
 
 export const MODAL_DISCLAIMER = 'MODAL_DISCLAIMER'
 export const MODAL_DISCLAIMER_DELAY = 1 * 1000
+export const MOCK_DATA_SEED = floatFromEnv('MOCK_DATA_SEED', Math.random())


### PR DESCRIPTION
This PR is to give ability to generate mock data for accounts.

- It doesn't trash previous data, doesn't do any hard reset. 

- It is for marketing and design purposes to generate mock accounts. 

- Currently, it generates 3 accounts per crypto. This number can easily be changed if needed. 

- It doesn't mock the device 

### Type

Feature request
### Context

Github issue #1228 
### Parts of the app affected / Test plan

Mock data for accounts.

To run from the command line there are 2 env variables:
USE_MOCK_DATA - to toggle on the mock
MOCK_DATA_SEED - to ensure stable single global seed if needed (otherwise it defaults to Math.random())

exp: ```USE_MOCK_DATA=1 MOCK_DATA_SEED=0.03 yarn start```