### PR TITLE
Allow to flag disabled currencies so they still keep in sync

### DIFF
--- a/src/bridge/BridgeSyncContext.js
+++ b/src/bridge/BridgeSyncContext.js
@@ -77,7 +77,8 @@ class Provider extends Component<BridgeSyncProviderOwnProps, Sync> {
         return
       }
 
-      if (currencyDownStatusLocal(this.props.currenciesStatus, account.currency)) {
+      const downStatus = currencyDownStatusLocal(this.props.currenciesStatus, account.currency)
+      if (downStatus && !downStatus.keepSync) {
         next()
         return
       }

--- a/src/components/CurrenciesStatusBanner.js
+++ b/src/components/CurrenciesStatusBanner.js
@@ -116,7 +116,11 @@ class BannerItem extends PureComponent<{
   render() {
     const { item, t } = this.props
     return (
-      <Box relative key={item.id} style={styles.banner}>
+      <Box
+        relative
+        key={item.id}
+        style={{ ...styles.banner, ...(item.warning ? styles.warning : null) }}
+      >
         <CloseIcon onClick={this.dismiss} />
         <Box horizontal flow={2}>
           <IconTriangleWarning height={16} width={16} color="white" />
@@ -159,8 +163,11 @@ const styles = {
     left: 32,
     bottom: 32,
   },
+  warning: {
+    background: colors.orange,
+  },
   banner: {
-    background: colors.alertRed,
+    background: colors.warning,
     overflow: 'hidden',
     borderRadius: 4,
     fontSize: 13,

--- a/src/components/CurrenciesStatusBanner.js
+++ b/src/components/CurrenciesStatusBanner.js
@@ -167,7 +167,7 @@ const styles = {
     background: colors.orange,
   },
   banner: {
-    background: colors.warning,
+    background: colors.alertRed,
     overflow: 'hidden',
     borderRadius: 4,
     fontSize: 13,

--- a/src/components/CurrencyDownStatusAlert.js
+++ b/src/components/CurrencyDownStatusAlert.js
@@ -28,7 +28,7 @@ const CurrencyDownBox = styled(Box).attrs({
   py: 2,
   mb: 4,
 })`
-  background-color: ${p => p.theme.colors.alertRed};
+  background-color: ${p => (p.warning ? p.theme.colors.orange : p.theme.colors.alertRed)};
 `
 
 const Link = styled.span`
@@ -48,7 +48,7 @@ class CurrencyDownStatusAlert extends PureComponent<Props> {
     const { status, t } = this.props
     if (!status) return null
     return (
-      <CurrencyDownBox>
+      <CurrencyDownBox warning={!!status.warning}>
         <Box mr={2}>
           <IconTriangleWarning height={16} width={16} />
         </Box>

--- a/src/reducers/currenciesStatus.js
+++ b/src/reducers/currenciesStatus.js
@@ -15,6 +15,7 @@ export type CurrencyStatus = {
   message: string,
   link: string,
   nonce: number,
+  keepSync?: boolean, // even if something is happening, make live still stay in sync
 }
 
 export type CurrenciesStatusState = CurrencyStatus[]

--- a/src/reducers/currenciesStatus.js
+++ b/src/reducers/currenciesStatus.js
@@ -15,6 +15,7 @@ export type CurrencyStatus = {
   message: string,
   link: string,
   nonce: number,
+  warning?: boolean, // display as a warning
   keepSync?: boolean, // even if something is happening, make live still stay in sync
 }
 


### PR DESCRIPTION
We have recently disabled 2 coins: POSW and HSR but we didn't use it in the way the current system was meant to be used for. It's more a warning we want to do but the sync should still continue for these. This allow to do so with a flag.

### Type

improvement

### Context

LL-925

### Parts of the app affected / Test plan

for POSW and HSR accounts, this will now no longer pause the synchronization because explorers are still up and users should be able to use them.