### PR TITLE
Fix app install/uninstall modal alignment

### DIFF
--- a/src/components/ManagerPage/AppsList.js
+++ b/src/components/ManagerPage/AppsList.js
@@ -205,7 +205,7 @@ class AppsList extends PureComponent<Props, State> {
                     </Box>
                   )}
                 </ModalTitle>
-                <ModalContent>
+                <ModalContent align="center">
                   <Text ff="Museo Sans|Regular" fontSize={6} color="dark">
                     {t(`manager.apps.${mode}`, { app })}
                   </Text>


### PR DESCRIPTION
This misalignment was triggering.

before | after
--|--
![2019-02-06_22-32-09_1018x620](https://user-images.githubusercontent.com/315259/52375153-45a1c480-2a5f-11e9-88d1-3bebd9474ab1.png) | ![2019-02-06_22-31-36_1015x616](https://user-images.githubusercontent.com/315259/52375154-463a5b00-2a5f-11e9-8af8-9826f1ba54de.png)


:smile: 