### PR TITLE
LL-766 Fixes broken order when missing provider/balance

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@ledgerhq/hw-transport": "^4.32.0",
     "@ledgerhq/hw-transport-node-hid": "^4.32.0",
     "@ledgerhq/ledger-core": "2.0.0-rc.14",
-    "@ledgerhq/live-common": "4.8.0-beta.23",
+    "@ledgerhq/live-common": "4.8.0-beta.24",
     "animated": "^0.2.2",
     "async": "^2.6.1",
     "axios": "^0.18.0",

--- a/src/actions/general.js
+++ b/src/actions/general.js
@@ -33,11 +33,8 @@ const selectAccountsBalanceAndOrder = createStructuredSelector({
 
 export const refreshAccountsOrdering = () => (dispatch: *, getState: *) => {
   const all = selectAccountsBalanceAndOrder(getState())
-  const allRatesAvailable = all.accountsBtcBalance.every(b => !!b)
-  if (allRatesAvailable) {
-    dispatch({
-      type: 'DB:REORDER_ACCOUNTS',
-      payload: sortAccounts(all),
-    })
-  }
+  dispatch({
+    type: 'DB:REORDER_ACCOUNTS',
+    payload: sortAccounts(all),
+  })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,10 +1725,10 @@
     bindings "^1.3.0"
     nan "^2.6.2"
 
-"@ledgerhq/live-common@4.8.0-beta.23":
-  version "4.8.0-beta.23"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-4.8.0-beta.23.tgz#a6f0d5016116204ffba92648fb5b1f6fd0458196"
-  integrity sha512-sgwto1g8VyNSYAr7kimvuX+hlYN9r1FvArCD1JvUtjo9I57Ucj8TMyusfHLhne1exivrjuoNdVJIZaR3YJUvXg==
+"@ledgerhq/live-common@4.8.0-beta.24":
+  version "4.8.0-beta.24"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-4.8.0-beta.24.tgz#5f30ea9b63c1a561120eb6757b6663d1c20b67e0"
+  integrity sha512-guW9LH/kAk9bmZ8dJV0OlzNYOoE8Jo0VPxZuYCLuzO09Xr41oBfEARdSnVNV6+n/L/BDc8EZSlixpbxMKZ9yFQ==
   dependencies:
     "@aeternity/ledger-app-api" "0.0.4"
     "@ledgerhq/hw-app-btc" "^4.32.0"


### PR DESCRIPTION
### Dependant on https://github.com/LedgerHQ/ledger-live-common/pull/121 being merged
----
Removes the requirement of having all rates available to sort the accounts. To test this without having the linked PR merged would require you to modify https://github.com/LedgerHQ/ledger-live-common/blob/master/src/account.js#L261 locally adding the `||BigNumber(-1)` over there.