### PR TITLE
Addresses the inconsistency between firmware hashes displayed

### DIFF
--- a/src/components/modals/UpdateFirmware/steps/01-step-install-full-firmware.js
+++ b/src/components/modals/UpdateFirmware/steps/01-step-install-full-firmware.js
@@ -134,7 +134,7 @@ class StepFullFirmwareInstall extends PureComponent<Props, State> {
     }
 
     hash = hash.toUpperCase()
-    return hash.length > 8 ? `[${hash.slice(0, 4)}...${hash.substr(-4)}]` : hash
+    return hash.length > 8 ? `${hash.slice(0, 4)}...${hash.substr(-4)}` : hash
   }
 
   renderBody = () => {

--- a/src/components/modals/UpdateFirmware/steps/01-step-install-full-firmware.js
+++ b/src/components/modals/UpdateFirmware/steps/01-step-install-full-firmware.js
@@ -128,22 +128,18 @@ class StepFullFirmwareInstall extends PureComponent<Props, State> {
     }
   }
 
-  formatHashName = (hash: string): string[] => {
+  formatHashName = (hash: string): string => {
     if (!hash) {
-      return []
+      return ''
     }
 
-    const length = hash.length
-    const half = Math.ceil(length / 2)
-    const start = hash.slice(0, half)
-    const end = hash.slice(half)
-    return [start, end]
+    hash = hash.toUpperCase()
+    return hash.length > 8 ? `[${hash.slice(0, 4)}...${hash.substr(-4)}]` : hash
   }
 
   renderBody = () => {
     const { installing } = this.state
     const { t, firmware } = this.props
-
     return installing ? (
       <Installing />
     ) : (
@@ -155,11 +151,7 @@ class StepFullFirmwareInstall extends PureComponent<Props, State> {
           <Text ff="Open Sans|SemiBold" align="center" color="smoke">
             {t('manager.modal.identifier')}
           </Text>
-          <Address>
-            {firmware &&
-              firmware.hash &&
-              this.formatHashName(firmware.hash.toUpperCase()).join('\n')}
-          </Address>
+          <Address>{firmware && this.formatHashName(firmware.hash)}</Address>
         </Box>
         <Box mt={5}>
           <DeviceConfirm />


### PR DESCRIPTION

Makes the hash displayed more consistent between the device and the app when upgrading the firmware. Might want to change the box's width to accommodate the smaller hash, or increase the font.

### Context

https://github.com/LedgerHQ/ledger-live-desktop/issues/1576

### Parts of the app affected / Test plan

Can be tested by hardcoding a lower version on the[ `getCurrentFirmware` helper](https://github.com/LedgerHQ/ledger-live-desktop/blob/d90543c4a0fdeea70faf4ca378a5360a4ab90605/src/helpers/devices/getCurrentFirmware.js#L14). Although it can't really be installed since the device rejects the installation, I'm assuming due to being the same version

<img width="1136" alt="screenshot 2018-10-12 at 17 36 42" src="https://user-images.githubusercontent.com/4631227/46879132-783b0800-ce45-11e8-963c-d3f6e5ede4cd.png">
