### PR TITLE
LL-735 Adds a maxTime for the debounce on the auto-lock idler

### DIFF
--- a/src/components/Idler.js
+++ b/src/components/Idler.js
@@ -40,7 +40,7 @@ class Idler extends PureComponent<Props> {
 
   lastAction: number = -1
 
-  debounceOnChange = debounce(_ => this.idleTimeHandler(), 1000, { maxWait: 1000, leading: true })
+  debounceOnChange = debounce(this.idleTimeHandler, 1000, { maxWait: 1000, leading: true })
 
   checkForAutoLock = _ => {
     const timeout = this.props.autoLockTimeout

--- a/src/components/Idler.js
+++ b/src/components/Idler.js
@@ -40,7 +40,7 @@ class Idler extends PureComponent<Props> {
 
   lastAction: number = -1
 
-  debounceOnChange = debounce(_ => this.idleTimeHandler(), 1000, { maxWait: 1000 })
+  debounceOnChange = debounce(_ => this.idleTimeHandler(), 1000, { maxWait: 1000, leading: true })
 
   checkForAutoLock = _ => {
     const timeout = this.props.autoLockTimeout

--- a/src/components/Idler.js
+++ b/src/components/Idler.js
@@ -40,7 +40,7 @@ class Idler extends PureComponent<Props> {
 
   lastAction: number = -1
 
-  debounceOnChange = debounce(_ => this.idleTimeHandler(), 1000)
+  debounceOnChange = debounce(_ => this.idleTimeHandler(), 1000, { maxWait: 1000 })
 
   checkForAutoLock = _ => {
     const timeout = this.props.autoLockTimeout


### PR DESCRIPTION
There was indeed a bug in the behavior for the auto lock that was quite tricky to find since it really depends on the way you use the app. Basically, the use of [`debounce`](https://lodash.com/docs/4.17.11#debounce) meant that while we were moving the mouse, typing or pressing buttons the `lastAction` timestamp was not being updated, giving time for the lock check to trigger (every 10 seconds) while we acted, and locking the app again.

## Bug
Since we start typing, having the [`debounce`](https://lodash.com/docs/4.17.11#debounce) reject all actions that are less than 1000ms apart from the previous one, the `lastAction` timestamp still holds the old value. If we keep moving the mouse or typing this value will be present when `checkForAutoLock` runs, locking the app again, and updating the timestamp afterwards 🤷‍♂️ 

![bug](https://user-images.githubusercontent.com/4631227/50388388-2d771f80-0715-11e9-8ab0-bfabe07841e6.png)


## Fix
Adding the `maxTime` option to [`debounce`](https://lodash.com/docs/4.17.11#debounce) allows a maximum time between triggers, meaning that even if we move our mouse for the 10 seconds it will take for `checkForAutoLock` to trigger, the  timestamp will be updated every X. Also, setting `leading`to true will remove the slight chance of the check being triggered in that 1000ms frame.

![fix](https://user-images.githubusercontent.com/4631227/50388390-31a33d00-0715-11e9-8806-e046768b0c56.png)




>**Note:**
> Sadly, this doesn't seem to be related to `LL-736` directly, there is a buggy behavior regardless of having the `Idler` present if we spam click on the _send_ button. The modal seems to freeze and we can't hide it. This triggers the autolock too, if present but I don't think it's causing it