### PR TITLE
Reversed icon shown for asc/desc account ordering

### DIFF
--- a/src/components/DashboardPage/AccountsOrder.js
+++ b/src/components/DashboardPage/AccountsOrder.js
@@ -118,7 +118,7 @@ class AccountsOrder extends Component<Props> {
           <BoldToggle isBold={isActive}>{item.label}</BoldToggle>
         </Box>
         <OrderIcon isActive={isActive}>
-          {order === 'desc' ? <IconArrowUp size={14} /> : <IconArrowDown size={14} />}
+          {order === 'asc' ? <IconArrowUp size={14} /> : <IconArrowDown size={14} />}
         </OrderIcon>
       </DropDownItem>
     )


### PR DESCRIPTION
When the selected order was order was in `desc` mode it was showing the upwards arrow and the other way around. This fix makes it work the same as in mobile.
![image](https://user-images.githubusercontent.com/4631227/50378265-5ec8f000-062e-11e9-8ef3-b3aab79218f2.png)
