### PR TITLE
Prepare for patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@ledgerhq/hw-transport": "^4.13.0",
     "@ledgerhq/hw-transport-node-hid": "4.22.0",
     "@ledgerhq/ledger-core": "2.0.0-rc.6",
-    "@ledgerhq/live-common": "^3.3.0",
+    "@ledgerhq/live-common": "^3.4.0",
     "animated": "^0.2.2",
     "async": "^2.6.1",
     "axios": "^0.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,9 +1549,9 @@
     npm "^5.7.1"
     prebuild-install "^2.2.2"
 
-"@ledgerhq/live-common@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-3.3.0.tgz#e4e798f5bfee8e788094fab8dc11fe957a750544"
+"@ledgerhq/live-common@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-3.4.0.tgz#49a9f8865d2e3ea898cfba15d69bdaf32c949f80"
   dependencies:
     axios "^0.18.0"
     bignumber.js "^7.2.1"


### PR DESCRIPTION
- Rollback changes concerning DGB to still allow to use the previous Digibyte app (until we release a wider fix for DGB in incoming release)