### PR TITLE
Fixes broken Copy component + hover styles

### DIFF
--- a/src/components/modals/OperationDetails.js
+++ b/src/components/modals/OperationDetails.js
@@ -12,23 +12,24 @@ import uniq from 'lodash/uniq'
 
 import TrackPage from 'analytics/TrackPage'
 import type { Account, Operation } from '@ledgerhq/live-common/lib/types'
+import { colors } from 'styles/theme'
+
 import type { T, CurrencySettings } from 'types/common'
-
 import { MODAL_OPERATION_DETAILS } from 'config/constants'
-import { getMarketColor } from 'styles/helpers'
 
+import { getMarketColor } from 'styles/helpers'
 import Box from 'components/base/Box'
 import Button from 'components/base/Button'
 import Bar from 'components/base/Bar'
 import FormattedVal from 'components/base/FormattedVal'
 import Modal, { ModalBody } from 'components/base/Modal'
 import Text from 'components/base/Text'
-import CopyWithFeedback from 'components/base/CopyWithFeedback'
 
+import CopyWithFeedback from 'components/base/CopyWithFeedback'
 import { createStructuredSelector, createSelector } from 'reselect'
 import { accountSelector } from 'reducers/accounts'
-import { currencySettingsForAccountSelector, marketIndicatorSelector } from 'reducers/settings'
 
+import { currencySettingsForAccountSelector, marketIndicatorSelector } from 'reducers/settings'
 import IconChevronRight from 'icons/ChevronRight'
 import CounterValue from 'components/CounterValue'
 import ConfirmationCheck from 'components/OperationsList/ConfirmationCheck'
@@ -42,6 +43,11 @@ const OpDetailsTitle = styled(Box).attrs({
   mb: 1,
 })`
   letter-spacing: 2px;
+`
+export const Address = styled(Text).attrs({})`
+  flex-wrap: wrap;
+  padding: 3px;
+  width: fit-content;
 `
 
 export const GradientHover = styled(Box).attrs({
@@ -69,6 +75,14 @@ const OpDetailsData = styled(Box).attrs({
 
   &:hover ${GradientHover} {
     display: flex;
+    & > * {
+      cursor: pointer;
+    }
+  }
+
+  &:hover ${Address} {
+    background: ${colors.pillActiveBackground};
+    color: ${colors.wallet};
   }
 `
 
@@ -294,7 +308,7 @@ export class DataList extends Component<{ lines: string[], t: T }, *> {
       <Box>
         {(shouldShowMore ? lines.slice(0, numToShow) : lines).map(line => (
           <OpDetailsData key={line}>
-            {line}
+            <Address>{line}</Address>
             <GradientHover>
               <CopyWithFeedback text={line} />
             </GradientHover>
@@ -310,7 +324,14 @@ export class DataList extends Component<{ lines: string[], t: T }, *> {
             </Box>
           )}
         {showMore &&
-          lines.slice(numToShow).map(line => <OpDetailsData key={line}>{line}</OpDetailsData>)}
+          lines.slice(numToShow).map(line => (
+            <OpDetailsData key={line}>
+              <Address>{line}</Address>
+              <GradientHover>
+                <CopyWithFeedback text={line} />
+              </GradientHover>
+            </OpDetailsData>
+          ))}
         {shouldShowMore &&
           showMore && (
             <Box onClick={this.onClick} py={1}>

--- a/src/components/modals/OperationDetails.js
+++ b/src/components/modals/OperationDetails.js
@@ -45,8 +45,10 @@ const OpDetailsTitle = styled(Box).attrs({
   letter-spacing: 2px;
 `
 export const Address = styled(Text).attrs({})`
+  margin-left: -4px;
+  border-radius: 4px;
   flex-wrap: wrap;
-  padding: 3px;
+  padding: 4px;
   width: fit-content;
 `
 
@@ -83,6 +85,7 @@ const OpDetailsData = styled(Box).attrs({
   &:hover ${Address} {
     background: ${colors.pillActiveBackground};
     color: ${colors.wallet};
+    font-weight: 400;
   }
 `
 

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { rgba } from './helpers'
+
 export const space = [0, 5, 10, 15, 20, 30, 40, 50, 70]
 export const fontSizes = [8, 9, 10, 12, 13, 16, 18, 22, 32]
 export const radii = [0, 4]
@@ -81,6 +83,7 @@ export const colors = {
   positiveGreen: '#66be54',
   smoke: '#666666',
   wallet: '#6490f1',
+  pillActiveBackground: rgba('#6490f1', 0.1),
   white: '#ffffff',
 
   // market indicator


### PR DESCRIPTION

![youhoverwithstylenowyes](https://user-images.githubusercontent.com/4631227/54629625-45daaa00-4a78-11e9-894b-d270640bd9fb.gif)
Rows after the second one for operation details were not getting the copy component, also added some styles for hover to highlight the row being copied.