### PR TITLE
Ethereum libcore integration

### DIFF
--- a/scripts/cli/cli.sh
+++ b/scripts/cli/cli.sh
@@ -6,4 +6,4 @@ export LEDGER_LOGS_DIRECTORY="$LEDGER_DATA_DIR/logs"
 export LEDGER_LIVE_SQLITE_PATH="$LEDGER_DATA_DIR/sqlite"
 export CLI=1
 
-node -r @babel/register scripts/cli/txBetweenAccounts.js
+node -r @babel/register scripts/cli/ethTx.js

--- a/scripts/cli/ethScanAccounts.js
+++ b/scripts/cli/ethScanAccounts.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+
+import '@babel/polyfill'
+import 'globals'
+import withLibcore from 'helpers/withLibcore'
+
+import { scanAccountsOnDevice } from 'helpers/libcore'
+import getDevice from './getDevice'
+
+async function main() {
+  try {
+    const device = await getDevice()
+
+    await withLibcore(async core => {
+      const accounts = await scanAccountsOnDevice({
+        core,
+        devicePath: device.path,
+        currencyId: 'ethereum',
+        onAccountScanned: account => {
+          console.log(`---------------------> account scanned: ${account.id}`)
+        },
+        isUnsubscribed: () => false,
+      })
+      // console.log(`\n-- final result --\n`)
+       console.log(accounts)
+    })
+  } catch (err) {
+    console.log(`[ERROR]`, err)
+  }
+}
+
+main()

--- a/scripts/cli/ethTx.js
+++ b/scripts/cli/ethTx.js
@@ -1,0 +1,70 @@
+/* eslint-disable no-console */
+
+import { getCryptoCurrencyById } from '@ledgerhq/live-common/lib/currencies'
+
+import 'globals'
+import accountModel from 'helpers/accountModel'
+import { doSignAndBroadcast } from 'commands/libcoreSignAndBroadcast'
+import withLibcore from 'helpers/withLibcore'
+import parseAppFile from './parseAppFile'
+import getDevice from './getDevice'
+
+// { id: 'libcore:1:ethereum:0x9A7Dd4bA62C978744A45fF85356F3a600d8fB665:',
+//     seedIdentifier: '0xA32C4b7968115742d55Ce2cB7Fd111d9A3cfc307',
+//     derivationMode: '',
+//     xpub: '0x9A7Dd4bA62C978744A45fF85356F3a600d8fB665',
+//     path: '44\'/60\'',
+//     name: 'Ethereum 1',
+//     freshAddress: '0x9A7Dd4bA62C978744A45fF85356F3a600d8fB665',
+//     freshAddressPath: '44\'/60\'/0\'/0/0',
+//     balance: 3042995800000000,
+//     blockHeight: 6531810,
+//     archived: false,
+//     index: 0,
+//     operations: [],
+//     pendingOperations: [],
+//     currencyId: 'ethereum',
+//     unitMagnitude: 18,
+//     lastSyncDate: '2018-10-17T12:16:08.688Z' }
+
+async function main() {
+  try {
+    const device = await getDevice()
+    const app = await parseAppFile()
+    const account = accountModel.decode(app.accounts[0])
+    if (account.currency.id !== 'ethereum') {
+      throw new Error('WTF dude your first account is not ethereum')
+    }
+    const currency = getCryptoCurrencyById('ethereum')
+
+    await withLibcore(async core => {
+      await doSignAndBroadcast({
+        accountId: 'libcore:1:ethereum:0xAc6603e97e774Cd34603293b69bBBB1980acEeaA:',
+        derivationMode: '',
+        seedIdentifier: '0xfB98Bdd04d82648f25E67041D6E27a866BEC0B47',
+        currency,
+        xpub: '0xAc6603e97e774Cd34603293b69bBBB1980acEeaA',
+        index: 0,
+        transaction: {
+          recipient: '0xAc6603e97e774Cd34603293b69bBBB1980acEeaA',
+          amount: '1000000000000000',
+          gasPrice: '8000000000',
+          gasLimit: '21000',
+        },
+        deviceId: device.path,
+        core,
+        isCancelled: () => false,
+        onSigned: () => {
+          console.log(`[[[[transaction signed]]]]`)
+        },
+        onOperationBroadcasted: () => {
+          console.log(`[[[[transaction broadcasted]]]]`)
+        },
+      })
+    })
+  } catch (err) {
+    console.log(`[ERROR]`, err)
+  }
+}
+
+main()

--- a/scripts/cli/parseAppFile.js
+++ b/scripts/cli/parseAppFile.js
@@ -1,0 +1,9 @@
+import path from 'path'
+import fs from 'fs'
+
+export default async function parseAppFile() {
+  const appFilePath = path.resolve(process.env.LEDGER_DATA_DIR, 'app.json')
+  const appFileContent = fs.readFileSync(appFilePath, 'utf-8')
+  const parsedApp = JSON.parse(appFileContent)
+  return parsedApp.data
+}

--- a/src/bridge/index.js
+++ b/src/bridge/index.js
@@ -4,14 +4,13 @@ import invariant from 'invariant'
 import { USE_MOCK_DATA } from 'config/constants'
 import { WalletBridge } from './types'
 import LibcoreBridge from './LibcoreBridge'
