### PR TITLE
fix: yarn storybook

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,4 +10,7 @@ module.exports = {
       },
     ],
   },
+  node: {
+    fs: 'empty',
+  },
 }


### PR DESCRIPTION
### Type

Bug Fix

### Context

With a fresh clone of the repo, executing `yarn storybook` results in:

```
ERROR in ./node_modules/electron/index.js
Module not found: Error: Can't resolve 'fs'
```

The update to the webpack config fixes that.
