### PR TITLE
Add fail-safe for Fees to block the UI until loaded

### DIFF
--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -16,20 +16,20 @@ import { getDerivations } from 'helpers/derivations'
 import getAddressCommand from 'commands/getAddress'
 import signTransactionCommand from 'commands/signTransaction'
 import { getAccountPlaceholderName, getNewAccountPlaceholderName } from 'helpers/accountName'
-import { NotEnoughBalance, ETHAddressNonEIP } from 'config/errors'
+import { NotEnoughBalance, FeeNotLoaded, ETHAddressNonEIP } from 'config/errors'
 import type { EditProps, WalletBridge } from './types'
 
 type Transaction = {
   recipient: string,
   amount: BigNumber,
-  gasPrice: BigNumber,
+  gasPrice: ?BigNumber,
   gasLimit: BigNumber,
 }
 
 const serializeTransaction = t => ({
   recipient: t.recipient,
   amount: `0x${BigNumber(t.amount).toString(16)}`,
-  gasPrice: `0x${BigNumber(t.gasPrice).toString(16)}`,
+  gasPrice: !t.gasPrice ? '0x00' : `0x${BigNumber(t.gasPrice).toString(16)}`,
   gasLimit: `0x${BigNumber(t.gasLimit).toString(16)}`,
 })
 
