### PR TITLE
Remove timeouts on coreSyncAccount calls, related issue #1446

### DIFF
--- a/src/helpers/libcore.js
+++ b/src/helpers/libcore.js
@@ -271,7 +271,7 @@ async function scanNextAccount(props: {
 
   const shouldSyncAccount = true // TODO: let's sync everytime. maybe in the future we can optimize.
   if (shouldSyncAccount) {
-    await timeoutTagged('coreSyncAccount', 30000, coreSyncAccount(core, njsAccount))
+    await coreSyncAccount(core, njsAccount)
   }
 
   if (isUnsubscribed()) return []
@@ -549,7 +549,7 @@ export async function syncAccount({
     )
   }
 
-  const unsub = await timeoutTagged('coreSyncAccount', 30000, coreSyncAccount(core, njsAccount))
+  const unsub = await coreSyncAccount(core, njsAccount)
   unsub()
 
   const query = njsAccount.queryOperations()


### PR DESCRIPTION
Removing timeouts on coreSyncAccount calls, for more details, check the issue #1446 and comments on issue #1439 .
We were reaching limits of these timeouts when having a slow connection but more often it was reached when users were having a lot of transactions (mainly from mining activities)

### Type

Bug Fix

### Context

Github issues #1446 and #1439 (comments)

### Parts of the app affected / Test plan

Synchronization of bitcoin-like accounts.
