### PR TITLE
LL-631 make fees level selectable event if fees have the same value

### DIFF
--- a/src/components/FeesField/BitcoinKind.js
+++ b/src/components/FeesField/BitcoinKind.js
@@ -89,7 +89,7 @@ class FeesField extends Component<OwnProps, State> {
     }
     items.push(!feePerByte && !error ? notLoadedItem : customItem)
     const selectedItem =
-      !feePerByte && prevState.selectedItem.feePerByte.eq(feePerByte)
+      feePerByte && prevState.selectedItem.feePerByte.eq(feePerByte)
         ? prevState.selectedItem
         : items.find(f => f.feePerByte.eq(feePerByte)) || items[items.length - 1]
     return { items, selectedItem }


### PR DESCRIPTION
### Type
Fix

### Context
https://ledgerhq.atlassian.net/browse/LL-631
Fee level (Low, Standard, High) could not be selected if the amount was the same between the different levels.

### Parts of the app affected
Send Flow

![select-fees](https://user-images.githubusercontent.com/671786/49520784-55a4f880-f8a4-11e8-9f52-11ff3a8c7c81.gif)
