### PR TITLE
Fixes LL-1090

### DIFF
--- a/src/components/SettingsPage/sections/CurrencyRows.js
+++ b/src/components/SettingsPage/sections/CurrencyRows.js
@@ -56,7 +56,7 @@ class CurrencyRows extends PureComponent<Props> {
   }
 
   render() {
-    const { currency, t, currencySettings } = this.props
+    const { currency, t, settings, currencySettings } = this.props
     const { confirmationsNb, exchange } = currencySettings
     const defaults = currencySettingsDefaults(currency)
     return (
@@ -67,7 +67,8 @@ class CurrencyRows extends PureComponent<Props> {
               ticker: currency.ticker,
             })}
             desc={t('settings.currencies.exchangeDesc', {
-              currencyName: currency.name,
+              ticker: currency.ticker,
+              fiat: settings.counterValue,
             })}
           >
             <ExchangeSelect

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -389,7 +389,7 @@
     "currencies": {
       "desc": "Select a crypto asset to edit its settings.",
       "exchange": "Rate provider ({{ticker}} → BTC)",
-      "exchangeDesc": "Choose the provider of the exchange rate from {{currencyName}} to Bitcoin, used to estimate the value of your crypto assets ({{currencyName}} → BTC → {{fiat}}).",
+      "exchangeDesc": "Choose the provider of the exchange rate from {{currencyName}} to Bitcoin, used to estimate the value of your crypto assets ({{ticker}} → BTC → {{fiat}}).",
       "confirmationsNb": "Number of confirmations",
       "confirmationsNbDesc": "Set the number of network confirmations for a transaction to be marked as confirmed."
     },


### PR DESCRIPTION
Fixes a glitch that was no longer showing the correct mapping in the Currency Settings > Rate Provider.

It was displaying `Decred -> BTC ->` (empty).

now it will display `DCR -> BTC -> USD`

<img width="550" alt="capture d ecran 2019-02-26 a 09 30 07" src="https://user-images.githubusercontent.com/211411/53398184-4a480180-39a9-11e9-9e57-904bea8cb6f9.png">

### Type

Bug

### Context

LL-1090

### Parts of the app affected / Test plan

settings of any currency other than bitcoin. rate provider row.