### PR TITLE
Adds the developer mode to exported data

### DIFF
--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -244,10 +244,12 @@ export const exportSettingsSelector = createSelector(
   counterValueCurrencySelector,
   counterValueExchangeSelector,
   state => state.settings.currenciesSettings,
-  (counterValueCurrency, counterValueExchange, currenciesSettings) => ({
+  developerModeSelector,
+  (counterValueCurrency, counterValueExchange, currenciesSettings, developerModeEnabled) => ({
     counterValue: counterValueCurrency.ticker,
     counterValueExchange,
     currenciesSettings,
+    developerModeEnabled,
   }),
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13495,17 +13495,7 @@ react-treebeard@^2.1.0:
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
 
-react@*, react@^16.2.0:
-  version "16.6.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.6.1.tgz#ee2aef4f0a09e494594882029821049772f915fe"
-  integrity sha512-OtawJThYlvRgm9BXK+xTL7BIlDx8vv21j+fbQDjRRUyok6y7NyjlweGorielTahLZHYIdKUoK2Dp9ByVWuMqxw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.11.0"
-
-react@^16.6.3:
+react@*, react@^16.2.0, react@^16.6.3:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
   integrity sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==
@@ -14423,14 +14413,6 @@ sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
-
-scheduler@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.0.tgz#def1f1bfa6550cc57981a87106e65e8aea41a6b5"
-  integrity sha512-MAYbBfmiEHxF0W+c4CxMpEqMYK+rYF584VP/qMKSiHM6lTkBKKYOJaDiSILpJHla6hBOsVd6GucPL46o2Uq3sg==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.11.2:
   version "0.11.3"


### PR DESCRIPTION
Depends on https://github.com/LedgerHQ/ledger-live-common/pull/150 being merged and a version bump, but this allows the developer mode setting to be imported on mobile (no change needed on that end).