### PR TITLE
add migrationNonce mecanism in the walletName generation

### DIFF
--- a/src/helpers/libcore.js
+++ b/src/helpers/libcore.js
@@ -29,6 +29,15 @@ const SPLITTED_CURRENCIES = {
   },
 }
 
+// each time there is a breaking change that needs use to clear cache on both libcore and js side,
+// we should bump a nonce in this map
+// tech notes:
+// - this is used to generate walletName for libcore to completely re-sync to a new wallet.
+// - by changing walletName we also make the JS db refresh because we handle the accountId changes (walletName is in accountId).
+const migrationNonceByCurrency = {
+  digibyte: 1,
+}
+
 export function isValidAddress(core: *, currency: *, address: string): boolean {
   const addr = new core.NJSAddress(address, currency)
   return addr.isValid(address, currency)
@@ -319,14 +328,16 @@ const createWalletConfig = (core, configMap = {}) => {
 
 async function getOrCreateWallet(
   core: *,
-  WALLET_IDENTIFIER: string,
+  walletName: string,
   currencyId: string,
   isSegwit: boolean,
   isUnsplit: boolean,
 ): NJSWallet {
+  const migrationNonce = migrationNonceByCurrency[currencyId]
+  const walletId = walletName + (migrationNonce ? `_${migrationNonce}` : '')
   const pool = core.getPoolInstance()
   try {
-    const wallet = await timeoutTagged('getWallet', 5000, pool.getWallet(WALLET_IDENTIFIER))
+    const wallet = await timeoutTagged('getWallet', 5000, pool.getWallet(walletId))
     return wallet
   } catch (err) {
     const currency = await timeoutTagged('getCurrency', 5000, pool.getCurrency(currencyId))
@@ -346,7 +357,7 @@ async function getOrCreateWallet(
     const wallet = await timeoutTagged(
       'createWallet',
       10000,
-      core.getPoolInstance().createWallet(WALLET_IDENTIFIER, currency, njsWalletConfig),
+      core.getPoolInstance().createWallet(walletId, currency, njsWalletConfig),
     )
     return wallet
   }
@@ -513,23 +524,13 @@ export async function syncAccount({
   const decodedAccountId = accountIdHelper.decode(accountId)
   const isSegwit = isSegwitPath(freshAddressPath)
   const isUnsplit = isUnsplitPath(freshAddressPath, SPLITTED_CURRENCIES[currencyId])
-  let njsWallet
-  try {
-    njsWallet = await timeoutTagged(
-      'getWallet',
-      10000,
-      core.getPoolInstance().getWallet(decodedAccountId.walletName),
-    )
-  } catch (e) {
-    logger.warn(`Have to reimport the account... (${e})`)
-    njsWallet = await getOrCreateWallet(
-      core,
-      decodedAccountId.walletName,
-      currencyId,
-      isSegwit,
-      isUnsplit,
-    )
-  }
+  const njsWallet = await getOrCreateWallet(
+    core,
+    decodedAccountId.walletName,
+    currencyId,
+    isSegwit,
+    isUnsplit,
+  )
 
   let njsAccount
   try {

--- a/src/helpers/libcore.js
+++ b/src/helpers/libcore.js
@@ -164,6 +164,7 @@ async function scanAccountsOnDeviceBySegwit({
   const accounts = await scanNextAccount({
     core,
     wallet,
+    walletName,
     devicePath,
     currencyId,
     accountsCount,
@@ -241,6 +242,7 @@ const coreSyncAccount = (core, account) =>
 async function scanNextAccount(props: {
   // $FlowFixMe
   wallet: NJSWallet,
+  walletName: string,
   core: *,
   devicePath: string,
   currencyId: string,
@@ -256,6 +258,7 @@ async function scanNextAccount(props: {
   const {
     core,
     wallet,
+    walletName,
     devicePath,
     currencyId,
     accountsCount,
@@ -294,6 +297,7 @@ async function scanNextAccount(props: {
     isUnsplit,
     accountIndex,
     wallet,
+    walletName,
     currencyId,
     core,
     ops,
@@ -368,6 +372,7 @@ async function buildAccountRaw({
   isSegwit,
   isUnsplit,
   wallet,
+  walletName,
   currencyId,
   core,
   accountIndex,
@@ -377,6 +382,7 @@ async function buildAccountRaw({
   isSegwit: boolean,
   isUnsplit: boolean,
   wallet: NJSWallet,
+  walletName: string,
   currencyId: string,
   accountIndex: number,
   core: *,
@@ -441,7 +447,7 @@ async function buildAccountRaw({
       type: 'libcore',
       version: '1',
       xpub,
-      walletName: wallet.getName(),
+      walletName,
     }),
     xpub,
     path: walletPath,
@@ -522,15 +528,10 @@ export async function syncAccount({
   index: number,
 }) {
   const decodedAccountId = accountIdHelper.decode(accountId)
+  const { walletName } = decodedAccountId
   const isSegwit = isSegwitPath(freshAddressPath)
   const isUnsplit = isUnsplitPath(freshAddressPath, SPLITTED_CURRENCIES[currencyId])
-  const njsWallet = await getOrCreateWallet(
-    core,
-    decodedAccountId.walletName,
-    currencyId,
-    isSegwit,
-    isUnsplit,
-  )
+  const njsWallet = await getOrCreateWallet(core, walletName, currencyId, isSegwit, isUnsplit)
 
   let njsAccount
   try {
@@ -563,6 +564,7 @@ export async function syncAccount({
     isUnsplit,
     accountIndex: index,
     wallet: njsWallet,
+    walletName,
     currencyId,
     core,
     ops,


### PR DESCRIPTION
- this needs a new libcore release with the DGB fixes
- we need to actually test a repro of the bug in previous app version and that this actually will fix it and properly clear the cache (without user to do it)