### PR TITLE
Use the freshResetAll libcore’s function when resetting the app.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@ledgerhq/hw-app-xrp": "^4.39.0",
     "@ledgerhq/hw-transport": "^4.39.0",
     "@ledgerhq/hw-transport-node-hid": "^4.40.0",
-    "@ledgerhq/ledger-core": "2.0.0-rc.19",
+    "@ledgerhq/ledger-core": "2.0.0-rc.21",
     "@ledgerhq/live-common": "4.16.1",
     "animated": "^0.2.2",
     "async": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@ledgerhq/hw-app-xrp": "^4.35.0",
     "@ledgerhq/hw-transport": "^4.35.0",
     "@ledgerhq/hw-transport-node-hid": "^4.35.0",
-    "@ledgerhq/ledger-core": "2.0.0-rc.16",
+    "@ledgerhq/ledger-core": "2.0.0-rc.19",
     "@ledgerhq/live-common": "4.16.1",
     "animated": "^0.2.2",
     "async": "^2.6.1",

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -16,6 +16,7 @@ import installApp from 'commands/installApp'
 import killInternalProcess from 'commands/killInternalProcess'
 import libcoreGetFees from 'commands/libcoreGetFees'
 import libcoreGetVersion from 'commands/libcoreGetVersion'
+import libcoreReset from 'commands/libcoreReset'
 import libcoreScanAccounts from 'commands/libcoreScanAccounts'
 import libcoreScanFromXPUB from 'commands/libcoreScanFromXPUB'
 import libcoreSignAndBroadcast from 'commands/libcoreSignAndBroadcast'
