### PR TITLE
Stress less the device

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -46,6 +46,8 @@ export const SYNC_BOOT_DELAY = 2 * 1000
 export const SYNC_PENDING_INTERVAL = 10 * 1000
 export const SYNC_MAX_CONCURRENT = intFromEnv('LEDGER_SYNC_MAX_CONCURRENT', 1)
 export const SYNC_TIMEOUT = intFromEnv('SYNC_TIMEOUT', 5 * 60 * 1000)
+export const DELAY_DEVICE_ACCESS = intFromEnv('DELAY_DEVICE_ACCESS', 60)
+export const DELAY_DEVICE_OPEN = intFromEnv('DELAY_DEVICE_OPEN', 20)
 
 // Endpoints...
 


### PR DESCRIPTION
This is an attempt to address #1386 . according to @btchip the internal error experienced by some users might be caused by a too fast exchange with the device / apdu interleaved.

**As no one from our develop team was able to reproduce the problem,** we encourage our community to help us testing this, investigating on the problem and experimenting solutions. Thanks!

---

This PR changes will attempt to fix the problem by locking more time before and after each "atomic" exchange with the device, done by this withDevice function.

To be clear: in current implementation of Ledger Live, all code that exchange with the device is always run in a queue, never in parallel so the only possible thing that can happen is that two "commands" get executed one after the other without any delay.

By "commands" i mean an atomic series of APDUs. for instance signing a transaction is unified into one command (even if it's multiple APDUs). Today we are already protected from access multiple time the device and having "interleaved" APDUs **within the Ledger Live app**. NB the "within the LL app" , because this does not actually protect from another app accessing the device at the same time, we **can't** protect us from that.. So if users use both Ledger Live and another app using the device (examples: MEW / Radar Relay / any ddex / any GUI like monero,decrediton,whatever) , you're going to have issues.


### Type

bugfix attempt

### Context

#1386

### Parts of the app affected / Test plan

all part accessing the device
