### PR TITLE
Removed double gradient from notes

### DIFF
--- a/src/components/modals/ReleaseNotes/ReleaseNotesBody.js
+++ b/src/components/modals/ReleaseNotes/ReleaseNotesBody.js
@@ -9,7 +9,6 @@ import Button from 'components/base/Button'
 import Box from 'components/base/Box'
 import Text from 'components/base/Text'
 import Spinner from 'components/base/Spinner'
-import GradientBox from 'components/GradientBox'
 import TranslatedError from 'components/TranslatedError'
 import TrackPage from 'analytics/TrackPage'
 import Markdown, { Notes } from 'components/base/Markdown'
@@ -118,12 +117,9 @@ class ReleaseNotesBody extends PureComponent<Props, State> {
         onClose={onClose}
         title={t('releaseNotes.title')}
         render={() => (
-          <Box relative style={{ height: 500 }} px={0} pb={0}>
+          <Box relative style={{ height: 500 }} px={5} pb={8}>
             <TrackPage category="Modal" name="ReleaseNotes" />
-            <Box px={5} pb={8}>
-              {this.renderContent()}
-            </Box>
-            <GradientBox />
+            {this.renderContent()}
           </Box>
         )}
         renderFooter={() => (


### PR DESCRIPTION
We had a vestigial gradientBox inside the release notes' body, and another one in the enclosing modal. 
![mar-08-2019 10-25-27](https://user-images.githubusercontent.com/4631227/54020674-973c8c80-418e-11e9-821c-d5933281683a.gif)
