### PR TITLE
Should fixes LL-828

### DIFF
--- a/src/reducers/currenciesStatus.js
+++ b/src/reducers/currenciesStatus.js
@@ -37,7 +37,9 @@ export const fetchCurrenciesStatus = () => async (dispatch: *) => {
       method: 'GET',
       url: process.env.LL_STATUS_ENDPOINT || urls.currenciesStatus,
     })
-    dispatch(setCurrenciesStatus(data))
+    if (Array.isArray(data)) {
+      dispatch(setCurrenciesStatus(data))
+    }
   } catch (err) {
     logger.error(err)
   }


### PR DESCRIPTION
for some reason some users have a bad result on the currencies.json endpoint

### Type

bugfix

### Context

LL-828 

### Parts of the app affected / Test plan

everything still works. komodo still displayed as disrupted.