### PR TITLE
Handle sqlite gaps while scanning accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ledgerhq/hw-app-xrp": "^4.24.0",
     "@ledgerhq/hw-transport": "^4.24.0",
     "@ledgerhq/hw-transport-node-hid": "4.24.0",
-    "@ledgerhq/ledger-core": "2.0.0-rc.9",
+    "@ledgerhq/ledger-core": "2.0.0-rc.10",
     "@ledgerhq/live-common": "4.0.0-beta.1",
     "animated": "^0.2.2",
     "async": "^2.6.1",

--- a/src/helpers/libcore.js
+++ b/src/helpers/libcore.js
@@ -111,7 +111,6 @@ async function scanAccountsOnDeviceBySegwit({
 
   // retrieve or create the wallet
   const wallet = await getOrCreateWallet(core, walletName, { currency, derivationMode })
-  const accountsCount = await wallet.getAccountCount()
 
   // recursively scan all accounts on device on the given app
   // new accounts will be created in sqlite, existing ones will be updated
@@ -121,7 +120,6 @@ async function scanAccountsOnDeviceBySegwit({
     walletName,
     devicePath,
     currency,
-    accountsCount,
     accountIndex: 0,
     accounts: [],
     onAccountScanned,
@@ -202,7 +200,6 @@ async function scanNextAccount(props: {
   currency: CryptoCurrency,
   seedIdentifier: string,
   derivationMode: string,
-  accountsCount: number,
   accountIndex: number,
   accounts: AccountRaw[],
   onAccountScanned: AccountRaw => void,
@@ -215,7 +212,6 @@ async function scanNextAccount(props: {
     walletName,
     devicePath,
     currency,
-    accountsCount,
     accountIndex,
     accounts,
     onAccountScanned,
@@ -225,13 +221,12 @@ async function scanNextAccount(props: {
     isUnsubscribed,
   } = props
 
-  // create account only if account has not been scanned yet
-  // if it has already been created, we just need to get it, and sync it
-  const hasBeenScanned = accountIndex < accountsCount
-
-  const njsAccount = hasBeenScanned
-    ? await wallet.getAccount(accountIndex)
-    : await createAccount(wallet, devicePath)
+  let njsAccount
+  try {
+    njsAccount = await wallet.getAccount(accountIndex)
+  } catch (err) {
+    njsAccount = await createAccount(wallet, devicePath)
+  }
 
   if (isUnsubscribed()) return []
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1733,10 +1733,10 @@
   dependencies:
     events "^3.0.0"
 
-"@ledgerhq/ledger-core@2.0.0-rc.9":
-  version "2.0.0-rc.9"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.9.tgz#f478f52fac0ecace8842df430bc83fa60e14483f"
-  integrity sha512-wd+w4W/8IfhX2a4h1sM9rkKD0vfcixkbrvKa+SmKzv0WtiUx1i94rHlPLX08tbP2ubaAv/LufeT2DwFz+EcssA==
+"@ledgerhq/ledger-core@2.0.0-rc.10":
+  version "2.0.0-rc.10"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.10.tgz#55b7261924df8ed5a33fcc51fdfafc8d6a323fc4"
+  integrity sha512-PbT6y8lwpVfbD5DZIH8CsOZoipNSGHY7BVHNTS+55QsQ6wAPf7sztZjZ8fk6TM0SfdbdIr7Cc5bFQ6cgljTNIA==
   dependencies:
     "@ledgerhq/hw-app-btc" "^4.7.3"
     "@ledgerhq/hw-transport-node-hid" "^4.7.6"


### PR DESCRIPTION
LL-329

TL;DR, the PR should **only** be merged once [this line](https://github.com/KhalilBellakrid/lib-ledger-core/blob/3fc65779c3ac1f82215e0cec8f80f511639a460c/core/src/wallet/common/database/AccountDatabaseHelper.cpp#L77) is updated with `ORDER BY idx` in lib-ledger-core, to fix the `getNextAccountCreationInfo` (actually it returns always index `0` when there is gaps in created accounts).

to reproduce the problem:

- open LL with empty user data
- scan currency with (at least) 3 accounts
- import the 3nd one
- clear cache
- scan again
- error is throw (account 0 does not exists)

to test the resolution

- switch to this branch
- do same thing and
- realize it doesnt throw
- shutdown your computer