### PR TITLE
Handle source===destination on select recipient for xrp

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     }
   },
   "dependencies": {
+    "@ledgerhq/errors": "^4.35.1",
     "@ledgerhq/hw-app-btc": "^4.34.0",
     "@ledgerhq/hw-app-eth": "^4.32.0",
     "@ledgerhq/hw-app-xrp": "^4.32.0",

--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -129,7 +129,7 @@ function isRecipientValid(currency, recipient) {
 }
 
 // Returns a warning if we detect a non-eip address
-function getRecipientWarning(currency, recipient) {
+function getRecipientWarning(account, recipient) {
   if (!recipient.match(/^0x[0-9a-fA-F]{40}$/)) return null
   const slice = recipient.substr(2)
   const isFullUpper = slice === slice.toUpperCase()
@@ -420,9 +420,9 @@ const EthereumBridge: WalletBridge<Transaction> = {
 
   pullMoreOperations: () => Promise.resolve(a => a), // NOT IMPLEMENTED
 
-  isRecipientValid: (currency, recipient) => Promise.resolve(isRecipientValid(currency, recipient)),
-  getRecipientWarning: (currency, recipient) =>
-    Promise.resolve(getRecipientWarning(currency, recipient)),
+  isRecipientValid: (account, recipient) => Promise.resolve(isRecipientValid(account, recipient)),
+  getRecipientWarning: (account, recipient) =>
+    Promise.resolve(getRecipientWarning(account, recipient)),
 
   createTransaction: () => ({
     amount: BigNumber(0),

--- a/src/bridge/LibcoreBridge.js
+++ b/src/bridge/LibcoreBridge.js
@@ -60,15 +60,15 @@ const EditAdvancedOptions = ({ onChange, value }: EditProps<Transaction>) => (
 
 const recipientValidLRU = LRU({ max: 100 })
 
-const isRecipientValid = (currency, recipient) => {
-  const key = `${currency.id}_${recipient}`
+const isRecipientValid = (account, recipient) => {
+  const key = `${account.currency.id}_${recipient}`
   let promise = recipientValidLRU.get(key)
   if (promise) return promise
   if (!recipient) return Promise.resolve(false)
   promise = libcoreValidAddress
     .send({
       address: recipient,
-      currencyId: currency.id,
+      currencyId: account.currency.id,
     })
     .toPromise()
   recipientValidLRU.set(key, promise)
@@ -83,7 +83,7 @@ const getFeesKey = (a, t) =>
   }`
 
 const getFees = async (a, transaction) => {
-  const isValid = await isRecipientValid(a.currency, transaction.recipient)
+  const isValid = await isRecipientValid(a, transaction.recipient)
   if (!isValid) return null
   const key = getFeesKey(a, transaction)
   let promise = feesLRU.get(key)

--- a/src/bridge/RippleJSBridge.js
+++ b/src/bridge/RippleJSBridge.js
@@ -137,21 +137,18 @@ async function signAndBroadcast({ a, t, deviceId, isCancelled, onSigned, onOpera
   }
 }
 
-function isRecipientValid(recipient, source) {
-  if (source === recipient) {
-    return false
-  }
-
+function isRecipientValid(account, recipient) {
   try {
     bs58check.decode(recipient)
-    return true
+
+    return !(account && account.freshAddress === recipient)
   } catch (e) {
     return false
   }
 }
 
-function getRecipientWarning(recipient, source) {
-  if (source === recipient) {
+function getRecipientWarning(account, recipient) {
+  if (account.freshAddress === recipient) {
     return new InvalidAddressBecauseDestinationIsAlsoSource()
   }
   return null
@@ -282,7 +279,7 @@ const getServerInfo = (map => endpointConfig => {
 })({})
 
 const recipientIsNew = async (endpointConfig, recipient) => {
-  if (!isRecipientValid(recipient)) return false
+  if (!isRecipientValid(null, recipient)) return false
   const api = apiForEndpointConfig(RippleAPI, endpointConfig)
   try {
     await api.connect()
@@ -517,10 +514,9 @@ const RippleJSBridge: WalletBridge<Transaction> = {
 
   pullMoreOperations: () => Promise.resolve(a => a), // FIXME not implemented
 
-  isRecipientValid: (currency, recipient, source) =>
-    Promise.resolve(isRecipientValid(recipient, source)),
-  getRecipientWarning: (currency, recipient, source) =>
-    Promise.resolve(getRecipientWarning(recipient, source)),
+  isRecipientValid: (account, recipient) => Promise.resolve(isRecipientValid(account, recipient)),
+  getRecipientWarning: (account, recipient) =>
+    Promise.resolve(getRecipientWarning(account, recipient)),
 
   createTransaction: () => ({
     amount: BigNumber(0),

--- a/src/bridge/RippleJSBridge.js
+++ b/src/bridge/RippleJSBridge.js
@@ -136,13 +136,24 @@ async function signAndBroadcast({ a, t, deviceId, isCancelled, onSigned, onOpera
   }
 }
 
-function isRecipientValid(recipient) {
+function isRecipientValid(recipient, source) {
+  if (source === recipient) {
+    return false
+  }
+
   try {
     bs58check.decode(recipient)
     return true
   } catch (e) {
     return false
   }
+}
+
+function getRecipientWarning(recipient, source) {
+  if (source === recipient) {
+    return new Error('InvalidAddressBecauseDestinationIsAlsoSource')
+  }
+  return null
 }
 
 function mergeOps(existing: Operation[], newFetched: Operation[]) {
@@ -505,8 +516,10 @@ const RippleJSBridge: WalletBridge<Transaction> = {
 
   pullMoreOperations: () => Promise.resolve(a => a), // FIXME not implemented
 
-  isRecipientValid: (currency, recipient) => Promise.resolve(isRecipientValid(recipient)),
-  getRecipientWarning: () => Promise.resolve(null),
+  isRecipientValid: (currency, recipient, source) =>
+    Promise.resolve(isRecipientValid(recipient, source)),
+  getRecipientWarning: (currency, recipient, source) =>
+    Promise.resolve(getRecipientWarning(recipient, source)),
 
   createTransaction: () => ({
     amount: BigNumber(0),

--- a/src/bridge/RippleJSBridge.js
+++ b/src/bridge/RippleJSBridge.js
@@ -34,6 +34,7 @@ import {
   NotEnoughBalance,
   FeeNotLoaded,
   NotEnoughBalanceBecauseDestinationNotCreated,
+  InvalidAddressBecauseDestinationIsAlsoSource,
 } from '@ledgerhq/errors'
 import type { WalletBridge, EditProps } from './types'
 
@@ -151,7 +152,7 @@ function isRecipientValid(recipient, source) {
 
 function getRecipientWarning(recipient, source) {
   if (source === recipient) {
-    return new Error('InvalidAddressBecauseDestinationIsAlsoSource')
+    return new InvalidAddressBecauseDestinationIsAlsoSource()
   }
   return null
 }

--- a/src/bridge/makeMockBridge.js
+++ b/src/bridge/makeMockBridge.js
@@ -128,7 +128,7 @@ function makeMockBridge(opts?: Opts): WalletBridge<*> {
       }
     },
 
-    isRecipientValid: (currency, recipient) => Promise.resolve(recipient.length > 0),
+    isRecipientValid: (account, recipient) => Promise.resolve(recipient.length > 0),
     getRecipientWarning: () => Promise.resolve(null),
 
     createTransaction: () => ({

--- a/src/bridge/types.js
+++ b/src/bridge/types.js
@@ -52,8 +52,8 @@ export interface WalletBridge<Transaction> {
   // count is user's desired number of ops to pull (but implementation can decide to ignore it or not)
   pullMoreOperations(initialAccount: Account, count: number): Promise<(Account) => Account>;
 
-  isRecipientValid(currency: Currency, recipient: string): Promise<boolean>;
-  getRecipientWarning(currency: Currency, recipient: string): Promise<?Error>;
+  isRecipientValid(currency: Currency, recipient: string, source?: string): Promise<boolean>;
+  getRecipientWarning(currency: Currency, recipient: string, source?: string): Promise<?Error>;
 
   // Related to send funds:
 

--- a/src/bridge/types.js
+++ b/src/bridge/types.js
@@ -52,8 +52,8 @@ export interface WalletBridge<Transaction> {
   // count is user's desired number of ops to pull (but implementation can decide to ignore it or not)
   pullMoreOperations(initialAccount: Account, count: number): Promise<(Account) => Account>;
 
-  isRecipientValid(currency: Currency, recipient: string, source?: string): Promise<boolean>;
-  getRecipientWarning(currency: Currency, recipient: string, source?: string): Promise<?Error>;
+  isRecipientValid(account: Account, recipient: string): Promise<boolean>;
+  getRecipientWarning(account: Account, recipient: string): Promise<?Error>;
 
   // Related to send funds:
 

--- a/src/components/modals/Send/fields/RecipientField.js
+++ b/src/components/modals/Send/fields/RecipientField.js
@@ -53,12 +53,8 @@ class RecipientField<Transaction> extends Component<
     const { account, bridge, transaction } = this.props
     const syncId = ++this.syncId
     const recipient = bridge.getTransactionRecipient(account, transaction)
-    const isValid = await bridge.isRecipientValid(account.currency, recipient, account.freshAddress)
-    const warning = await bridge.getRecipientWarning(
-      account.currency,
-      recipient,
-      account.freshAddress,
-    )
+    const isValid = await bridge.isRecipientValid(account, recipient)
+    const warning = await bridge.getRecipientWarning(account, recipient)
     if (syncId !== this.syncId) return
     if (this.isUnmounted) return
     this.setState({ isValid, warning })
@@ -73,9 +69,7 @@ class RecipientField<Transaction> extends Component<
     if (amount) {
       t = bridge.editTransactionAmount(account, t, amount)
     }
-    const warning = fromQRCode
-      ? await bridge.getRecipientWarning(account.currency, recipient)
-      : null
+    const warning = fromQRCode ? await bridge.getRecipientWarning(account, recipient) : null
     if (this.isUnmounted) return false
     if (warning) {
       // clear the input if field has warning AND has a warning

--- a/src/components/modals/Send/fields/RecipientField.js
+++ b/src/components/modals/Send/fields/RecipientField.js
@@ -53,8 +53,12 @@ class RecipientField<Transaction> extends Component<
     const { account, bridge, transaction } = this.props
     const syncId = ++this.syncId
     const recipient = bridge.getTransactionRecipient(account, transaction)
-    const isValid = await bridge.isRecipientValid(account.currency, recipient)
-    const warning = await bridge.getRecipientWarning(account.currency, recipient)
+    const isValid = await bridge.isRecipientValid(account.currency, recipient, account.freshAddress)
+    const warning = await bridge.getRecipientWarning(
+      account.currency,
+      recipient,
+      account.freshAddress,
+    )
     if (syncId !== this.syncId) return
     if (this.isUnmounted) return
     this.setState({ isValid, warning })
@@ -97,7 +101,7 @@ class RecipientField<Transaction> extends Component<
     const error =
       !value || isValid
         ? QRCodeRefusedReason
-        : new InvalidAddress(null, { currencyName: account.currency.name })
+        : warning || new InvalidAddress(null, { currencyName: account.currency.name })
 
     return (
       <Box flow={1}>

--- a/src/components/modals/Send/steps/01-step-amount.js
+++ b/src/components/modals/Send/steps/01-step-amount.js
@@ -133,7 +133,7 @@ export class StepAmountFooter extends PureComponent<
       const totalSpent = await bridge.getTotalSpent(account, transaction)
       if (syncId !== this.syncId) return
       const isRecipientValid = await bridge.isRecipientValid(
-        account.currency,
+        account,
         bridge.getTransactionRecipient(account, transaction),
       )
       if (syncId !== this.syncId) return

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -901,7 +901,7 @@
       "title": "This is not a valid {{currencyName}} address"
     },
     "InvalidAddressBecauseDestinationIsAlsoSource": {
-      "title": "Destination and source accounts can't be the same"
+      "title": "Recipient address is the same as the sender address"
     },
     "CantOpenDevice": {
       "title": "Oops, couldn’t connect to device",

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -900,6 +900,9 @@
     "InvalidAddress": {
       "title": "This is not a valid {{currencyName}} address"
     },
+    "InvalidAddressBecauseDestinationIsAlsoSource": {
+      "title": "Destination and source accounts can't be the same"
+    },
     "CantOpenDevice": {
       "title": "Oops, couldn’t connect to device",
       "description": "Device detected but connection failed. Please try again or contact us if the problem persists."

--- a/yarn.lock
+++ b/yarn.lock
@@ -1677,10 +1677,10 @@
     camelcase "^5.0.0"
     prettier "^1.13.7"
 
-"@ledgerhq/errors@^4.32.0":
-  version "4.33.7"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.33.7.tgz#b78becd20e8a68f7115ad0986fa357a8adddf6b7"
-  integrity sha512-1vKWcttI5NHpT6rMKKuxWPAjfwDgfgUTf/AyNAT5KXHlhiLvqnA3NDCdNUVadajVNKSa/s1u1ZWKismtbfePzg==
+"@ledgerhq/errors@^4.32.0", "@ledgerhq/errors@^4.35.1":
+  version "4.35.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.35.1.tgz#3f162dc05480e444083b6381bd098df187751633"
+  integrity sha512-2Bo3/NRKyz3ddR07TvZ87VpDJc8fz4+ONLJnhzC0mwIwu+Pxal6SgCBiGtv503oGxkgDuG5PtODZBaehWkGRnQ==
 
 "@ledgerhq/hw-app-btc@^4.32.0":
   version "4.32.0"


### PR DESCRIPTION
Similar to https://github.com/LedgerHQ/ledger-live-mobile/pull/740  it depends on https://github.com/LedgerHQ/ledgerjs/pull/285 being merged and ready so I can use a translated error instead of a generic key.
There are some differences in the desktop implementation of the validation since it doesn't throw an error from but rather return a boolean, then a second method to specify the warning (if I got it right), at any rate, this would be the equivalent.

![image](https://user-images.githubusercontent.com/4631227/52241245-70f7a880-28d3-11e9-880f-11fc3fad733d.png)
