### PR TITLE
LL-1128 Made the operation details amount and countervalue selectable

### DIFF
--- a/src/components/modals/OperationDetails.js
+++ b/src/components/modals/OperationDetails.js
@@ -145,7 +145,7 @@ const OperationDetails = connect(mapStateToProps)((props: Props) => {
               withTooltip={false}
             />
             <Box my={4} alignItems="center">
-              <Box>
+              <Box selectable>
                 <FormattedVal
                   color={amount.isNegative() ? 'smoke' : undefined}
                   unit={unit}
@@ -156,7 +156,7 @@ const OperationDetails = connect(mapStateToProps)((props: Props) => {
                   disableRounding
                 />
               </Box>
-              <Box mt={1}>
+              <Box mt={1} selectable>
                 <CounterValue
                   color="grey"
                   fontSize={5}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/54295572-98692180-45b3-11e9-82a6-027e85e2f8b1.png)

### How to test?
Operation details should allow the individual selection of both the amount and the countervalue amount.