### PR TITLE
fix typo

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -851,7 +851,7 @@
       "description": "{{message}}"
     },
     "UnexpectedBootloader": {
-      "title": "Opps, your device should not be in Bootloader mode",
+      "title": "Oops, your device should not be in Bootloader mode",
       "description": "Please restart your device or contact us"
     },
     "UserRefusedFirmwareUpdate": {


### PR DESCRIPTION

### Type

Polish

### Context

Based on the other error strings found in the file, I believe this is the correct string. `s/Opps/Oops`
