### PR TITLE
Bump live-common to 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@ledgerhq/hw-transport": "^4.13.0",
     "@ledgerhq/hw-transport-node-hid": "4.22.0",
     "@ledgerhq/ledger-core": "2.0.0-rc.6",
-    "@ledgerhq/live-common": "3.0.0",
+    "@ledgerhq/live-common": "3.0.2",
     "animated": "^0.2.2",
     "async": "^2.6.1",
     "axios": "^0.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1542,9 +1542,9 @@
     npm "^5.7.1"
     prebuild-install "^2.2.2"
 
-"@ledgerhq/live-common@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-3.0.0.tgz#abbd88e351c7d0ffffabf7e8502f5b2fbecdc150"
+"@ledgerhq/live-common@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-3.0.2.tgz#1ee5fcc6044c5a049c067978d81892f79789863c"
   dependencies:
     axios "^0.18.0"
     bignumber.js "^7.2.1"


### PR DESCRIPTION
Bump live-common to 3.0.2 to get the following fixes:

- ledgerHQ/ledger-live-common#63 add segwit for digibyte
- ledgerHQ/ledger-live-common#64 Fix over-truncating amounts 0.5 or less away from the next power of 10

### Type

Bug Fixes
