### PR TITLE
Disable Ripple & ZenCash install (now XRP and Horizen)

### DIFF
--- a/src/components/ManagerPage/AppsList.js
+++ b/src/components/ManagerPage/AppsList.js
@@ -71,6 +71,9 @@ type State = {
   mode: Mode,
 }
 
+const oldAppsInstallDisabled = ['ZenCash', 'Ripple']
+const canHandleInstall = c => !oldAppsInstallDisabled.includes(c.name)
+
 const LoadingApp = () => (
   <FakeManagerAppContainer noShadow align="center" justify="center" style={{ height: 90 }}>
     <Spinner size={16} color="rgba(0, 0, 0, 0.3)" />
@@ -285,7 +288,7 @@ class AppsList extends PureComponent<Props, State> {
                   name={c.name}
                   version={`Version ${c.version}`}
                   icon={ICONS_FALLBACK[c.icon] || c.icon}
-                  onInstall={this.handleInstallApp(c)}
+                  onInstall={canHandleInstall(c) ? this.handleInstallApp(c) : null}
                   onUninstall={this.handleUninstallApp(c)}
                 />
               ))}

--- a/src/components/ManagerPage/ManagerApp.js
+++ b/src/components/ManagerPage/ManagerApp.js
@@ -49,7 +49,7 @@ type Props = {
   name: string,
   version: string,
   icon: string,
-  onInstall: Function,
+  onInstall?: Function,
   onUninstall: Function,
 }
 
@@ -64,17 +64,19 @@ function ManagerApp({ name, version, icon, onInstall, onUninstall, t }: Props) {
           {version}
         </Text>
       </Box>
-      <Button
-        outline
-        onClick={onInstall}
-        event={'Manager Install Click'}
-        eventProperties={{
-          appName: name,
-          appVersion: version,
-        }}
-      >
-        {t('app:manager.apps.install')}
-      </Button>
+      {onInstall ? (
+        <Button
+          outline
+          onClick={onInstall}
+          event={'Manager Install Click'}
+          eventProperties={{
+            appName: name,
+            appVersion: version,
+          }}
+        >
+          {t('app:manager.apps.install')}
+        </Button>
+      ) : null}
       <Button
         outline
         onClick={onUninstall}


### PR DESCRIPTION
Ripple & ZenCash happen to still exist in Manager because we need a way for devices having the old app to be able to uninstall it. they need to migrate to XRP and Horizen now so we'll prevent the feature to install them again.