### PR TITLE
Avoid stack overflow when calling execute method of NJSExecutionContext

### DIFF
--- a/src/helpers/init-libcore.js
+++ b/src/helpers/init-libcore.js
@@ -24,7 +24,8 @@ const stringToBytesArray = str => Array.from(Buffer.from(str))
 const NJSExecutionContextImpl = {
   execute: runnable => {
     try {
-      runnable.run()
+      const runFunction = () => runnable.run()
+      setImmediate(runFunction)
     } catch (e) {
       logger.log(e)
     }


### PR DESCRIPTION
This will avoid an 'Internal Process Error (null)' caused by a stack overflow (Maximum call stack size exceeded on JS side) due to recursive calls to execute method of NJSExecutionContext

### Type

Bug Fix

### Context

Many users are facing unexplained libcore errors of type 'Internal Process Error (null)' when computing fees, this occurs when users try to send an important amount which requires picking a lot of UTXOs (more than 150).

### Parts of the app affected / Test plan

All runnables from libcore side are now called through a 'setImmediate' method
