### PR TITLE
Cancel empty onChange events for InputCurrency components

### DIFF
--- a/src/components/base/InputCurrency/index.js
+++ b/src/components/base/InputCurrency/index.js
@@ -172,7 +172,7 @@ class InputCurrency extends PureComponent<Props, State> {
   renderListUnits = () => {
     const { units, onChangeUnit, unit } = this.props
     const { isFocused } = this.state
-
+    const avoidEmptyValue = value => value && onChangeUnit(value)
     if (units.length <= 1) {
       return null
     }
@@ -180,7 +180,7 @@ class InputCurrency extends PureComponent<Props, State> {
     return (
       <Currencies onClick={stopPropagation}>
         <Select
-          onChange={onChangeUnit}
+          onChange={avoidEmptyValue}
           options={units}
           value={unit}
           getOptionValue={unitGetOptionValue}


### PR DESCRIPTION
Solves https://github.com/LedgerHQ/ledger-live-desktop/issues/1457
Simply added a wrapper handler again to the onChange event for the `InputCurrency`, I looked into doing it directly at the `Select` component but it looks like you guys are already doing some other logic there and didn't want to interfere. I don't _think_ this breaks anything, the component is only used ont the currency specific `FeesField` and `RequestAmount`

I made a gif but.. since it doesn't crash it was silly.
