### PR TITLE
Preparsed value for RecipientAddress to remove spaces

### DIFF
--- a/src/components/RecipientAddress/index.js
+++ b/src/components/RecipientAddress/index.js
@@ -99,9 +99,10 @@ class RecipientAddress extends PureComponent<Props, State> {
       </Right>
     ) : null
 
+    const preOnChange = text => onChange((text && text.replace(/\s/g, '')) || '')
     return (
       <Box relative justifyContent="center">
-        <Input {...rest} value={value} onChange={onChange} renderRight={renderRight} />
+        <Input {...rest} value={value} onChange={preOnChange} renderRight={renderRight} />
       </Box>
     )
   }


### PR DESCRIPTION
Addresses https://github.com/LedgerHQ/ledger-live-desktop/issues/1445 by wrapping the `onChange` which is bridge dependant in a preOnChange function inside the component itself. Avoided doing it inline in case we wanted to do some other sanitization of the value or logging or whatever.

![trim](https://user-images.githubusercontent.com/4631227/44619085-38ae6180-a881-11e8-9be3-0ee4480175bd.gif)