@@ -140,6 +140,8 @@ const signAndBroadcast = async ({
   onSigned,
   onOperationBroadcasted,
 }) => {
+  const { gasPrice, amount, gasLimit } = t
+  if (!gasPrice) throw new FeeNotLoaded()
   const api = apiForCurrency(a.currency)
 
   const nonce = await api.getAccountNonce(a.freshAddress)
@@ -162,8 +164,8 @@ const signAndBroadcast = async ({
       id: `${a.id}-${hash}-OUT`,
       hash,
       type: 'OUT',
-      value: t.amount,
-      fee: t.gasPrice.times(t.gasLimit),
+      value: amount,
+      fee: gasPrice.times(gasLimit),
       blockHeight: null,
       blockHash: null,
       accountId: a.id,
@@ -402,7 +404,7 @@ const EthereumBridge: WalletBridge<Transaction> = {
   createTransaction: () => ({
     amount: BigNumber(0),
     recipient: '',
-    gasPrice: BigNumber(0),
+    gasPrice: null,
     gasLimit: BigNumber(0x5208),
   }),
 
@@ -425,16 +427,22 @@ const EthereumBridge: WalletBridge<Transaction> = {
   EditAdvancedOptions,
 
   checkValidTransaction: (a, t) =>
-    t.amount.isLessThanOrEqualTo(a.balance)
-      ? Promise.resolve(true)
-      : Promise.reject(new NotEnoughBalance()),
+    !t.gasPrice
+      ? Promise.reject(new FeeNotLoaded())
+      : t.amount.isLessThanOrEqualTo(a.balance)
+        ? Promise.resolve(true)
+        : Promise.reject(new NotEnoughBalance()),
 
   getTotalSpent: (a, t) =>
-    t.amount.isGreaterThan(0) && t.gasPrice.isGreaterThan(0) && t.gasLimit.isGreaterThan(0)
+    t.amount.isGreaterThan(0) &&
+    t.gasPrice &&
+    t.gasPrice.isGreaterThan(0) &&
+    t.gasLimit.isGreaterThan(0)
       ? Promise.resolve(t.amount.plus(t.gasPrice.times(t.gasLimit)))
       : Promise.resolve(BigNumber(0)),
 
-  getMaxAmount: (a, t) => Promise.resolve(a.balance.minus(t.gasPrice.times(t.gasLimit))),
+  getMaxAmount: (a, t) =>
+    Promise.resolve(a.balance.minus((t.gasPrice || BigNumber(0)).times(t.gasLimit))),
 
   signAndBroadcast: (a, t, deviceId) =>
     Observable.create(o => {

--- a/src/bridge/LibcoreBridge.js
+++ b/src/bridge/LibcoreBridge.js
@@ -11,7 +11,7 @@ import libcoreSyncAccount from 'commands/libcoreSyncAccount'
 import libcoreSignAndBroadcast from 'commands/libcoreSignAndBroadcast'
 import libcoreGetFees, { extractGetFeesInputFromAccount } from 'commands/libcoreGetFees'
 import libcoreValidAddress from 'commands/libcoreValidAddress'
-import { NotEnoughBalance } from 'config/errors'
+import { NotEnoughBalance, FeeNotLoaded } from 'config/errors'
 import type { WalletBridge, EditProps } from './types'
 
 const NOT_ENOUGH_FUNDS = 52
@@ -20,15 +20,18 @@ const notImplemented = new Error('LibcoreBridge: not implemented')
 
 type Transaction = {
   amount: BigNumber,
-  feePerByte: BigNumber,
+  feePerByte: ?BigNumber,
   recipient: string,
 }
 
-const serializeTransaction = t => ({
-  recipient: t.recipient,
-  amount: t.amount.toString(),
-  feePerByte: t.feePerByte.toString(),
-})
+const serializeTransaction = t => {
+  const { feePerByte } = t
+  return {
+    recipient: t.recipient,
+    amount: t.amount.toString(),
+    feePerByte: (feePerByte && feePerByte.toString()) || '0',
+  }
+}
 
 const decodeOperation = (encodedAccount, rawOp) =>
   decodeAccount({ ...encodedAccount, operations: [rawOp] }).operations[0]
@@ -75,7 +78,9 @@ const isRecipientValid = (currency, recipient) => {
 const feesLRU = LRU({ max: 100 })
 
 const getFeesKey = (a, t) =>
-  `${a.id}_${a.blockHeight || 0}_${t.amount.toString()}_${t.recipient}_${t.feePerByte.toString()}`
+  `${a.id}_${a.blockHeight || 0}_${t.amount.toString()}_${t.recipient}_${
+    t.feePerByte ? t.feePerByte.toString() : ''
+  }`
 
 const getFees = async (a, transaction) => {
   const isValid = await isRecipientValid(a.currency, transaction.recipient)
@@ -83,6 +88,7 @@ const getFees = async (a, transaction) => {
   const key = getFeesKey(a, transaction)
   let promise = feesLRU.get(key)
   if (promise) return promise
+
   promise = libcoreGetFees
     .send({
       ...extractGetFeesInputFromAccount(a),
@@ -95,17 +101,19 @@ const getFees = async (a, transaction) => {
 }
 
 const checkValidTransaction = (a, t) =>
-  !t.amount
-    ? Promise.resolve(true)
-    : getFees(a, t)
-        .then(() => true)
-        .catch(e => {
-          if (e.code === NOT_ENOUGH_FUNDS) {
-            throw new NotEnoughBalance()
-          }
-          feesLRU.del(getFeesKey(a, t))
-          throw e
-        })
+  !t.feePerByte
+    ? Promise.reject(new FeeNotLoaded())
+    : !t.amount
+      ? Promise.resolve(true)
+      : getFees(a, t)
+          .then(() => true)
+          .catch(e => {
+            if (e.code === NOT_ENOUGH_FUNDS) {
+              throw new NotEnoughBalance()
+            }
+            feesLRU.del(getFeesKey(a, t))
+            throw e
+          })
 
 const LibcoreBridge: WalletBridge<Transaction> = {
   scanAccountsOnDevice(currency, devicePath) {
@@ -169,7 +177,7 @@ const LibcoreBridge: WalletBridge<Transaction> = {
   createTransaction: () => ({
     amount: BigNumber(0),
     recipient: '',
-    feePerByte: BigNumber(0),
+    feePerByte: null,
     isRBF: false,
   }),
 

--- a/src/bridge/RippleJSBridge.js
+++ b/src/bridge/RippleJSBridge.js
@@ -20,7 +20,11 @@ import {
 import FeesRippleKind from 'components/FeesField/RippleKind'
 import AdvancedOptionsRippleKind from 'components/AdvancedOptions/RippleKind'
 import { getAccountPlaceholderName, getNewAccountPlaceholderName } from 'helpers/accountName'
-import { NotEnoughBalance, FeeNotLoaded, NotEnoughBalanceBecauseDestinationNotCreated } from 'config/errors'
+import {
+  NotEnoughBalance,
+  FeeNotLoaded,
+  NotEnoughBalanceBecauseDestinationNotCreated,
+} from 'config/errors'
 import type { WalletBridge, EditProps } from './types'
 
 type Transaction = {

--- a/src/components/FeesField/BitcoinKind.js
+++ b/src/components/FeesField/BitcoinKind.js
@@ -51,6 +51,12 @@ const customItem = {
   blockCount: 0,
   feePerByte: BigNumber(0),
 }
+const notLoadedItem = {
+  label: 'Standard',
+  value: 'standard',
+  blockCount: 0,
+  feePerByte: BigNumber(0),
+}
 
 type State = { isFocused: boolean, items: FeeItem[], selectedItem: FeeItem }
 
@@ -58,13 +64,13 @@ type OwnProps = Props & { fees?: Fees, error?: Error }
 
 class FeesField extends Component<OwnProps, State> {
   state = {
-    items: [customItem],
-    selectedItem: customItem,
+    items: [notLoadedItem],
+    selectedItem: notLoadedItem,
     isFocused: false,
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    const { fees, feePerByte } = nextProps
+    const { fees, feePerByte, error } = nextProps
     let items: FeeItem[] = []
     if (fees) {
       for (const key of Object.keys(fees)) {
@@ -81,10 +87,9 @@ class FeesField extends Component<OwnProps, State> {
       }
       items = items.sort((a, b) => a.blockCount - b.blockCount)
     }
-    items.push(customItem)
-    const selectedItem = !feePerByte
-      ? customItem
-      : prevState.selectedItem.feePerByte.eq(feePerByte)
+    items.push(!feePerByte && !error ? notLoadedItem : customItem)
+    const selectedItem =
+      !feePerByte && prevState.selectedItem.feePerByte.eq(feePerByte)
         ? prevState.selectedItem
         : items.find(f => f.feePerByte.eq(feePerByte)) || items[items.length - 1]
     return { items, selectedItem }

--- a/src/components/FeesField/EthereumKind.js
+++ b/src/components/FeesField/EthereumKind.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react'
 import { BigNumber } from 'bignumber.js'
 import type { Account } from '@ledgerhq/live-common/lib/types'
 
+import { FeeNotLoaded } from 'config/errors'
 import InputCurrency from 'components/base/InputCurrency'
 import type { Fees } from 'api/Fees'
 import WithFeesAPI from '../WithFeesAPI'
@@ -11,7 +12,7 @@ import GenericContainer from './GenericContainer'
 
 type Props = {
   account: Account,
-  gasPrice: BigNumber,
+  gasPrice: ?BigNumber,
   onChange: BigNumber => void,
 }
 
@@ -22,7 +23,7 @@ class FeesField extends Component<Props & { fees?: Fees, error?: Error }, *> {
   componentDidUpdate() {
     const { gasPrice, fees, onChange } = this.props
     const { isFocused } = this.state
-    if (gasPrice.isZero() && fees && fees.gas_price && !isFocused) {
+    if (!gasPrice && fees && fees.gas_price && !isFocused) {
       onChange(BigNumber(fees.gas_price)) // we want to set the default to gas_price
     }
   }
@@ -33,12 +34,14 @@ class FeesField extends Component<Props & { fees?: Fees, error?: Error }, *> {
     const { account, gasPrice, error, onChange } = this.props
     const { units } = account.currency
     return (
-      <GenericContainer error={error}>
+      <GenericContainer>
         <InputCurrency
           defaultUnit={units.length > 1 ? units[1] : units[0]}
           units={units}
           containerProps={{ grow: true }}
           value={gasPrice}
+          loading={!error && !gasPrice}
+          error={!gasPrice && error ? new FeeNotLoaded() : null}
           onChange={onChange}
           onChangeFocus={this.onChangeFocus}
         />

--- a/src/components/FeesField/RippleKind.js
+++ b/src/components/FeesField/RippleKind.js
@@ -4,12 +4,13 @@ import React, { Component } from 'react'
 import type { BigNumber } from 'bignumber.js'
 import type { Account } from '@ledgerhq/live-common/lib/types'
 import { apiForEndpointConfig, parseAPIValue } from 'api/Ripple'
+import { FeeNotLoaded } from 'config/errors'
 import InputCurrency from 'components/base/InputCurrency'
 import GenericContainer from './GenericContainer'
 
 type Props = {
   account: Account,
-  fee: BigNumber,
+  fee: ?BigNumber,
   onChange: BigNumber => void,
 }
 
@@ -36,7 +37,7 @@ class FeesField extends Component<Props, State> {
       const info = await api.getServerInfo()
       if (syncId !== this.syncId) return
       const serverFee = parseAPIValue(info.validatedLedger.baseFeeXRP)
-      if (this.props.fee.isZero()) {
+      if (!this.props.fee) {
         this.props.onChange(serverFee)
       }
     } catch (error) {
@@ -50,11 +51,13 @@ class FeesField extends Component<Props, State> {
     const { error } = this.state
     const { units } = account.currency
     return (
-      <GenericContainer error={error}>
+      <GenericContainer>
         <InputCurrency
           defaultUnit={units[0]}
           units={units}
           containerProps={{ grow: true }}
+          loading={!error && !fee}
+          error={!fee && error ? new FeeNotLoaded() : null}
           value={fee}
           onChange={onChange}
         />

--- a/src/components/base/Input/index.js
+++ b/src/components/base/Input/index.js
@@ -4,9 +4,8 @@ import React, { PureComponent } from 'react'
 import styled from 'styled-components'
 import { fontSize, space } from 'styled-system'
 import noop from 'lodash/noop'
-
 import fontFamily from 'styles/styled/fontFamily'
-
+import Spinner from 'components/base/Spinner'
 import Box from 'components/base/Box'
 import TranslatedError from 'components/TranslatedError'
 
@@ -42,6 +41,19 @@ const ErrorDisplay = styled(Box)`
   font-size: 12px;
   white-space: nowrap;
   color: ${p => p.theme.colors.pearl};
+`
+
+const LoadingDisplay = styled(Box)`
+  position: absolute;
+  left: 0px;
+  top: 0px;
+  bottom: 0px;
+  background: white;
+  pointer-events: none;
+  flex-direction: row;
+  align-items: center;
+  padding: 0 15px;
+  border-radius: 4px;
 `
 
 const WarningDisplay = styled(ErrorDisplay)`
@@ -98,6 +110,7 @@ type Props = {
   renderLeft?: any,
   renderRight?: any,
   containerProps?: Object,
+  loading?: boolean,
   error?: ?Error | boolean,
   warning?: ?Error | boolean,
   small?: boolean,
@@ -182,6 +195,7 @@ class Input extends PureComponent<Props, State> {
       editInPlace,
       small,
       error,
+      loading,
       warning,
       ...props
     } = this.props
@@ -216,6 +230,11 @@ class Input extends PureComponent<Props, State> {
             <WarningDisplay>
               <TranslatedError error={warning} />
             </WarningDisplay>
+          ) : null}
+          {loading && !isFocus ? (
+            <LoadingDisplay>
+              <Spinner size={16} />
+            </LoadingDisplay>
           ) : null}
         </Box>
         {renderRight}

--- a/src/components/base/InputCurrency/index.js
+++ b/src/components/base/InputCurrency/index.js
@@ -81,7 +81,7 @@ type Props = {
   renderRight: any,
   unit: Unit,
   units: Unit[],
-  value: BigNumber,
+  value: ?BigNumber,
   showAllDigits?: boolean,
   subMagnitude: number,
   allowZero: boolean,
@@ -98,7 +98,7 @@ class InputCurrency extends PureComponent<Props, State> {
     onChange: noop,
     renderRight: null,
     units: [],
-    value: BigNumber(0),
+    value: null,
     showAllDigits: false,
     subMagnitude: 0,
     allowZero: false,
@@ -123,13 +123,14 @@ class InputCurrency extends PureComponent<Props, State> {
     if (needsToBeReformatted) {
       const { isFocused } = this.state
       this.setState({
-        displayValue: nextProps.value.isZero()
-          ? ''
-          : format(nextProps.unit, nextProps.value, {
-              isFocused,
-              showAllDigits: nextProps.showAllDigits,
-              subMagnitude: nextProps.subMagnitude,
-            }),
+        displayValue:
+          !nextProps.value || nextProps.value.isZero()
+            ? ''
+            : format(nextProps.unit, nextProps.value, {
+                isFocused,
+                showAllDigits: nextProps.showAllDigits,
+                subMagnitude: nextProps.subMagnitude,
+              }),
       })
     }
   }
@@ -138,7 +139,7 @@ class InputCurrency extends PureComponent<Props, State> {
     const { onChange, unit, value } = this.props
     const r = sanitizeValueString(unit, v)
     const satoshiValue = BigNumber(r.value)
-    if (!value.isEqualTo(satoshiValue)) {
+    if (!value || !value.isEqualTo(satoshiValue)) {
       onChange(satoshiValue, unit)
     }
     this.setState({ displayValue: r.display })
@@ -159,7 +160,7 @@ class InputCurrency extends PureComponent<Props, State> {
     this.setState({
       isFocused,
       displayValue:
-        (!value || value.isZero()) && !allowZero
+        !value || (value.isZero() && !allowZero)
           ? ''
           : format(unit, value, { isFocused, showAllDigits, subMagnitude }),
     })

--- a/src/components/modals/Send/fields/AmountField.js
+++ b/src/components/modals/Send/fields/AmountField.js
@@ -4,6 +4,9 @@ import Box from 'components/base/Box'
 import Label from 'components/base/Label'
 import RequestAmount from 'components/RequestAmount'
 
+// list of errors that are handled somewhere else on UI, otherwise the field will catch every other errors.
+const blacklistErrorName = ['FeeNotLoaded', 'InvalidAddress']
+
 class AmountField extends Component<*, { validTransactionError: ?Error }> {
   state = {
     validTransactionError: null,
@@ -49,7 +52,11 @@ class AmountField extends Component<*, { validTransactionError: ?Error }> {
         <RequestAmount
           withMax={false}
           account={account}
-          validTransactionError={validTransactionError}
+          validTransactionError={
+            validTransactionError && blacklistErrorName.includes(validTransactionError.name)
+              ? null
+              : validTransactionError
+          }
           onChange={this.onChange}
           value={bridge.getTransactionAmount(account, transaction)}
         />

--- a/src/config/errors.js
+++ b/src/config/errors.js
@@ -42,6 +42,7 @@ export const WebsocketConnectionFailed = createCustomErrorClass('WebsocketConnec
 export const WrongDeviceForAccount = createCustomErrorClass('WrongDeviceForAccount')
 export const ETHAddressNonEIP = createCustomErrorClass('ETHAddressNonEIP')
 export const CantScanQRCode = createCustomErrorClass('CantScanQRCode')
+export const FeeNotLoaded = createCustomErrorClass('FeeNotLoaded')
 
 // db stuff, no need to translate
 export const NoDBPathGiven = createCustomErrorClass('NoDBPathGiven')

--- a/static/i18n/en/errors.json
+++ b/static/i18n/en/errors.json
@@ -172,5 +172,8 @@
   },
   "CantScanQRCode": {
     "title": "Couldn't scan this QR-code: auto-verification not supported by this address"
+  },
+  "FeeNotLoaded": {
+    "title": "Couldn't load default fees. Please carefully set."
   }
 }

--- a/static/i18n/en/errors.json
+++ b/static/i18n/en/errors.json
@@ -174,6 +174,6 @@
     "title": "Couldn't scan this QR-code: auto-verification not supported by this address"
   },
   "FeeNotLoaded": {
-    "title": "Couldn't load default fees. Please carefully set."
+    "title": "Couldn’t load fee rates. Please set manual fees"
   }
 }


### PR DESCRIPTION
In an edge-case scenario, it was possible to accidentally Send transactions without fees. This happen if you are fast enough to input everything and this before our API that fetches the fees respond and if you are not careful enough in what are in the fields.

This is now fixed by adding a fail safe that block the UI until fees load. Since we block the UI, we must provided a good feedback to the user on what's happening at any time. We use a spinner when fees are loaded (you likely won't see it, both because load is fast and also because we have a cache so fees get loaded only once). In case of a server failure, you would see an error as well but it's not blocking the Send feature to work. You can also interrupt the load at any time by clicking the input and typing yourself the fees.

<img width="300" alt="capture d ecran 2018-09-25 a 17 13 45" src="https://user-images.githubusercontent.com/211411/46024624-810ea880-c0e7-11e8-81e6-9d5144d277ec.png"> <img width="300" alt="capture d ecran 2018-09-25 a 17 10 27" src="https://user-images.githubusercontent.com/211411/46024625-810ea880-c0e7-11e8-9c09-69423a1cea3d.png">

^ once again, these 2 screen would be edge case and you likely don't have time to even see them.


(BTW, this Input loading will be useful if we need it somewhere else)


cc @dasilvarosa for a wording check (the error case)

### Type

edge case bug fix

### Context

was discussed internally a few weeks ago. thx @bscholving for brainstorming the UX.

### Parts of the app affected / Test plan

- because the work was done 3 times, one for each implementation (BTC-*, XRP, ETH-*),  we must test it on at least these 3 family of coins
- we need to test things properly by potentially mocking in the code the part that load the fees. (i've developed the feature mainly by modifying api/Fees.js. `promise = Promise.reject(new Error(..))` and `promise = new Promise(()=>{})` for respectively the error and the loading cases.
- transaction obviously should still work on these 3 families with the correct fees i've inputed.
- test that Custom fees inputing still work (in all scenarios)
- test that one of the preference (High/Medium/Low) still properly work