@@ -44,6 +45,7 @@ const all: Array<Command<any, any>> = [
   killInternalProcess,
   libcoreGetFees,
   libcoreGetVersion,
+  libcoreReset,
   libcoreScanAccounts,
   libcoreScanFromXPUB,
   libcoreSignAndBroadcast,

--- a/src/commands/killInternalProcess.js
+++ b/src/commands/killInternalProcess.js
@@ -1,10 +1,10 @@
 // @flow
 
 import { createCommand, Command } from 'helpers/ipc'
-import { of } from 'rxjs'
+import { never } from 'rxjs'
 
 type Input = void
-type Result = boolean
+type Result = void
 
 const cmd: Command<Input, Result> = createCommand('killInternalProcess', () => {
   setTimeout(() => {
@@ -12,7 +12,8 @@ const cmd: Command<Input, Result> = createCommand('killInternalProcess', () => {
     // special exit code for better identification
     process.exit(42)
   })
-  return of(true)
+  // The command shouldn't finish now because process.exit will make it end!
+  return never()
 })
 
 export default cmd

--- a/src/commands/libcoreReset.js
+++ b/src/commands/libcoreReset.js
@@ -1,15 +1,15 @@
 // @flow
 
 import { createCommand, Command } from 'helpers/ipc'
-import { of } from 'rxjs'
+import { from } from 'rxjs'
 import withLibcore from 'helpers/withLibcore'
 
 type Input = void
 type Result = boolean
 
-const cmd: Command<Input, Result> = createCommand('libcoreReset', () => {
-  withLibcore(core => core.getPoolInstance().freshResetAll())
-  return of(true)
-})
+const cmd: Command<Input, Result> = createCommand(
+  'libcoreReset',
+  () => from(withLibcore(core => core.getPoolInstance().freshResetAll()))
+)
 
 export default cmd

--- a/src/commands/libcoreReset.js
+++ b/src/commands/libcoreReset.js
@@ -7,9 +7,8 @@ import withLibcore from 'helpers/withLibcore'
 type Input = void
 type Result = boolean
 
-const cmd: Command<Input, Result> = createCommand(
-  'libcoreReset',
-  () => from(withLibcore(core => core.getPoolInstance().freshResetAll()))
+const cmd: Command<Input, Result> = createCommand('libcoreReset', () =>
+  from(withLibcore(core => core.getPoolInstance().freshResetAll())),
 )
 
 export default cmd

--- a/src/commands/libcoreReset.js
+++ b/src/commands/libcoreReset.js
@@ -1,0 +1,15 @@
+// @flow
+
+import { createCommand, Command } from 'helpers/ipc'
+import { of } from 'rxjs'
+import withLibcore from 'helpers/withLibcore'
+
+type Input = void
+type Result = boolean
+
+const cmd: Command<Input, Result> = createCommand('libcoreReset', () => {
+  withLibcore(core => core.getPoolInstance().freshResetAll())
+  return of(true)
+})
+
+export default cmd

--- a/src/components/SettingsPage/CleanButton.js
+++ b/src/components/SettingsPage/CleanButton.js
@@ -6,6 +6,7 @@ import { translate } from 'react-i18next'
 import logger from 'logger'
 import type { T } from 'types/common'
 import { cleanAccountsCache } from 'actions/accounts'
+import SyncSkipUnderPriority from 'components/SyncSkipUnderPriority'
 import Button from 'components/base/Button'
 import ConfirmModal from 'components/base/Modal/ConfirmModal'
 import { softReset } from 'helpers/reset'
@@ -69,7 +70,9 @@ class CleanButton extends PureComponent<Props, State> {
           title={t('settings.softResetModal.title')}
           subTitle={t('common.areYouSure')}
           desc={t('settings.softResetModal.desc')}
-        />
+        >
+          <SyncSkipUnderPriority priority={999} />
+        </ConfirmModal>
 
         <ResetFallbackModal isOpened={fallbackOpened} onClose={this.closeFallback} />
       </Fragment>

--- a/src/components/SettingsPage/ResetButton.js
+++ b/src/components/SettingsPage/ResetButton.js
@@ -7,6 +7,7 @@ import { translate } from 'react-i18next'
 import logger from 'logger'
 import type { T } from 'types/common'
 import { hardReset } from 'helpers/reset'
+import SyncSkipUnderPriority from 'components/SyncSkipUnderPriority'
 import Box from 'components/base/Box'
 import Button from 'components/base/Button'
 import ConfirmModal from 'components/base/Modal/ConfirmModal'
@@ -73,7 +74,9 @@ class ResetButton extends PureComponent<Props, State> {
               <IconTriangleWarning width={23} height={21} />
             </IconWrapperCircle>
           )}
-        />
+        >
+          <SyncSkipUnderPriority priority={999} />
+        </ConfirmModal>
 
         <ResetFallbackModal isOpened={fallbackOpened} onClose={this.closeFallback} />
       </Fragment>

--- a/src/components/base/Modal/ConfirmModal.js
+++ b/src/components/base/Modal/ConfirmModal.js
@@ -29,6 +29,7 @@ type Props = {
   analyticsName: string,
   cancellable?: boolean,
   centered?: boolean,
+  children?: *,
 }
 
 class ConfirmModal extends PureComponent<Props> {

--- a/src/components/base/Modal/ConfirmModal.js
+++ b/src/components/base/Modal/ConfirmModal.js
@@ -50,6 +50,7 @@ class ConfirmModal extends PureComponent<Props> {
       t,
       analyticsName,
       centered,
+      children,
       ...props
     } = this.props
 
@@ -91,6 +92,7 @@ class ConfirmModal extends PureComponent<Props> {
               <Box ff="Open Sans" color="smoke" fontSize={4} textAlign="center">
                 {desc}
               </Box>
+              {children}
             </Box>
           )}
         />

--- a/src/helpers/reset.js
+++ b/src/helpers/reset.js
@@ -9,8 +9,10 @@ import killInternalProcess from 'commands/killInternalProcess'
 import libcoreReset from 'commands/libcoreReset'
 
 async function resetLibcore() {
-  await libcoreReset.send().toPromise()
+  // we need to stop everything that is happening right now, like syncs
   await killInternalProcess.send().toPromise()
+  // we can now ask libcore to reset itself
+  await libcoreReset.send().toPromise()
 }
 
 function reload() {

--- a/src/helpers/reset.js
+++ b/src/helpers/reset.js
@@ -10,7 +10,10 @@ import libcoreReset from 'commands/libcoreReset'
 
 async function resetLibcore() {
   // we need to stop everything that is happening right now, like syncs
-  await killInternalProcess.send().toPromise()
+  await killInternalProcess
+    .send()
+    .toPromise()
+    .catch(() => {}) // this is a normal error due to the crash of the process, we ignore it
   // we can now ask libcore to reset itself
   await libcoreReset.send().toPromise()
 }

--- a/src/helpers/reset.js
+++ b/src/helpers/reset.js
@@ -6,11 +6,11 @@ import { disable as disableDBMiddleware } from 'middlewares/db'
 import db from 'helpers/db'
 import { delay } from 'helpers/promise'
 import killInternalProcess from 'commands/killInternalProcess'
-import withLibcore from 'helpers/withLibcore'
+import libcoreReset from 'commands/libcoreReset'
 
 async function resetLibcore() {
+  await libcoreReset.send().toPromise()
   await killInternalProcess.send().toPromise()
-  withLibcore(core => core.freshResetAll())
 }
 
 function reload() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,10 +1722,10 @@
   dependencies:
     events "^3.0.0"
 
-"@ledgerhq/ledger-core@2.0.0-rc.16":
-  version "2.0.0-rc.16"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.16.tgz#51f141c0143edb020e38855bf2e2619e3446e74f"
-  integrity sha512-gmbeXRBg4NSqzH6+EajYTzaQlwN5ugaN1nH0SI6BvRqMfcorxNRE8byfh3F2u+7TNchBW72vOZnKPDShaR9/pQ==
+"@ledgerhq/ledger-core@2.0.0-rc.19":
+  version "2.0.0-rc.19"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.19.tgz#f8cd0bdc4e8f067bd95aced895d3e1190bb63f06"
+  integrity sha512-pkSVOFNGYYiujJFCJ7JkQrwK5YMVx6MoyXBD4jA+SKthlZ8zo3X3jfhRJdZ1rUiI87GP/ncdh0Kc+epuWTqlDQ==
   dependencies:
     bindings "^1.3.0"
     nan "^2.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1733,10 +1733,10 @@
     "@ledgerhq/errors" "^4.39.0"
     events "^3.0.0"
 
-"@ledgerhq/ledger-core@2.0.0-rc.19":
-  version "2.0.0-rc.19"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.19.tgz#f8cd0bdc4e8f067bd95aced895d3e1190bb63f06"
-  integrity sha512-pkSVOFNGYYiujJFCJ7JkQrwK5YMVx6MoyXBD4jA+SKthlZ8zo3X3jfhRJdZ1rUiI87GP/ncdh0Kc+epuWTqlDQ==
+"@ledgerhq/ledger-core@2.0.0-rc.21":
+  version "2.0.0-rc.21"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.0.0-rc.21.tgz#f9e48cf162150ef3d5089ac19e9effcef4626697"
+  integrity sha512-DqBY1D95wz3a56k8bx7e8YhTsVake/4ZBxH5RgUnXl4OQYRQNKyrtqt94yKvYi+JkRqtU2z60XgB5mo58jaq+w==
   dependencies:
     bindings "^1.3.0"
     nan "^2.6.2"


### PR DESCRIPTION
**Be careful: there are two important points:**
  - **The QA should test a lot because there is a lot of breaking changes and new features. Please heavily test.**
 - **Please inform clients about resetting their applications because of these breaking changes; these changes are for preparing Ethereum ERC20 integration.**

Also, bump libcore’s version to 2.5.0 (release-candidate).

> Please tell me how you want to handle release candidates. Your current code is currently using the 1.9.0 version IIRC (ping @KhalilBellakrid).

The change was integrated into the following screen: 

![screenshot 2019-02-01 at 15 20 35](https://user-images.githubusercontent.com/506592/52128337-f7428f00-2634-11e9-912b-37232a763da6.png)

I removed the `rimraf` stuff as long as the test you were used to do because Live shouldn’t worry about libcore’s data — if you still think you should have a way to check for that, maybe we need to add something in libcore, but I think it’s error-prone that Live make that check.

Also, thanks to @juan-cortes for his wise directions and indications about where to change code to integrate the change about resetting Live! :) 

Please, feel free to comment and open reviews for fixing anything you might dislike.

![](https://phaazon.net/media/uploads/sad_corgi.jpg)