### PR TITLE
Correctly handle sequence when UTXO script length is 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     }
   },
   "dependencies": {
-    "@ledgerhq/hw-app-btc": "4.21.0",
-    "@ledgerhq/hw-app-eth": "^4.14.0",
-    "@ledgerhq/hw-app-xrp": "^4.13.0",
-    "@ledgerhq/hw-transport": "^4.13.0",
-    "@ledgerhq/hw-transport-node-hid": "4.22.0",
+    "@ledgerhq/hw-app-btc": "4.24.0",
+    "@ledgerhq/hw-app-eth": "^4.24.0",
+    "@ledgerhq/hw-app-xrp": "^4.24.0",
+    "@ledgerhq/hw-transport": "^4.24.0",
+    "@ledgerhq/hw-transport-node-hid": "4.24.0",
     "@ledgerhq/ledger-core": "2.0.0-rc.8",
     "@ledgerhq/live-common": "3.8.0",
     "animated": "^0.2.2",

--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -23,8 +23,11 @@ require('winston-daily-rotate-file')
 const { format } = winston
 const { combine, json, timestamp } = format
 
+let logIndex = 0
+
 const pinfo = format(info => {
   info.pname = pname
+  info.index = logIndex++
   return info
 })
 
@@ -67,7 +70,12 @@ const queryAllLogs = async (date: Date = new Date()) => {
   const all = internal
     .concat(main)
     .concat(renderer)
-    .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+    .sort((a, b) => {
+      if (a.timestamp !== b.timestamp) {
+        return new Date(b.timestamp) - new Date(a.timestamp)
+      }
+      return b.index - a.index
+    })
   return all
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,12 +1672,12 @@
     camelcase "^5.0.0"
     prettier "^1.13.7"
 
-"@ledgerhq/hw-app-btc@4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-4.21.0.tgz#4f94571bb3d63cd785e31a7e1f77ce597c344516"
-  integrity sha1-T5RXG7PWPNeF4xp+H3fOWXw0RRY=
+"@ledgerhq/hw-app-btc@4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-4.24.0.tgz#8889b2bc9b9583209ed24f832c96ea8d23e1dc74"
+  integrity sha512-OEc8UCcdAWp10PPM9Keoh8imuusmNVe2o/89ujMT5UIWOGCu7duezpsnCY11jGNxf2hyos6lezUMlUAOHBuISQ==
   dependencies:
-    "@ledgerhq/hw-transport" "^4.21.0"
+    "@ledgerhq/hw-transport" "^4.24.0"
     create-hash "^1.1.3"
 
 "@ledgerhq/hw-app-btc@^4.7.3":
@@ -1688,30 +1688,30 @@
     "@ledgerhq/hw-transport" "^4.15.0"
     create-hash "^1.1.3"
 
-"@ledgerhq/hw-app-eth@^4.14.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.21.0.tgz#2d8bfbe5f09b92e8d6951ae685036d9d5aea96ff"
-  integrity sha1-LYv75fCbkujWlRrmhQNtnVrqlv8=
+"@ledgerhq/hw-app-eth@^4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.24.0.tgz#b62514e0d18672d6d35d76dfbeaf93b67d2e5324"
+  integrity sha512-x8qFHN+JUsLgtm4GI3E1OxwL/7LVIaUfGkKs53a2Zr89h5YFp2GZvFcHdwbEypQAWS8cs+4vEqaEYFwQ9bSwlQ==
   dependencies:
-    "@ledgerhq/hw-transport" "^4.21.0"
+    "@ledgerhq/hw-transport" "^4.24.0"
 
-"@ledgerhq/hw-app-xrp@^4.13.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-xrp/-/hw-app-xrp-4.21.0.tgz#259010f10bd7fdcb6eb24eb25aa5144545d1a402"
-  integrity sha1-JZAQ8QvX/ctusk6yWqUURUXRpAI=
+"@ledgerhq/hw-app-xrp@^4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-xrp/-/hw-app-xrp-4.24.0.tgz#cb41975597ac43d6f95dfb6ef52ff3ce5376ab80"
+  integrity sha512-KWxqnf4Ci3pF/2RsavDLNXHwh7iG2xBkUBD5iYgui9WaWCJfTv+F5zBYeeDeULfTSj9+WAtNcPXFHyiKLYPTfw==
   dependencies:
-    "@ledgerhq/hw-transport" "^4.21.0"
+    "@ledgerhq/hw-transport" "^4.24.0"
     bip32-path "0.4.2"
 
-"@ledgerhq/hw-transport-node-hid@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-4.22.0.tgz#1ee00dcccd852cb6fb152cd68c781c9689cf9f24"
-  integrity sha1-HuANzM2FLLb7FSzWjHgclonPnyQ=
+"@ledgerhq/hw-transport-node-hid@4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid/-/hw-transport-node-hid-4.24.0.tgz#8457969d66819e8f7f50d5dd96527ab26cd3787d"
+  integrity sha512-RA3ZlRM+6y/XL/sAFKUpuLIU5tsmEpDBwJEBKC+qdzG508Vl/kBJDMuQyo6pmx/YcKZrtjfKiXXQEXP9Fgk75w==
   dependencies:
-    "@ledgerhq/hw-transport" "^4.21.0"
-    lodash "^4.17.10"
+    "@ledgerhq/hw-transport" "^4.24.0"
+    lodash "^4.17.11"
     node-hid "^0.7.2"
-    usb "^1.3.2"
+    usb "^1.3.3"
 
 "@ledgerhq/hw-transport-node-hid@^4.7.6":
   version "4.16.0"
@@ -1721,19 +1721,19 @@
     "@ledgerhq/hw-transport" "^4.15.0"
     node-hid "^0.7.2"
 
-"@ledgerhq/hw-transport@^4.13.0", "@ledgerhq/hw-transport@^4.21.0":
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.21.0.tgz#50f85cfe115ba3f9d5bf94755c701e927175794f"
-  integrity sha1-UPhc/hFbo/nVv5R1XHAeknF1eU8=
-  dependencies:
-    events "^2.0.0"
-
 "@ledgerhq/hw-transport@^4.15.0":
   version "4.19.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.19.0.tgz#19a804aee1bfc4abac1dc9a2a7a582e79273f991"
   integrity sha1-GagEruG/xKusHcmip6WC55Jz+ZE=
   dependencies:
     events "^2.0.0"
+
+"@ledgerhq/hw-transport@^4.24.0":
+  version "4.24.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.24.0.tgz#8def925d8c2e1f73d15128d9e27ead729870be58"
+  integrity sha512-L34TG1Ss7goRB+5BxtvBwUuu0CmDSIxS33oUqkpEy6rCs31k7XicV48iUGAnRnt8hNY2DvJ9WFyaOroUE9h6wQ==
+  dependencies:
+    events "^3.0.0"
 
 "@ledgerhq/ledger-core@2.0.0-rc.8":
   version "2.0.0-rc.8"
@@ -7370,6 +7370,11 @@ events@^2.0.0:
   resolved "https://registry.yarnpkg.com/events/-/events-2.1.0.tgz#2a9a1e18e6106e0e812aa9ebd4a819b3c29c0ba5"
   integrity sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==
 
+events@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
+  integrity sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==
+
 eventsource@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-0.1.6.tgz#0acede849ed7dd1ccc32c811bb11b944d4f29232"
@@ -10587,6 +10592,11 @@ lodash@^4.0.1, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.0, l
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
   integrity sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==
+
+lodash@^4.17.11:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
+  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -15797,10 +15807,10 @@ url@^0.11.0, url@~0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-usb@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/usb/-/usb-1.3.2.tgz#4563a32323856e26c97dae374b34c66c3d83b5f4"
-  integrity sha512-FhyDAkccL2ycJw3SDEwuMVYwrwo6+wJOqeImwBcZwrK0fIPzg9eWR3vFWDzXLOtMq/06mXyQb122UgbsE/Qhcg==
+usb@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/usb/-/usb-1.3.3.tgz#4e8a4b44ab8833fa1c4fb99778ebae1d2d626970"
+  integrity sha512-WRBxI54yEs2QPj28G6kITI3Wu7VxrtHbqiDvDRUDKdg97lcK1pTP8y9LoDWF22OiCCrEvrdeq0lNcr84QOzjXQ==
   dependencies:
     nan "^2.8.0"
     node-pre-gyp "^0.10.0"


### PR DESCRIPTION
TL;DR, following #1386, we identified & reproduced `0x6f01` error, occurring in the specific case of having a 0 length script in inputs, which resulted in not passing sequence in the transaction. So the fix is located in [ledgerjs/hw-app-btc](https://github.com/LedgerHQ/ledgerjs/commit/2b3ed5a60b4e4b42613d7c773a67fb7d42c22e12).

Thanks @btchip, @pollastri-pierre and @KhalilBellakrid for helping on this one! :rocket: 
