### PR TITLE
Bump latest live-common

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@ledgerhq/hw-transport": "^4.13.0",
     "@ledgerhq/hw-transport-node-hid": "4.22.0",
     "@ledgerhq/ledger-core": "2.0.0-rc.6",
-    "@ledgerhq/live-common": "3.2.3",
+    "@ledgerhq/live-common": "^3.3.0",
     "animated": "^0.2.2",
     "async": "^2.6.1",
     "axios": "^0.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,9 +1549,9 @@
     npm "^5.7.1"
     prebuild-install "^2.2.2"
 
-"@ledgerhq/live-common@3.2.3":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-3.2.3.tgz#24853f89548f68dc55bde956eb8e2e0d580ee340"
+"@ledgerhq/live-common@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-3.3.0.tgz#e4e798f5bfee8e788094fab8dc11fe957a750544"
   dependencies:
     axios "^0.18.0"
     bignumber.js "^7.2.1"


### PR DESCRIPTION
includes zencash rebranding

<img width="493" alt="capture d ecran 2018-08-31 a 14 51 36" src="https://user-images.githubusercontent.com/211411/44913364-756cd380-ad2d-11e8-8f8f-6dc9dd068a86.png">