### PR TITLE
Show menu on top for bitcoin fees

### DIFF
--- a/src/components/FeesField/BitcoinKind.js
+++ b/src/components/FeesField/BitcoinKind.js
@@ -137,7 +137,13 @@ class FeesField extends Component<OwnProps, State> {
 
     return (
       <GenericContainer>
-        <Select width={156} options={items} value={selectedItem} onChange={this.onSelectChange} />
+        <Select
+          menuPlacement="top"
+          width={156}
+          options={items}
+          value={selectedItem}
+          onChange={this.onSelectChange}
+        />
         <InputCurrency
           ref={this.input}
           defaultUnit={satoshi}


### PR DESCRIPTION
Makes the menu dropdown display on top for the fees select.
![image](https://user-images.githubusercontent.com/4631227/55146693-5b6d6500-5145-11e9-8a9c-1b6f2374d86a.png)


### Type

UI Polish

### Parts of the app affected / Test plan

Send flow, fees field for bitcoin family