### PR TITLE
LL-1132 Remove footer for modals with renderFooter resolving to falsey

### DIFF
--- a/src/components/base/Modal/ModalBody.js
+++ b/src/components/base/Modal/ModalBody.js
@@ -62,6 +62,9 @@ class ModalBody extends PureComponent<Props, State> {
       opacity: animGradient,
     }
 
+    // For `renderFooter` returning falsy values, we need to resolve first.
+    const renderedFooter = renderFooter && renderFooter(renderProps)
+
     return (
       <Fragment>
         <ModalHeader onBack={onBack} onClose={onClose}>
@@ -78,7 +81,7 @@ class ModalBody extends PureComponent<Props, State> {
         <div style={GRADIENT_WRAPPER_STYLE}>
           <Animated.div style={gradientStyle} />
         </div>
-        {renderFooter && <ModalFooter>{renderFooter(renderProps)}</ModalFooter>}
+        {renderedFooter && <ModalFooter>{renderedFooter}</ModalFooter>}
       </Fragment>
     )
   }


### PR DESCRIPTION
The check was being done against passing or not a render function, since some models are using a passed function that resolves to a falsey value, we need to take that into account to render or not the footer. All that's ok.

My concern here comes with the fact that we can't close the repair modal once open. 
**Is this expected?**

>Also note we need https://github.com/LedgerHQ/ledger-live-desktop/pull/1839 to fix the dropdown glitch.

![image](https://user-images.githubusercontent.com/4631227/53878973-90d2d700-400d-11e9-900e-30c0383ea5cb.png)
