### PR TITLE
Generalize app dependency error messages.

### DIFF
--- a/static/i18n/en/errors.json
+++ b/static/i18n/en/errors.json
@@ -72,8 +72,8 @@
     "description": "Check your device to see which apps are already installed."
   },
   "ManagerAppRelyOnBTC": {
-    "title": "Bitcoin app required",
-    "description": "Install the latest version of the Bitcoin app before installing this app."
+    "title": "Bitcoin or Ethereum app required",
+    "description": "Either install the latest Ethereum app (RSK/WAN/kUSD/POA), or the latest Bitcoin app."
   },
   "ManagerDeviceLocked": {
     "title": "Please unlock your device",
@@ -84,8 +84,8 @@
     "description": "Uninstall some apps to increase available storage and try again."
   },
   "ManagerUninstallBTCDep": {
-    "title": "Sorry, Bitcoin is required",
-    "description": "First uninstall apps that depend on Bitcoin."
+    "title": "Sorry, this app is required",
+    "description": "Uninstall the Bitcoin or Ethereum app last."
   },
   "NetworkDown": {
     "title": "Oops, internet seems down",


### PR DESCRIPTION
App dependencies are not exclusive to the BTC app anymore, so we need to generalize the error messages. 

E.g., previously, you would see an error message that you need the Bitcoin app, when trying to install RSK that requires the ETH app.