### PR TITLE
UpdateYourApp error in a 6b00 during sign transaction

### DIFF
--- a/src/commands/libcoreSignAndBroadcast.js
+++ b/src/commands/libcoreSignAndBroadcast.js
@@ -2,6 +2,7 @@
 
 import logger from 'logger'
 import { BigNumber } from 'bignumber.js'
+import { StatusCodes } from '@ledgerhq/hw-transport'
 import Btc from '@ledgerhq/hw-app-btc'
 import { Observable } from 'rxjs'
 import { isSegwitDerivationMode } from '@ledgerhq/live-common/lib/derivation'
@@ -13,6 +14,7 @@ import {
   bigNumberToLibcoreAmount,
   getOrCreateWallet,
 } from 'helpers/libcore'
+import { UpdateYourApp } from 'config/errors'
 
 import withLibcore from 'helpers/withLibcore'
 import { createCommand, Command } from 'helpers/ipc'
@@ -227,7 +229,12 @@ export async function doSignAndBroadcast({
       hasTimestamp,
       derivationMode,
     }),
-  )
+  ).catch(e => {
+    if (e && e.statusCode === StatusCodes.INCORRECT_P1_P2) {
+      throw new UpdateYourApp(`UpdateYourApp ${currency.id}`, currency)
+    }
+    throw e
+  })
 
   if (!signedTransaction || isCancelled() || !njsAccount) return
   onSigned()

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -826,8 +826,8 @@
       "description": "Please try again or contact Ledger Support"
     },
     "UpdateYourApp": {
-      "title": "App update required. Uninstall and reinstall the {{managerAppName}} app in the Manager",
-      "description": null
+      "title": "App update required",
+      "description": "Uninstall and reinstall the {{managerAppName}} app in the Manager"
     },
     "WebsocketConnectionError": {
       "title": "Sorry, try again (websocket error).",


### PR DESCRIPTION
throw UpdateYourApp if we receive a 0x6b00 during sign transaction. checked with @btchip that this error mostly always means the app is outdated.

### Type

polish

### testing plan

when you will test the new ZCash app and try to do a send **after the ZCash sapling update**, there will be an error "update your app".