### PR TITLE
Disable ModalWrap focus grab if lastFocus is inside it already

### DIFF
--- a/src/components/base/Modal/index.js
+++ b/src/components/base/Modal/index.js
@@ -186,8 +186,7 @@ export class Modal extends Component<Props> {
   focusWrapper = () => {
     // Forced to use findDOMNode here, because innerRef is giving a proxied component
     const domWrapper = findDOMNode(this._wrapper) // eslint-disable-line react/no-find-dom-node
-
-    if (domWrapper instanceof HTMLDivElement) {
+    if (domWrapper instanceof HTMLDivElement && !domWrapper.contains(this._lastFocusedElement)) {
       domWrapper.focus()
     }
   }


### PR DESCRIPTION
Simple bug fix that should not affect any functionality apart from the one specified in the issue. The autofocus prop was being ignored or rather overridden by a focus from `ModalWrapper` that was in place to ensure a more natural accessibility flow for keyboard usage.

By checking if the focused element prior to the focus grab is already inside the Modal we guarantee that any other cases that were using this `focusWrapper` functionality still use it.

### Type

BugFix
### Context

https://github.com/LedgerHQ/ledger-live-desktop/issues/1588