### PR TITLE
fixes sent modal for ethereum/litecoin when no balance was set

### DIFF
--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -403,7 +403,10 @@ const EthereumBridge: WalletBridge<Transaction> = {
       ? Promise.resolve()
       : Promise.reject(new NotEnoughBalance()),
 
-  getTotalSpent: (a, t) => Promise.resolve(t.amount.plus(t.gasPrice.times(t.gasLimit))),
+  getTotalSpent: (a, t) =>
+    t.amount.isGreaterThan(0) && t.gasPrice.isGreaterThan(0) && t.gasLimit.isGreaterThan(0)
+      ? Promise.resolve(t.amount.plus(t.gasPrice.times(t.gasLimit)))
+      : Promise.resolve(BigNumber(0)),
 
   getMaxAmount: (a, t) => Promise.resolve(a.balance.minus(t.gasPrice.times(t.gasLimit))),
 

--- a/src/bridge/LibcoreBridge.js
+++ b/src/bridge/LibcoreBridge.js
@@ -197,7 +197,7 @@ const LibcoreBridge: WalletBridge<Transaction> = {
   checkCanBeSpent,
 
   getTotalSpent: (a, t) =>
-    !t.amount
+    t.amount.isZero()
       ? Promise.resolve(BigNumber(0))
       : getFees(a, t)
           .then(totalFees => t.amount.plus(totalFees || 0))

--- a/src/components/FeesField/BitcoinKind.js
+++ b/src/components/FeesField/BitcoinKind.js
@@ -53,7 +53,9 @@ const customItem = {
 
 type State = { isFocused: boolean, items: FeeItem[], selectedItem: FeeItem }
 
-class FeesField extends Component<Props & { fees?: Fees, error?: Error }, State> {
+type OwnProps = Props & { fees?: Fees, error?: Error }
+
+class FeesField extends Component<OwnProps, State> {
   state = {
     items: [customItem],
     selectedItem: customItem,
@@ -85,10 +87,10 @@ class FeesField extends Component<Props & { fees?: Fees, error?: Error }, State>
     return { items, selectedItem }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate({ fees: prevFees }: OwnProps) {
     const { feePerByte, fees, onChange } = this.props
     const { items, isFocused } = this.state
-    if (fees && feePerByte.isZero() && !isFocused) {
+    if (fees && fees !== prevFees && feePerByte.isZero() && !isFocused) {
       // initialize with the median
       const feePerByte = (items.find(item => item.blockCount === defaultBlockCount) || items[0])
         .feePerByte
@@ -140,6 +142,7 @@ class FeesField extends Component<Props & { fees?: Fees, error?: Error }, State>
               {t('app:send.steps.amount.unitPerByte', { unit: satoshi.code })}
             </InputRight>
           }
+          allowZero
         />
       </GenericContainer>
     )

--- a/src/components/base/InputCurrency/index.js
+++ b/src/components/base/InputCurrency/index.js
@@ -84,6 +84,7 @@ type Props = {
   value: BigNumber,
   showAllDigits?: boolean,
   subMagnitude: number,
+  allowZero: boolean,
 }
 
 type State = {
@@ -100,6 +101,7 @@ class InputCurrency extends PureComponent<Props, State> {
     value: BigNumber(0),
     showAllDigits: false,
     subMagnitude: 0,
+    allowZero: false,
   }
 
   state = {
@@ -153,11 +155,11 @@ class InputCurrency extends PureComponent<Props, State> {
   }
 
   syncInput = ({ isFocused }: { isFocused: boolean }) => {
-    const { value, showAllDigits, subMagnitude, unit } = this.props
+    const { value, showAllDigits, subMagnitude, unit, allowZero } = this.props
     this.setState({
       isFocused,
       displayValue:
-        !value || value.isZero()
+        (!value || value.isZero()) && !allowZero
           ? ''
           : format(unit, value, { isFocused, showAllDigits, subMagnitude }),
     })

--- a/src/components/modals/Send/steps/01-step-amount.js
+++ b/src/components/modals/Send/steps/01-step-amount.js
@@ -138,7 +138,7 @@ export class StepAmountFooter extends PureComponent<
         .checkCanBeSpent(account, transaction)
         .then(() => true, () => false)
       if (syncId !== this.syncId) return
-      const canNext = isRecipientValid && canBeSpent
+      const canNext = isRecipientValid && canBeSpent && totalSpent.gt(0)
       this.setState({ totalSpent, canNext, isSyncing: false })
     } catch (err) {
       logger.critical(err)


### PR DESCRIPTION
Fix some issues on the send modal, allow zero to be set in fees, also fixed the trigger on ethereum to continue to next step

### Type

Bug Fix

### Context

Bug/Regression found while using the app. Some of these issues are a side effect of switching to BigNumber

### Parts of the app affected / Test plan

Send Modal