### PR TITLE
 Add the metadata to build the snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ yarn start
 
 ```bash
 # Build & package the whole app
-# Creates a .dmg for Mac, .exe installer for Windows, or .AppImage for Linux
+# Creates a .dmg for Mac, .exe installer for Windows, or .AppImage and .snap for Linux
 # Output files will be created in dist/ folder
 yarn dist
 ```

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -24,6 +24,9 @@ linux:
     - target: AppImage
       arch:
         - x64
+    - target: snap
+      arch:
+        - x64
 
 win:
   artifactName: ${name}-${version}-${os}-${arch}.${ext}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,6 +28,9 @@ linux:
       arch:
         - x64
 
+snap:
+  plugs: [raw-usb]
+
 win:
   artifactName: ${name}-${version}-${os}-${arch}.${ext}
   icon: build/windows/app.ico


### PR DESCRIPTION
This uses electron-builder to build the ledger-live snap.

### Type

Feature. 

### Context

Fixes #1431.

### Parts of the app affected / Test plan

yarn dist will generate the snap. It just requires snapcraft installed (`sudo apt install snapcraft`)
To install the generated snap: `sudo snap install dist/*.snap --dangerous`
To connect the raw-usb interface: `sudo snap connect ledger-live-desktop:raw-usb`
