### PR TITLE
Bump ledger-core bindings to 2.0.0-rc.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ledgerhq/hw-app-xrp": "^4.13.0",
     "@ledgerhq/hw-transport": "^4.13.0",
     "@ledgerhq/hw-transport-node-hid": "4.22.0",
-    "@ledgerhq/ledger-core": "2.0.0-rc.5",
+    "@ledgerhq/ledger-core": "2.0.0-rc.6",
     "@ledgerhq/live-common": "3.0.0",
     "animated": "^0.2.2",
     "async": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,9 +1529,9 @@
   dependencies:
     events "^2.0.0"
 
-"@ledgerhq/ledger-core@2.0.0-rc.5":
-  version "2.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.5.tgz#ec42f6c3cc265fc5ca82e01d27df38357642d3ed"
+"@ledgerhq/ledger-core@2.0.0-rc.6":
+  version "2.0.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.6.tgz#a08c84bd91c680cd731e1030ce081a9b568a2c47"
   dependencies:
     "@ledgerhq/hw-app-btc" "^4.7.3"
     "@ledgerhq/hw-transport-node-hid" "^4.7.6"


### PR DESCRIPTION
- Bug Fixes:
  - Fix Pivx failing synchronization due to zero-knowledge protocol (closes #1089)
  - Fix Digibyte (and others) hanging transactions due to accounts with hundreds or thousands transactions, this fix affect all other cryptos encountering same issue ("Oops ! Time out error"),
  - Remove ssl (for release version) and krb5 dependencies,
- Features:
  - Optimistic update: once a transaction is broadcasted from libcore side, it is automatically submitted to local (sqlite) database.