-import EthereumJSBridge from './EthereumJSBridge'
 import RippleJSBridge from './RippleJSBridge'
 import makeMockBridge from './makeMockBridge'
 
 const perFamily = {
   bitcoin: LibcoreBridge,
   ripple: RippleJSBridge,
-  ethereum: EthereumJSBridge,
+  ethereum: LibcoreBridge,
   stellar: null,
 }
 if (USE_MOCK_DATA) {

--- a/src/commands/libcoreGetFees.js
+++ b/src/commands/libcoreGetFees.js
@@ -50,43 +50,53 @@ const cmd: Command<Input, Result> = createCommand(
       const isCancelled = () => unsubscribed
       const currency = getCryptoCurrencyById(currencyId)
 
-      withLibcore(async core => {
-        const walletName = getWalletName({
-          currency,
-          derivationMode,
-          seedIdentifier,
-        })
-        const njsWallet = await getOrCreateWallet(core, walletName, {
-          currency,
-          derivationMode,
-        })
-        if (isCancelled()) return
-        const njsAccount = await njsWallet.getAccount(accountIndex)
-        if (isCancelled()) return
-        const bitcoinLikeAccount = njsAccount.asBitcoinLikeAccount()
-        const njsWalletCurrency = njsWallet.getCurrency()
-        const amount = bigNumberToLibcoreAmount(
-          core,
-          njsWalletCurrency,
-          BigNumber(transaction.amount),
-        )
-        const feesPerByte = bigNumberToLibcoreAmount(
-          core,
-          njsWalletCurrency,
-          BigNumber(transaction.feePerByte),
-        )
-        const transactionBuilder = bitcoinLikeAccount.buildTransaction()
-        if (!isValidAddress(core, njsWalletCurrency, transaction.recipient)) {
-          // FIXME this is a bug in libcore. later it will probably check this and we can remove this check
-          throw new InvalidAddress()
-        }
-        transactionBuilder.sendToAddress(amount, transaction.recipient)
-        transactionBuilder.pickInputs(0, 0xffffff)
-        transactionBuilder.setFeesPerByte(feesPerByte)
-        const builded = await transactionBuilder.build()
-        const totalFees = libcoreAmountToBigNumber(builded.getFees()).toString()
+      if (currency.family === 'ethereum') {
+        const { gasPrice } = transaction
+        // TODO don't hardcode
+        const gasLimit = BigNumber(0x5208)
+        const totalFees = BigNumber(gasPrice).times(gasLimit)
         o.next({ totalFees })
-      }).then(() => o.complete(), e => o.error(e))
+        o.complete()
+      } else {
+        withLibcore(async core => {
+          const walletName = getWalletName({
+            currency,
+            derivationMode,
+            seedIdentifier,
+          })
+          const njsWallet = await getOrCreateWallet(core, walletName, {
+            currency,
+            derivationMode,
+          })
+          if (isCancelled()) return
+          const njsAccount = await njsWallet.getAccount(accountIndex)
+          if (isCancelled()) return
+
+          const njsWalletCurrency = njsWallet.getCurrency()
+          const bitcoinLikeAccount = njsAccount.asBitcoinLikeAccount()
+          const amount = bigNumberToLibcoreAmount(
+            core,
+            njsWalletCurrency,
+            BigNumber(transaction.amount),
+          )
+          const feesPerByte = bigNumberToLibcoreAmount(
+            core,
+            njsWalletCurrency,
+            BigNumber(transaction.feePerByte),
+          )
+          const transactionBuilder = bitcoinLikeAccount.buildTransaction()
+          if (!isValidAddress(core, njsWalletCurrency, transaction.recipient)) {
+            // FIXME this is a bug in libcore. later it will probably check this and we can remove this check
+            throw new InvalidAddress()
+          }
+          transactionBuilder.sendToAddress(amount, transaction.recipient)
+          transactionBuilder.pickInputs(0, 0xffffff)
+          transactionBuilder.setFeesPerByte(feesPerByte)
+          const builded = await transactionBuilder.build()
+          const totalFees = libcoreAmountToBigNumber(builded.getFees()).toString()
+          o.next({ totalFees })
+        }).then(() => o.complete(), e => o.error(e))
+      }
 
       return () => {
         unsubscribed = true

--- a/src/helpers/getAddressForCurrency/ethereum.js
+++ b/src/helpers/getAddressForCurrency/ethereum.js
@@ -9,7 +9,7 @@ export default async (
   transport: Transport<*>,
   currency: CryptoCurrency,
   path: string,
-  { verify = false }: *,
+  { verify = false }: * = {},
 ) => {
   const eth = new Eth(transport)
   const r = await eth.getAddress(path, verify)

--- a/src/helpers/init-libcore.js
+++ b/src/helpers/init-libcore.js
@@ -97,7 +97,7 @@ const NJSHttpClient = new lib.NJSHttpClient({
     let res
     try {
       // $FlowFixMe
-      res = await network({ method: lib.METHODS[method], url, headers, data })
+      res = await network({ method: lib.METHODS[method], url, headers, data : lib.METHODS[method] === "GET"  ? undefined : data  })
       const urlConnection = createHttpConnection(res)
       r.complete(urlConnection, null)
     } catch (err) {

--- a/src/internals/index.js
+++ b/src/internals/index.js
@@ -1,4 +1,5 @@
 // @flow
+import '@babel/polyfill'
 import commands from 'commands'
 import logger from 'logger'
 import uuid from 'uuid/v4'


### PR DESCRIPTION
**This is still a WIP.**

The purpose of this PR is to open discussion about the optimal way to handle particular behaviour based on currency, in LibcoreBridge. Here, mostly dirty `if` on `currency.family` to make scan/tx logic stay as close as possible between BTC/ETH.

What's included?

- [x] ETH scan accounts (& ops), on all derivations
- [x] ETH transaction (sign & broadcast)
- [x] UI integration / reconnect of EthereumKind fields in LibcoreBridge

What's not included?

- [ ] flow-type (I didnt even test)
- [ ] beautiful code