### PR TITLE
Set nLockTime for Komodo transactions

### DIFF
--- a/src/commands/libcoreSignAndBroadcast.js
+++ b/src/commands/libcoreSignAndBroadcast.js
@@ -170,7 +170,7 @@ async function signTransaction({
   // should be `transaction.getLockTime()` as soon as lock time is
   // handled by libcore (actually: it always returns a default value
   // and that caused issue with zcash (see #904))
-  let lockTime = undefined
+  let lockTime;
 
   // Set lockTime for Komodo to enable reward claiming on UTXOs created by
   // Ledger Live. We should only set this if the currency is Komodo and

--- a/src/commands/libcoreSignAndBroadcast.js
+++ b/src/commands/libcoreSignAndBroadcast.js
@@ -170,14 +170,14 @@ async function signTransaction({
   // should be `transaction.getLockTime()` as soon as lock time is
   // handled by libcore (actually: it always returns a default value
   // and that caused issue with zcash (see #904))
-  let lockTime;
+  let lockTime
 
   // Set lockTime for Komodo to enable reward claiming on UTXOs created by
   // Ledger Live. We should only set this if the currency is Komodo and
   // lockTime isn't already defined.
   if (currency.id === 'komodo' && lockTime === undefined) {
-    const unixtime = Math.floor(Date.now() / 1000);
-    lockTime = (unixtime - 777);
+    const unixtime = Math.floor(Date.now() / 1000)
+    lockTime = unixtime - 777
   }
 
   const signedTransaction = await hwApp.createPaymentTransactionNew(

--- a/src/commands/libcoreSignAndBroadcast.js
+++ b/src/commands/libcoreSignAndBroadcast.js
@@ -170,7 +170,15 @@ async function signTransaction({
   // should be `transaction.getLockTime()` as soon as lock time is
   // handled by libcore (actually: it always returns a default value
   // and that caused issue with zcash (see #904))
-  const lockTime = undefined
+  let lockTime = undefined
+
+  // Set lockTime for Komodo to enable reward claiming on UTXOs created by
+  // Ledger Live. We should only set this if the currency is Komodo and
+  // lockTime isn't already defined.
+  if (currency.id === 'komodo' && lockTime === undefined) {
+    const unixtime = Math.floor(Date.now() / 1000);
+    lockTime = (unixtime - 777);
+  }
 
   const signedTransaction = await hwApp.createPaymentTransactionNew(
     inputs,


### PR DESCRIPTION
This PR sets nLockTime to a value slightly in the past for Komodo transactions to enable reward claiming on UTXOs created by Ledger Live.

I'm aware you don't want to support the actual claim functionality inside Ledger Live, that's why we built our Ledger reward claiming app as an external web app (https://github.com/atomiclabs/ledger-kmd-reward-claim). However, the only requirement for a UTXO to be able to claim interest is that it has nLockTime set.

All Komodo wallets set nLockTime to a value slightly in the past for this reason. (It's actually a good idea to always set nLockTime for other reasons too https://bitcoin.stackexchange.com/a/48385/90269). But due to the fact that Ledger Live doesn't set nLockTime, as soon as the users spends a UTXO via Ledger Live, they can't earn any rewards on their change UTXO.

### Type

Feature

### Context

https://github.com/LedgerHQ/ledger-app-btc/pull/84

### Parts of the app affected / Test plan

Only Komodo transactions are affected. Currently, Komodo transactions don't have nLockTime set. If you test this PR and make a Komodo transaction, you'll see nLockTime is now set to a value slightly in the past (`unixtime - 777`).

It wouldn't be a bad idea to do this for all currencies, not just Komodo (https://bitcoin.stackexchange.com/a/48385/90269). But I've limited it to just Komodo for this PR to avoid making any decisions for you.