### PR TITLE
Insert variable currencyName in error message

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -137,7 +137,7 @@
   "currentAddress": {
     "title": "Current address",
     "for": "Address for account <1><0>{{accountName}}</0></1>",
-    "messageIfUnverified": "Please verify that the Bitcoin address shown on your device matches the one on your computer",
+    "messageIfUnverified": "Please verify that the {{currencyName}} address shown on your device matches the one on your computer",
     "messageIfAccepted": "Address confirmed, please re-verify it if you copy/paste or scan the QR code.",
     "messageIfSkipped": "Your {{currencyName}} address has not been confirmed on your Ledger device. Please verify it for optimal security."
   },


### PR DESCRIPTION
Variable got erroneously replaced by Bitcoin.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Wording fix