### PR TITLE
Update CircleCI cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v7-yarn-packages-{{ checksum "yarn.lock" }}
+            - v8-yarn-packages-{{ checksum "yarn.lock" }}
       - run: yarn install
       - save_cache:
-          key: v7-yarn-packages-{{ checksum "yarn.lock" }}
+          key: v8-yarn-packages-{{ checksum "yarn.lock" }}
           paths:
             - node_modules
       - run: yarn lint


### PR DESCRIPTION
I didn't find better alternative than updating the Circle cache key manually.
We can't put latest flow-typed commit hash inside checksum because it has to be a file.

A workaround would be to store the latest flow-typed commit hash inside a file that we commit. Maybe we should have a dedicated `hashs/` directory. Dunno dunno.