### PR TITLE
Fix a JS bug when you have no txs but have balance

### DIFF
--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -246,7 +246,9 @@ const EthereumBridge: WalletBridge<Transaction> = {
         }
         for (let i = 0; i < 50; i++) {
           const api = apiForCurrency(account.currency)
-          const { block } = txs[txs.length - 1]
+          const last = txs[txs.length - 1]
+          if (!last) break
+          const { block } = last
           if (!block) break
           const next = await api.getTransactions(account.freshAddress, block.hash)
           if (next.txs.length === 0) break

--- a/src/components/AccountPage/AccountHeaderActions.js
+++ b/src/components/AccountPage/AccountHeaderActions.js
@@ -7,6 +7,7 @@ import { translate } from 'react-i18next'
 import styled from 'styled-components'
 import type { Account } from '@ledgerhq/live-common/lib/types'
 import Tooltip from 'components/base/Tooltip'
+import isAccountEmpty from 'helpers/isAccountEmpty'
 
 import { MODAL_SEND, MODAL_RECEIVE, MODAL_SETTINGS_ACCOUNT } from 'config/constants'
 
@@ -61,7 +62,7 @@ class AccountHeaderActions extends PureComponent<Props> {
     const { account, openModal, t } = this.props
     return (
       <Box horizontal alignItems="center" justifyContent="flex-end" flow={2}>
-        {account.operations.length > 0 || !account.balance.isZero() ? (
+        {!isAccountEmpty(account) ? (
           <Fragment>
             <Button small primary onClick={() => openModal(MODAL_SEND, { account })}>
               <Box horizontal flow={1} alignItems="center">

--- a/src/components/AccountPage/index.js
+++ b/src/components/AccountPage/index.js
@@ -8,6 +8,7 @@ import { Redirect } from 'react-router'
 import type { Currency, Account } from '@ledgerhq/live-common/lib/types'
 import type { T } from 'types/common'
 import { accountSelector } from 'reducers/accounts'
+import isAccountEmpty from 'helpers/isAccountEmpty'
 import {
   counterValueCurrencySelector,
   localeSelector,
@@ -82,7 +83,7 @@ class AccountPage extends PureComponent<Props> {
           <AccountHeaderActions account={account} />
         </Box>
 
-        {account.operations.length > 0 || !account.balance.isZero() ? (
+        {!isAccountEmpty(account) ? (
           <Fragment>
             <Box mb={7}>
               <BalanceSummary

--- a/src/components/modals/AddAccounts/steps/03-step-import.js
+++ b/src/components/modals/AddAccounts/steps/03-step-import.js
@@ -10,6 +10,7 @@ import uniq from 'lodash/uniq'
 import { urls } from 'config/urls'
 import ExternalLinkButton from 'components/base/ExternalLinkButton'
 import RetryButton from 'components/base/RetryButton'
+import isAccountEmpty from 'helpers/isAccountEmpty'
 
 import { getBridgeForCurrency } from 'bridge'
 
@@ -132,7 +133,7 @@ class StepImport extends PureComponent<StepProps> {
           const { scannedAccounts, checkedAccountsIds, existingAccounts } = this.props
           const hasAlreadyBeenScanned = !!scannedAccounts.find(a => account.id === a.id)
           const hasAlreadyBeenImported = !!existingAccounts.find(a => account.id === a.id)
-          const isNewAccount = account.operations.length === 0
+          const isNewAccount = isAccountEmpty(account)
           if (!hasAlreadyBeenScanned) {
             setScannedAccounts({
               scannedAccounts: [...scannedAccounts, this.translateName(account)],
@@ -229,7 +230,7 @@ class StepImport extends PureComponent<StepProps> {
     let alreadyEmptyAccount
     scannedAccounts.forEach(acc => {
       const existingAccount = existingAccounts.find(a => a.id === acc.id)
-      const empty = acc.operations.length === 0
+      const empty = isAccountEmpty(acc)
       if (existingAccount) {
         importedAccounts.push(existingAccount)
         if (empty) {
@@ -343,12 +344,12 @@ export const StepImportFooter = ({
 }: StepProps) => {
   const willCreateAccount = checkedAccountsIds.some(id => {
     const account = scannedAccounts.find(a => a.id === id)
-    return account && account.operations.length === 0
+    return account && isAccountEmpty(account)
   })
 
   const willAddAccounts = checkedAccountsIds.some(id => {
     const account = scannedAccounts.find(a => a.id === id)
-    return account && account.operations.length > 0
+    return account && !isAccountEmpty(account)
   })
 
   const count = checkedAccountsIds.length

--- a/src/helpers/isAccountEmpty.js
+++ b/src/helpers/isAccountEmpty.js
@@ -1,0 +1,10 @@
+// @flow
+import type { Account } from '@ledgerhq/live-common/lib/types'
+
+// TODO move this back in live-common
+
+// An account is empty if there is no operations AND balance is zero.
+// balance can be non-zero in edgecases, for instance:
+// - Ethereum contract only funds (api limitations)
+// - Ripple node that don't show all ledgers and if you have very old txs
+export default (a: Account): boolean => a.operations.length === 0 && a.balance.isZero()


### PR DESCRIPTION
+ Fixes #1362 
+ fix visibility of Ethereum wallets that only receive funds from contract

we have to do a patch release this morning

### Type

bug

### Context

#1362

### Parts of the app affected / Test plan

ETH scanning if one of your account have contract-only funds, scan will crash