### PR TITLE
Issue 1468, wrong cursor on receive modal

### DIFF
--- a/src/components/base/Box/Box.js
+++ b/src/components/base/Box/Box.js
@@ -50,8 +50,7 @@ export default styled.div`
     p.selectable &&
     `
     user-select: text;
-    cursor: text;
-  `};
+    `};
 
   ${p =>
     p.sticky &&


### PR DESCRIPTION
On the receive modal, the full box was affected by that style as opposed to only the input.
I couldn't find any other places where the cursor was wrong but if any of you can point out more of them, we can tie them together in this pr.

![sep-30-2018 18-26-08](https://user-images.githubusercontent.com/4631227/46259842-60c35d00-c4de-11e8-814f-4e4f32f9c586.gif)

### Type

Bug Fix

### Context

https://github.com/LedgerHQ/ledger-live-desktop/issues/1468

