### PR TITLE
Alternative way to install latest yarn on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,10 @@ jobs:
       - run:
           name: Install latest yarn
           command: |
-            curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" ;
-            sudo mkdir -p /opt ;
-            sudo tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ ;
-            sudo ln -sf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn ;
-            sudo ln -sf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg ;
-            rm yarn-v$YARN_VERSION.tar.gz
+            curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - ;
+            echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list ;
+            sudo apt-get update && sudo apt-get install yarn
+            sudo rm /usr/local/bin/yarn # remove docker yarn
       - checkout
       - restore_cache:
           keys:


### PR DESCRIPTION
relatable #1555

Apparently previous way wasn't working [on our CI](https://circleci.com/gh/LedgerHQ/ledger-live-desktop/2959), no idea why it worked [on my fork](https://circleci.com/gh/meriadec/ledger-live-desktop/1447) (same config, same env vars). Is it interesting? No!

Best way would be latest yarn installed on stretch browser docker img, but they have [curious politics](https://github.com/nodejs/docker-node/pull/865) about upgrading it. So IMO, we should definitely build a custom docker image, with our exact libs etc.