### PR TITLE
Ensure sqlite folder is removed after clear cache / hard reset

### DIFF
--- a/src/components/SettingsPage/CleanButton.js
+++ b/src/components/SettingsPage/CleanButton.js
@@ -8,6 +8,7 @@ import { cleanAccountsCache } from 'actions/accounts'
 import Button from 'components/base/Button'
 import { ConfirmModal } from 'components/base/Modal'
 import { softReset } from 'helpers/reset'
+import ResetFallbackModal from './ResetFallbackModal'
 
 const mapDispatchToProps = {
   cleanAccountsCache,
@@ -20,32 +21,35 @@ type Props = {
 
 type State = {
   opened: boolean,
+  fallbackOpened: boolean,
   isLoading: boolean,
 }
 
 class CleanButton extends PureComponent<Props, State> {
   state = {
     opened: false,
+    fallbackOpened: false,
     isLoading: false,
   }
 
   open = () => this.setState({ opened: true })
 
   close = () => this.setState({ opened: false })
+  closeFallback = () => this.setState({ fallbackOpened: false })
 
   action = async () => {
     if (this.state.isLoading) return
     try {
       this.setState({ isLoading: true })
       await softReset({ cleanAccountsCache: this.props.cleanAccountsCache })
-    } finally {
-      this.setState({ isLoading: false })
+    } catch (err) {
+      this.setState({ isLoading: false, fallbackOpened: true })
     }
   }
 
   render() {
     const { t } = this.props
-    const { opened, isLoading } = this.state
+    const { opened, isLoading, fallbackOpened } = this.state
     return (
       <Fragment>
         <Button small primary onClick={this.open} event="ClearCacheIntent">
@@ -63,6 +67,8 @@ class CleanButton extends PureComponent<Props, State> {
           subTitle={t('common.areYouSure')}
           desc={t('settings.softResetModal.desc')}
         />
+
+        <ResetFallbackModal isOpened={fallbackOpened} onClose={this.closeFallback} />
       </Fragment>
     )
   }

--- a/src/components/SettingsPage/CleanButton.js
+++ b/src/components/SettingsPage/CleanButton.js
@@ -3,6 +3,7 @@
 import React, { Fragment, PureComponent } from 'react'
 import { connect } from 'react-redux'
 import { translate } from 'react-i18next'
+import logger from 'logger'
 import type { T } from 'types/common'
 import { cleanAccountsCache } from 'actions/accounts'
 import Button from 'components/base/Button'
@@ -43,6 +44,7 @@ class CleanButton extends PureComponent<Props, State> {
       this.setState({ isLoading: true })
       await softReset({ cleanAccountsCache: this.props.cleanAccountsCache })
     } catch (err) {
+      logger.error(err)
       this.setState({ isLoading: false, fallbackOpened: true })
     }
   }

--- a/src/components/SettingsPage/ResetButton.js
+++ b/src/components/SettingsPage/ResetButton.js
@@ -4,6 +4,7 @@ import React, { Fragment, PureComponent } from 'react'
 import styled from 'styled-components'
 import { remote } from 'electron'
 import { translate } from 'react-i18next'
+import logger from 'logger'
 import type { T } from 'types/common'
 import { hardReset } from 'helpers/reset'
 import Box from 'components/base/Box'
@@ -39,6 +40,7 @@ class ResetButton extends PureComponent<Props, State> {
       await hardReset()
       remote.getCurrentWindow().webContents.reloadIgnoringCache()
     } catch (err) {
+      logger.error(err)
       this.setState({ pending: false, fallbackOpened: true })
     }
   }

--- a/src/components/SettingsPage/ResetButton.js
+++ b/src/components/SettingsPage/ResetButton.js
@@ -10,6 +10,7 @@ import Box from 'components/base/Box'
 import Button from 'components/base/Button'
 import { ConfirmModal } from 'components/base/Modal'
 import IconTriangleWarning from 'icons/TriangleWarning'
+import ResetFallbackModal from './ResetFallbackModal'
 
 type Props = {
   t: T,
@@ -18,16 +19,19 @@ type Props = {
 type State = {
   opened: boolean,
   pending: boolean,
+  fallbackOpened: boolean,
 }
 
 class ResetButton extends PureComponent<Props, State> {
   state = {
     opened: false,
     pending: false,
+    fallbackOpened: false,
   }
 
   open = () => this.setState({ opened: true })
   close = () => this.setState({ opened: false })
+  closeFallback = () => this.setState({ fallbackOpened: false })
 
   action = async () => {
     this.setState({ pending: true })
@@ -35,13 +39,14 @@ class ResetButton extends PureComponent<Props, State> {
       await hardReset()
       remote.getCurrentWindow().webContents.reloadIgnoringCache()
     } catch (err) {
-      this.setState({ pending: false })
+      this.setState({ pending: false, fallbackOpened: true })
     }
   }
 
   render() {
     const { t } = this.props
-    const { opened, pending } = this.state
+    const { opened, pending, fallbackOpened } = this.state
+
     return (
       <Fragment>
         <Button small danger onClick={this.open} event="HardResetIntent">
@@ -66,6 +71,8 @@ class ResetButton extends PureComponent<Props, State> {
             </IconWrapperCircle>
           )}
         />
+
+        <ResetFallbackModal isOpened={fallbackOpened} onClose={this.closeFallback} />
       </Fragment>
     )
   }

--- a/src/components/SettingsPage/ResetFallbackModal.js
+++ b/src/components/SettingsPage/ResetFallbackModal.js
@@ -1,18 +1,20 @@
 // @flow
 
 import React, { PureComponent } from 'react'
+import { translate } from 'react-i18next'
 
 import { ConfirmModal } from 'components/base/Modal'
 import { openUserDataFolderAndQuit } from 'helpers/reset'
 
 type Props = {
+  t: *,
   isOpened: boolean,
   onClose: () => *,
 }
 
 class ResetFallbackModal extends PureComponent<Props> {
   render() {
-    const { isOpened, onClose } = this.props
+    const { t, isOpened, onClose } = this.props
     return (
       <ConfirmModal
         centered
@@ -24,13 +26,15 @@ class ResetFallbackModal extends PureComponent<Props> {
         title="Couldnt remove app files"
         desc={
           <div>
-            <p>{'Cache folder couldnt be deleted. You will have to delete it manually.'}</p>
+            <p>{t('settings.resetFallbackModal.part1')}</p>
             <p style={{ fontWeight: 'bold' }}>
-              {'Click on "Open folder", then the '}
-              <span style={{ textDecoration: 'underline' }}>{'app will close'}</span>
-              {', and you will have to delete the "sqlite" folder.'}
+              {t('settings.resetFallbackModal.part2')}
+              <span style={{ textDecoration: 'underline' }}>
+                {t('settings.resetFallbackModal.part3')}
+              </span>
+              {t('settings.resetFallbackModal.part4')}
             </p>
-            <p style={{ marginTop: 20 }}>{'After that, you can restart the app.'}</p>
+            <p style={{ marginTop: 20 }}>{t('settings.resetFallbackModal.part5')}</p>
           </div>
         }
       />
@@ -38,4 +42,4 @@ class ResetFallbackModal extends PureComponent<Props> {
   }
 }
 
-export default ResetFallbackModal
+export default translate()(ResetFallbackModal)

--- a/src/components/SettingsPage/ResetFallbackModal.js
+++ b/src/components/SettingsPage/ResetFallbackModal.js
@@ -1,0 +1,41 @@
+// @flow
+
+import React, { PureComponent } from 'react'
+
+import { ConfirmModal } from 'components/base/Modal'
+import { openUserDataFolderAndQuit } from 'helpers/reset'
+
+type Props = {
+  isOpened: boolean,
+  onClose: () => *,
+}
+
+class ResetFallbackModal extends PureComponent<Props> {
+  render() {
+    const { isOpened, onClose } = this.props
+    return (
+      <ConfirmModal
+        centered
+        isOpened={isOpened}
+        onConfirm={openUserDataFolderAndQuit}
+        onClose={onClose}
+        onReject={onClose}
+        confirmText={'Open folder'}
+        title="Couldnt remove app files"
+        desc={
+          <div>
+            <p>{'Cache folder couldnt be deleted. You will have to delete it manually.'}</p>
+            <p style={{ fontWeight: 'bold' }}>
+              {'Click on "Open folder", then the '}
+              <span style={{ textDecoration: 'underline' }}>{'app will close'}</span>
+              {', and you will have to delete the "sqlite" folder.'}
+            </p>
+            <p style={{ marginTop: 20 }}>{'After that, you can restart the app.'}</p>
+          </div>
+        }
+      />
+    )
+  }
+}
+
+export default ResetFallbackModal

--- a/src/components/SettingsPage/ResetFallbackModal.js
+++ b/src/components/SettingsPage/ResetFallbackModal.js
@@ -23,15 +23,13 @@ class ResetFallbackModal extends PureComponent<Props> {
         onClose={onClose}
         onReject={onClose}
         confirmText={'Open folder'}
-        title="Couldnt remove app files"
+        title={t('settings.resetFallbackModal.title')}
         desc={
           <div>
             <p>{t('settings.resetFallbackModal.part1')}</p>
             <p style={{ fontWeight: 'bold' }}>
               {t('settings.resetFallbackModal.part2')}
-              <span style={{ textDecoration: 'underline' }}>
-                {t('settings.resetFallbackModal.part3')}
-              </span>
+              {t('settings.resetFallbackModal.part3')}
               {t('settings.resetFallbackModal.part4')}
             </p>
             <p style={{ marginTop: 20 }}>{t('settings.resetFallbackModal.part5')}</p>

--- a/src/config/errors.js
+++ b/src/config/errors.js
@@ -50,3 +50,4 @@ export const FeeNotLoaded = createCustomErrorClass('FeeNotLoaded')
 // db stuff, no need to translate
 export const NoDBPathGiven = createCustomErrorClass('NoDBPathGiven')
 export const DBWrongPassword = createCustomErrorClass('DBWrongPassword')
+export const DBNotReset = createCustomErrorClass('DBNotReset')

--- a/src/helpers/reset.js
+++ b/src/helpers/reset.js
@@ -1,5 +1,7 @@
 // @flow
 
+import fs from 'fs'
+import { shell, remote } from 'electron'
 import path from 'path'
 import rimraf from 'rimraf'
 import resolveUserDataDirectory from 'helpers/resolveUserDataDirectory'
@@ -7,11 +9,15 @@ import { disable as disableDBMiddleware } from 'middlewares/db'
 import db from 'helpers/db'
 import { delay } from 'helpers/promise'
 import killInternalProcess from 'commands/killInternalProcess'
+import { DBNotReset } from 'config/errors'
 
 async function resetLibcoreDatabase() {
   await killInternalProcess.send().toPromise()
   const dbpath = path.resolve(resolveUserDataDirectory(), 'sqlite/')
   rimraf.sync(dbpath, { glob: false })
+  if (fs.existsSync(dbpath)) {
+    throw new DBNotReset()
+  }
 }
 
 function reload() {
@@ -24,7 +30,7 @@ export async function hardReset() {
   disableDBMiddleware()
   db.resetAll()
   await delay(500)
-  resetLibcoreDatabase()
+  await resetLibcoreDatabase()
   reload()
 }
 
@@ -32,6 +38,11 @@ export async function softReset({ cleanAccountsCache }: *) {
   cleanAccountsCache()
   await delay(500)
   await db.cleanCache()
-  resetLibcoreDatabase()
+  await resetLibcoreDatabase()
   reload()
+}
+
+export async function openUserDataFolderAndQuit() {
+  shell.openItem(resolveUserDataDirectory())
+  remote.app.quit()
 }

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -406,6 +406,13 @@
       "title": "Clear cache",
       "desc": "Clearing the Ledger Live cache forces network resynchronization. Your settings and accounts are not affected. The private keys to access your crypto assets in the blockchain remain secure on your Ledger device and on your Recovery sheet."
     },
+    "resetFallbackModal": {
+      "part1": "Cache folder couldnt be deleted. You will have to delete it manually.",
+      "part2": "Click on \"Open folder\", then the ",
+      "part3": "app will close",
+      "part4": ", and you will have to delete the \"sqlite\" folder.",
+      "part5": "After that, you can restart the app."
+    },
     "removeAccountModal": {
       "title": "Remove account",
       "desc": "The account will no longer be included in your portfolio. This operation does not affect your assets. Accounts can always be re-added."

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -407,11 +407,12 @@
       "desc": "Clearing the Ledger Live cache forces network resynchronization. Your settings and accounts are not affected. The private keys to access your crypto assets in the blockchain remain secure on your Ledger device and on your Recovery sheet."
     },
     "resetFallbackModal": {
-      "part1": "Cache folder couldnt be deleted. You will have to delete it manually.",
-      "part2": "Click on \"Open folder\", then the ",
+      "title": "User action required",
+      "part1": "Could not delete cache folder. Please delete the folder manually:",
+      "part2": "Click the Open folder button, the ",
       "part3": "app will close",
-      "part4": ", and you will have to delete the \"sqlite\" folder.",
-      "part5": "After that, you can restart the app."
+      "part4": ", and manually delete the \"sqlite\" folder.",
+      "part5": "Then you can restart the app normally."
     },
     "removeAccountModal": {
       "title": "Remove account",


### PR DESCRIPTION
closes #1554

Clean cache / hard reset has been reported (& reproduced) failing to remove the `<user-data>/sqlite` folder on Windows (high chance of folder being "hold" by some process, even if we kill libcore before..) and we get some EPERM and ENOTEMPTY (relatable: https://github.com/isaacs/rimraf/issues/72).

Fallback here is to detect this behaviour, and provide a workaround: open the user data folder then quit the app, explaining the user he has to delete manually.

Additionally for support guys, here is a video of the process (@dasilvarosa feel free to discuss the wording):

**DEMO:**

[![kbwuldq](https://user-images.githubusercontent.com/315259/47020923-aa58ac80-d15a-11e8-88d5-993377d26ad1.png)](https://www.youtube.com/watch?v=7wzOY6Hn0oQ)

