### PR TITLE
Add NIX Support

### DIFF
--- a/src/config/cryptocurrencies.js
+++ b/src/config/cryptocurrencies.js
@@ -30,6 +30,7 @@ const supported: CryptoCurrencyIds[] = [
   'clubcoin',
   'decred',
   'bitcoin_testnet',
+  'nix',
 ]
 
 export const listCryptoCurrencies = memoize((withDevCrypto?: boolean) =>


### PR DESCRIPTION
NIX is added to the list of supported cryptocurrencies.

### Type
Feature

### Context
Since all the support for nix in `ledger-live-common` is complete and `lib-ledger-core` is pending(https://github.com/LedgerHQ/lib-ledger-core/pull/94). With lib-ledger-core pulled, it will be safe to add nix to the list of supported cryptocurrencies

### Parts of the app affected / Test plan
No current behavior in the app has been modified since only the bitcoin-like behavior is complete, nix behaves exactly as bitcoin.
