### PR TITLE
Fix storybook

### DIFF
--- a/src/helpers/linking.js
+++ b/src/helpers/linking.js
@@ -1,6 +1,11 @@
 // @flow
-import { shell } from 'electron'
 import { track } from 'analytics/segment'
+
+let shell
+if (!process.env.STORYBOOK_ENV) {
+  const electron = require('electron')
+  shell = electron.shell
+}
 
 export const openURL = (
   url: string,
@@ -8,5 +13,5 @@ export const openURL = (
   extraParams: Object = {},
 ) => {
   track(customEventName, { ...extraParams, url })
-  shell.openExternal(url)
+  shell && shell.openExternal(url)
 }


### PR DESCRIPTION
prevent loading `electron` from storybook