### PR TITLE
App dependency error message workaround

### DIFF
--- a/static/i18n/en/errors.json
+++ b/static/i18n/en/errors.json
@@ -72,8 +72,8 @@
     "description": "Check your device to see which apps are already installed."
   },
   "ManagerAppRelyOnBTC": {
-    "title": "Bitcoin or Ethereum app required",
-    "description": "Either install the latest Ethereum app (for ETC/UBIQ/EXP/RSK/WAN/kUSD/POA), or the latest Bitcoin app."
+    "title": "Bitcoin and Ethereum apps required",
+    "description": "Install the latest Bitcoin and Ethereum apps first."
   },
   "ManagerDeviceLocked": {
     "title": "Please unlock your device",


### PR DESCRIPTION
More ETH-dependent apps are coming, so need to remove the list of ETH-dep apps. For simplicity, users are asked to install both BTC and ETH.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

UI _polish_ (more workaround)

### Context

When installing an app that requires BTC/ETH app, users will get an error message that asks them to install the BTC or the ETH app, depending on the app they install. This was no longer feasible since the app list became too long. It's less confusing to just ask to install both instead.

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan
Manager