### PR TITLE
Bump electron to 1.8.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "chance": "^1.0.13",
     "concurrently": "3.5.1",
     "dotenv": "^5.0.1",
-    "electron": "1.8.7",
+    "electron": "1.8.8",
     "electron-builder": "20.14.7",
     "electron-devtools-installer": "^2.2.3",
     "electron-rebuild": "^1.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6105,9 +6105,9 @@ electron-webpack@^2.1.0:
     webpack-merge "^4.1.2"
     yargs "^11.1.0"
 
-electron@1.8.7:
-  version "1.8.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.7.tgz#373c1dc4589d7ab4acd49aff8db4a1c0a6c3bcc1"
+electron@1.8.8:
+  version "1.8.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.8.8.tgz#a90cddb075291f49576993e6f5c8bb4439301cae"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"


### PR DESCRIPTION
Following [WebPreferences electron fix](https://electronjs.org/blog/web-preferences-fix), let's bump electron version to 1.8.8. nb: it was not affecting the app, but it removes the github annoying header :)