### PR TITLE
Kill libcore when reset

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -15,6 +15,7 @@ import installFinalFirmware from 'commands/installFinalFirmware'
 import installMcu from 'commands/installMcu'
 import installOsuFirmware from 'commands/installOsuFirmware'
 import isDashboardOpen from 'commands/isDashboardOpen'
+import killInternalProcess from 'commands/killInternalProcess'
 import libcoreGetFees from 'commands/libcoreGetFees'
 import libcoreGetVersion from 'commands/libcoreGetVersion'
 import libcoreScanAccounts from 'commands/libcoreScanAccounts'
@@ -47,6 +48,7 @@ const all: Array<Command<any, any>> = [
   installMcu,
   installOsuFirmware,
   isDashboardOpen,
+  killInternalProcess,
   libcoreGetFees,
   libcoreGetVersion,
   libcoreScanAccounts,

--- a/src/commands/killInternalProcess.js
+++ b/src/commands/killInternalProcess.js
@@ -1,0 +1,18 @@
+// @flow
+
+import { createCommand, Command } from 'helpers/ipc'
+import { of } from 'rxjs'
+
+type Input = void
+type Result = boolean
+
+const cmd: Command<Input, Result> = createCommand('killInternalProcess', () => {
+  setTimeout(() => {
+    // we assume commands are run on the internal process
+    // special exit code for better identification
+    process.exit(42)
+  })
+  return of(true)
+})
+
+export default cmd

--- a/src/components/base/Modal/ConfirmModal.js
+++ b/src/components/base/Modal/ConfirmModal.js
@@ -79,6 +79,7 @@ class ConfirmModal extends PureComponent<Props> {
                 primary={!isDanger}
                 danger={isDanger}
                 isLoading={isLoading}
+                disabled={isLoading}
               >
                 {realConfirmText}
               </Button>

--- a/src/helpers/reset.js
+++ b/src/helpers/reset.js
@@ -6,8 +6,10 @@ import resolveUserDataDirectory from 'helpers/resolveUserDataDirectory'
 import { disable as disableDBMiddleware } from 'middlewares/db'
 import db from 'helpers/db'
 import { delay } from 'helpers/promise'
+import killInternalProcess from 'commands/killInternalProcess'
 
-function resetLibcoreDatabase() {
+async function resetLibcoreDatabase() {
+  await killInternalProcess.send().toPromise()
   const dbpath = path.resolve(resolveUserDataDirectory(), 'sqlite/')
   rimraf.sync(dbpath, { glob: false })
 }


### PR DESCRIPTION
Not sure it really fix anything, but users have reported having solved some problems by manually removing their `sqlite` folder, while it's normally done by clear-cache/hard-reset. So let's kill the internal (libcore) process before touching the folder.