### PR TITLE
Adds tag to transaction details, XRP

### DIFF
--- a/src/bridge/RippleJSBridge.js
+++ b/src/bridge/RippleJSBridge.js
@@ -121,7 +121,7 @@ async function signAndBroadcast({ a, t, deviceId, isCancelled, onSigned, onOpera
         transactionSequenceNumber:
           (a.operations.length > 0 ? a.operations[0].transactionSequenceNumber : 0) +
           a.pendingOperations.length,
-        extra: {},
+        extra: { tag: t.tag },
       }
       onOperationBroadcasted(op)
     }
@@ -164,6 +164,7 @@ type Tx = {
         currency: string,
         value: string,
       },
+      tag?: string,
     },
     paths: string,
   },
@@ -233,7 +234,7 @@ const txToOperation = (account: Account) => ({
     recipients: [destination.address],
     date: new Date(timestamp),
     transactionSequenceNumber: sequence,
-    extra: {},
+    extra: { tag: destination.tag },
   }
   return op
 }

--- a/src/bridge/RippleJSBridge.js
+++ b/src/bridge/RippleJSBridge.js
@@ -121,7 +121,11 @@ async function signAndBroadcast({ a, t, deviceId, isCancelled, onSigned, onOpera
         transactionSequenceNumber:
           (a.operations.length > 0 ? a.operations[0].transactionSequenceNumber : 0) +
           a.pendingOperations.length,
-        extra: { tag: t.tag },
+        extra: {},
+      }
+
+      if (t.tag) {
+        op.extra.tag = t.tag
       }
       onOperationBroadcasted(op)
     }
@@ -234,7 +238,11 @@ const txToOperation = (account: Account) => ({
     recipients: [destination.address],
     date: new Date(timestamp),
     transactionSequenceNumber: sequence,
-    extra: { tag: destination.tag },
+    extra: {},
+  }
+
+  if (destination.tag) {
+    op.extra.tag = destination.tag
   }
   return op
 }

--- a/src/components/modals/OperationDetails.js
+++ b/src/components/modals/OperationDetails.js
@@ -3,7 +3,7 @@
 import React, { Fragment, Component } from 'react'
 import { connect } from 'react-redux'
 import { openURL } from 'helpers/linking'
-import { translate } from 'react-i18next'
+import { Trans, translate } from 'react-i18next'
 import styled from 'styled-components'
 import moment from 'moment'
 import { getOperationAmountNumber } from '@ledgerhq/live-common/lib/operation'
@@ -114,7 +114,7 @@ type Props = {
 const OperationDetails = connect(mapStateToProps)((props: Props) => {
   const { t, onClose, operation, account, currencySettings, marketIndicator } = props
   if (!operation || !account || !currencySettings) return null
-  const { hash, date, senders, type, fee, recipients } = operation
+  const { extra, hash, date, senders, type, fee, recipients } = operation
 
   const { name, unit, currency } = account
   const amount = getOperationAmountNumber(operation)
@@ -226,6 +226,14 @@ const OperationDetails = connect(mapStateToProps)((props: Props) => {
               <OpDetailsTitle>{t('operationDetails.to')}</OpDetailsTitle>
               <DataList lines={recipients} t={t} />
             </Box>
+            {Object.entries(extra).map(([key, value]) => (
+              <Box key={key}>
+                <OpDetailsTitle>
+                  <Trans i18nKey={`operationDetails.extra.${key}`} defaults={key} />
+                </OpDetailsTitle>
+                <OpDetailsData>{value}</OpDetailsData>
+              </Box>
+            ))}
           </Box>
         </GrowScroll>
         <GradientBox />


### PR DESCRIPTION
Adds the tag to the transaction details on an XRP operation, I also allowed the keys stored in the extra field of an operation to be translatable by going into the `operationDetails.extra.key` format, to avoid having computer-named labels.

![image](https://user-images.githubusercontent.com/4631227/49797438-bc606100-fd3f-11e8-92d7-5acc4a483591.png)
