### PR TITLE
fix fees for bitcoin. fixes #1306

### DIFF
--- a/src/components/FeesField/BitcoinKind.js
+++ b/src/components/FeesField/BitcoinKind.js
@@ -79,10 +79,9 @@ class FeesField extends Component<Props & { fees?: Fees, error?: Error }, State>
       items = items.sort((a, b) => a.blockCount - b.blockCount)
     }
     items.push(customItem)
-    const selectedItem =
-      prevState.selectedItem.feePerByte === feePerByte
-        ? prevState.selectedItem
-        : items.find(f => f.feePerByte === feePerByte) || items[items.length - 1]
+    const selectedItem = prevState.selectedItem.feePerByte.eq(feePerByte)
+      ? prevState.selectedItem
+      : items.find(f => f.feePerByte.eq(feePerByte)) || items[items.length - 1]
     return { items, selectedItem }
   }
 


### PR DESCRIPTION
In Send Modal, default fees would always be Custom. This was due to BigNumber and how we compared the values

### Type

Regression Fix

### Context

#1306 

### Parts of the app affected / Test plan

Send Modal
