### PR TITLE
Added option of non-bitcoin currencies for testing in devtools

### DIFF
--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -203,6 +203,27 @@ const fetchCurrentBlock = (perCurrencyId => currency => {
 })({})
 
 const EthereumBridge: WalletBridge<Transaction> = {
+  getDummyAccountFromAddress: (currency, address) => {
+    const derivationMode = getDerivationModesForCurrency(currency).slice(-1)[0]
+    const index = -1
+    return {
+      id: `ethereumjs:2:${currency.id}:${address}:${derivationMode}`,
+      seedIdentifier: address,
+      derivationMode,
+      name: getAccountPlaceholderName({ currency, index, derivationMode }),
+      freshAddress: address,
+      freshAddressPath: '',
+      balance: BigNumber(0),
+      blockHeight: 0,
+      index,
+      currency,
+      operations: [],
+      pendingOperations: [],
+      unit: currency.units[0],
+      lastSyncDate: new Date(),
+    }
+  },
+
   scanAccountsOnDevice: (currency, deviceId) =>
     Observable.create(o => {
       let finished = false

--- a/src/bridge/RippleJSBridge.js
+++ b/src/bridge/RippleJSBridge.js
@@ -280,6 +280,27 @@ const cachedRecipientIsNew = (endpointConfig, recipient) => {
 }
 
 const RippleJSBridge: WalletBridge<Transaction> = {
+  getDummyAccountFromAddress: (currency, address) => {
+    const derivationMode = getDerivationModesForCurrency(currency).slice(-1)[0]
+    const index = -1
+    return {
+      id: `ripplejs:2:${currency.id}:${address}:${derivationMode}`,
+      seedIdentifier: address,
+      derivationMode,
+      name: getAccountPlaceholderName({ currency, index, derivationMode }),
+      freshAddress: address,
+      freshAddressPath: '',
+      balance: BigNumber(0),
+      blockHeight: 0,
+      index,
+      currency,
+      operations: [],
+      pendingOperations: [],
+      unit: currency.units[0],
+      lastSyncDate: new Date(),
+    }
+  },
+
   scanAccountsOnDevice: (currency, deviceId) =>
     Observable.create(o => {
       let finished = false

--- a/src/bridge/types.js
+++ b/src/bridge/types.js
@@ -36,6 +36,10 @@ export interface WalletBridge<Transaction> {
   // TODO return Observable
   scanAccountsOnDevice(currency: Currency, deviceId: DeviceId): Observable<Account>;
 
+  // only for devtools mode, allows us to import non-bitcoin-family accounts for monitoring
+  // making it easier to stress test the system using very active accounts as a base.
+  getDummyAccountFromAddress?: (currency: Currency, freshAddress: string) => Account;
+
   // synchronize an account. meaning updating the account object with latest state.
   // function receives the initialAccount object so you can actually know what the user side currently have
   // then you must emit one or more updater functions to inform data changes.


### PR DESCRIPTION
While researching https://github.com/LedgerHQ/ledger-live-desktop/issues/1594 I was unable to replicate the situation on my machine, neither could I replicate it on a vm running the same OS as the user. Under the assumption that what was probably causing this had more to do with the number of accounts and transactions than anything else and knowing my own accounts did not have enough movement I searched and found the devtools that allow you to add some bitcoin-family account by xpub.

Since Ethereum wasn't one of them and trying to easily add other cryptos simply by the public address I modified the dev tools page a bit, allowing Ethereum and Ripple (initially) to have accounts manually added. **I don't know if adding the method as an optional one to the bridges is a good approach** or if we'd rather abstract it out of there, but for now this works and might be useful for testing. Also handles non-bitcoin family coins with unsupported bridges without crashing.

![image](https://user-images.githubusercontent.com/4631227/47296675-4ed36680-d613-11e8-8c06-c5d89189f351.png)


I noticed that adding a mammoth account such as one used by an exchange **will never sync**, or at least it will take forever and apparently it will not sync other accounts meanwhile either. I couldn't see a huge spike in memory usage however so that might not have anything to do with it.

**However**, if we pass the `limit` option to the `getTransactions` call at the Ripple bridge, we do get the results back, seems like it's choking on hundreds of operations. In Ethereum's bridge, the "Show more" implementations seems to work a treat and doesn't choke even on thousands of transactions.

Didn't polish this since a normal user wouldn't be seeing it but I did change the inputs to ask for xpub/public address depending on the family. So the initial sync will not give the amount + transactions until we manually trigger it.