### PR TITLE
LL-1114 Duplicate banners + extras: Repair modal, Reset modal

### DIFF
--- a/src/components/AccountPage/index.js
+++ b/src/components/AccountPage/index.js
@@ -28,6 +28,7 @@ import AccountHeader from './AccountHeader'
 import AccountHeaderActions from './AccountHeaderActions'
 import AccountBalanceSummaryHeader from './AccountBalanceSummaryHeader'
 import EmptyStateAccount from './EmptyStateAccount'
+import { SeparatorBar } from '../DashboardPage'
 
 const mapStateToProps = (state, props) => ({
   account: accountSelector(state, { accountId: props.match.params.id }),
@@ -75,7 +76,7 @@ class AccountPage extends PureComponent<Props> {
           currency={account.currency.id}
           operationsLength={account.operations.length}
         />
-
+        <SeparatorBar />
         <SyncOneAccountOnMount priority={10} accountId={account.id} />
 
         <Box horizontal mb={5} flow={4}>

--- a/src/components/CurrenciesStatusBanner.js
+++ b/src/components/CurrenciesStatusBanner.js
@@ -103,7 +103,7 @@ class CurrenciesStatusBanner extends PureComponent<Props> {
     return (
       <Box flow={2} style={styles.container}>
         {filtered.map(r => (
-          <BannerItem key={`{r.id}_${r.nonce}`} t={t} item={r} onItemDismiss={this.dismiss} />
+          <BannerItem key={`${r.id}_${r.nonce}`} t={t} item={r} onItemDismiss={this.dismiss} />
         ))}
       </Box>
     )

--- a/src/components/DashboardPage/index.js
+++ b/src/components/DashboardPage/index.js
@@ -173,7 +173,7 @@ const TopBannerContainer = styled.div`
   }
 `
 // If no banners are present, the SeparatorBar appears
-const SeparatorBar = styled.div`
+export const SeparatorBar = styled.div`
   height: 1px;
   border-bottom: 1px solid ${p => p.theme.colors.fog};
   margin-bottom: 15px;

--- a/src/components/IsUnlocked.js
+++ b/src/components/IsUnlocked.js
@@ -194,6 +194,7 @@ class IsUnlocked extends Component<Props, State> {
           <ConfirmModal
             analyticsName="HardReset"
             isDanger
+            centered
             isLoading={isHardResetting}
             isOpened={isHardResetModalOpened}
             onClose={this.handleCloseHardResetModal}

--- a/src/components/base/Modal/RepairModal.js
+++ b/src/components/base/Modal/RepairModal.js
@@ -186,6 +186,7 @@ class RepairModal extends PureComponent<Props, *> {
         <TrackPage category="Modal" name={analyticsName} />
         <ModalBody
           title={title}
+          noScroll
           render={() => (
             <Box>
               {error ? (

--- a/src/reducers/currenciesStatus.js
+++ b/src/reducers/currenciesStatus.js
@@ -43,18 +43,20 @@ export const fetchCurrenciesStatus = () => async (dispatch: *) => {
       url: process.env.LL_STATUS_ENDPOINT || urls.currenciesStatus,
     })
 
-    const terminatedCurrencies = listCryptoCurrencies(true, true).map(coin => ({
-      id: coin.id,
-      nonce: 98,
-      message: (
-        <Trans
-          i18nKey="banners.genericTerminatedCrypto"
-          values={{ coinName: coin.name }}
-          parent="div"
-        />
-      ),
-      link: (coin.terminated && coin.terminated.link) || '#',
-    }))
+    const terminatedCurrencies = listCryptoCurrencies(true, true)
+      .filter(coin => !data.find(c => c.id === coin.id))
+      .map(coin => ({
+        id: coin.id,
+        nonce: 98,
+        message: (
+          <Trans
+            i18nKey="banners.genericTerminatedCrypto"
+            values={{ coinName: coin.name }}
+            parent="div"
+          />
+        ),
+        link: (coin.terminated && coin.terminated.link) || '#',
+      }))
 
     if (Array.isArray(data)) {
       dispatch(setCurrenciesStatus(data.concat(terminatedCurrencies)))


### PR DESCRIPTION
~Without being able to add accounts for `hcash` and `posw` to test this currently (the explorers reject the request) all I could find was this broken syntax for the banner id, perhaps it somehow made the banners act up~

@Arnaud97234  provided me with a data file containing a few of the cancelled accounts, this allowed me to pinpoint that the banners are in fact two locals (terminated accounts) and two remote hsm warnings that happened to have the same texts. By filtering them like this we should only have one, prioritising the HSM one.

Also added some polishes to:
- Repair modal, to allow the list to overflow
- Centered the reset modal from a locked screen
- Added a separator to the accounts page, but this is temporary since the separator should be in the header and not in the content so as to stay visible when scrolling. I will address that on a separate pr.
