### PR TITLE
Drastically increment sync timeouts to address long sync issues

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -45,7 +45,7 @@ export const SYNC_ALL_INTERVAL = 120 * 1000
 export const SYNC_BOOT_DELAY = 2 * 1000
 export const SYNC_PENDING_INTERVAL = 10 * 1000
 export const SYNC_MAX_CONCURRENT = intFromEnv('LEDGER_SYNC_MAX_CONCURRENT', 1)
-export const SYNC_TIMEOUT = intFromEnv('SYNC_TIMEOUT', 60 * 1000)
+export const SYNC_TIMEOUT = intFromEnv('SYNC_TIMEOUT', 5 * 60 * 1000)
 
 // Endpoints...
 

--- a/src/helpers/libcore.js
+++ b/src/helpers/libcore.js
@@ -555,7 +555,7 @@ export async function syncAccount({
   unsub()
 
   const query = njsAccount.queryOperations()
-  const ops = await timeoutTagged('ops', 30000, query.complete().execute())
+  const ops = await timeoutTagged('ops', 5 * 60 * 1000, query.complete().execute())
   const njsBalance = await timeoutTagged('getBalance', 10000, njsAccount.getBalance())
 
   const syncedRawAccount = await buildAccountRaw({


### PR DESCRIPTION
Those values had been tested against user xpub that was reported failing to sync (reproduced), and this fixes the problem.

More a quick win than an optimal solution.