### PR TITLE
Fixes LL-807

### DIFF
--- a/src/commands/libcoreSignAndBroadcast.js
+++ b/src/commands/libcoreSignAndBroadcast.js
@@ -129,7 +129,7 @@ async function signTransaction({
       const hexPreviousTransaction = Buffer.from(rawPreviousTransaction).toString('hex')
       const previousTransaction = hwApp.splitTransaction(
         hexPreviousTransaction,
-        true, // set to true allow both segwit AND non-segwit
+        currency.supportsSegwit,
         hasTimestamp,
         hasExtraData,
         additionals,


### PR DESCRIPTION
The previous code was actually incorrect, we also proved the fix works on mobile, as we already have that code from the start: https://github.com/LedgerHQ/ledger-live-mobile/blob/ebc9f9af8a519afa56911f0c1d888b349eb545af/src/libcore/signAndBroadcast.js#L143

**Technically, it should finally fixes some ZEC errors that shows as "getVarint error".**

### Type

bugfixes

### Context

LL-807

### Parts of the app affected / Test plan

everything still works. emphasis on the sign and broadcast of transactions for BTC & derivates.