### PR TITLE
Reset user data on reinstall

### DIFF
--- a/src/commands/autoUpdate.js
+++ b/src/commands/autoUpdate.js
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs'
 import { UPDATE_CHECK_IGNORE } from 'config/constants'
 // import createElectronAppUpdater from 'main/updater/createElectronAppUpdater'
 import type { UpdateStatus } from 'components/Updater/UpdaterContext'
+import { deleteInstallFlag } from '../helpers/reinstallCleanup'
 
 type Input = {}
 type Result = {
@@ -32,6 +33,8 @@ const cmd: Command<Input, Result> = createCommand('main:autoUpdate', () =>
         // await appUpdater.verify()
         sendStatus('check-success')
       } catch (err) {
+        // Next launch will update the executable?
+        deleteInstallFlag()
         // don't throw if the check fail for now. it's a white bullet.
         if (UPDATE_CHECK_IGNORE) {
           // TODO: track the error

--- a/src/components/FeesField/BitcoinKind.js
+++ b/src/components/FeesField/BitcoinKind.js
@@ -157,8 +157,8 @@ class FeesField extends Component<OwnProps, State> {
             !feePerByte && error
               ? new FeeNotLoaded()
               : feePerByte && feePerByte.isZero()
-                ? new FeeRequired()
-                : null
+              ? new FeeRequired()
+              : null
           }
           renderRight={
             <InputRight>{t('send.steps.amount.unitPerByte', { unit: satoshi.code })}</InputRight>

--- a/src/components/PartnersPage/index.js
+++ b/src/components/PartnersPage/index.js
@@ -24,7 +24,11 @@ class PartnersPage extends PureComponent<Props> {
         <Box ff="Museo Sans|Light" fontSize={5} mb={5}>
           {t('partners.desc')}
         </Box>
-        <Box flow={3}>{partners.map(card => <PartnerCard key={card.id} t={t} card={card} />)}</Box>
+        <Box flow={3}>
+          {partners.map(card => (
+            <PartnerCard key={card.id} t={t} card={card} />
+          ))}
+        </Box>
       </Box>
     )
   }

--- a/src/components/SettingsPage/index.js
+++ b/src/components/SettingsPage/index.js
@@ -107,7 +107,9 @@ class SettingsPage extends PureComponent<Props, State> {
         </Box>
         <Pills mb={4} items={items} activeKey={tab.key} onChange={this.handleChangeTab} />
         <Switch>
-          {items.map(i => <Route key={i.key} path={`${match.url}/${i.key}`} component={i.value} />)}
+          {items.map(i => (
+            <Route key={i.key} path={`${match.url}/${i.key}`} component={i.value} />
+          ))}
           <Route component={defaultItem.value} />
         </Switch>
       </Box>

--- a/src/components/SettingsPage/sections/Export.js
+++ b/src/components/SettingsPage/sections/Export.js
@@ -125,7 +125,9 @@ class SectionExport extends PureComponent<Props, State> {
               </Text>
             </Box>
             <Box style={{ width: 330 }}>
-              {stepsImportMobile.map(step => <BulletRow key={step.key} step={step} />)}
+              {stepsImportMobile.map(step => (
+                <BulletRow key={step.key} step={step} />
+              ))}
             </Box>
           </Box>
         )}

--- a/src/helpers/countervalues.js
+++ b/src/helpers/countervalues.js
@@ -27,11 +27,13 @@ const pairsSelector = createSelector(
       : [
           { from: intermediaryCurrency, to: counterValueCurrency, exchange: counterValueExchange },
         ].concat(
-          currencies.filter(c => c.ticker !== intermediaryCurrency.ticker).map(currency => ({
-            from: currency,
-            to: intermediaryCurrency,
-            exchange: currencySettingsSelector(state, { currency }).exchange,
-          })),
+          currencies
+            .filter(c => c.ticker !== intermediaryCurrency.ticker)
+            .map(currency => ({
+              from: currency,
+              to: intermediaryCurrency,
+              exchange: currencySettingsSelector(state, { currency }).exchange,
+            })),
         ),
 )
 

--- a/src/helpers/reinstallCleanup.js
+++ b/src/helpers/reinstallCleanup.js
@@ -1,0 +1,56 @@
+// @flow
+
+import fs from 'fs'
+import { app } from 'electron'
+import path from 'path'
+import { hardReset } from 'helpers/reset'
+
+export const checkFlag = async () => {
+  if (__PROD__) {
+    try {
+      await fs.stat(app.getPath('exe'), async (err, stats) => {
+        const executableCreationDate = stats.ctime
+        const userData = app.getPath('userData')
+        const dataFolder = fs.readdirSync(userData)
+        let flag
+        let kill = false
+
+        dataFolder.filter(file => {
+          if (file.match(/\d+\.flag/g)) {
+            flag = true
+            const date = new Date(+file.slice(0, -5))
+            if (date - executableCreationDate) {
+              // TODO Currently triggers reset / maybe ask user?
+              kill = true
+              fs.unlink(path.resolve(userData, file))
+              fs.writeFileSync(
+                path.resolve(userData, `${executableCreationDate.getTime()}.flag`),
+                '',
+                'utf-8',
+              )
+            }
+          }
+          return false
+        })
+
+        if (kill) await hardReset()
+        if (flag) return
+
+        fs.writeFileSync(
+          path.resolve(userData, `${executableCreationDate.getTime()}.flag`),
+          '',
+          'utf-8',
+        )
+      })
+    } catch (e) {
+      //
+    }
+  }
+}
+
+export const deleteInstallFlag = () => {
+  const userData = app.getPath('userData')
+  fs.readdirSync(userData)
+    .filter(f => /\d+\.flag/g.test(f))
+    .map(f => fs.unlinkSync(path.resolve(userData, f)))
+}

--- a/src/main/app.js
+++ b/src/main/app.js
@@ -1,7 +1,6 @@
 // @flow
 
 import 'helpers/live-common-setup'
-
 import { app, BrowserWindow, Menu, screen } from 'electron'
 import debounce from 'lodash/debounce'
 import {
@@ -17,6 +16,7 @@ import { i } from 'helpers/staticPath'
 import resolveUserDataDirectory from 'helpers/resolveUserDataDirectory'
 
 import { terminateAllTheThings } from './terminator'
+import { checkFlag } from '../helpers/reinstallCleanup'
 
 // necessary to prevent win from being garbage collected
 let mainWindow = null
@@ -176,6 +176,9 @@ app.on('ready', async () => {
   Menu.setApplicationMenu(menu)
 
   mainWindow = await createMainWindow()
+
+  await checkFlag()
+
   await clearSessionCache(mainWindow.webContents.session)
 })
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,4 +1,5 @@
 // @flow
+require('babel-polyfill')
 
 process.setMaxListeners(0)
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/55159337-0b040080-5161-11e9-8c3f-c02fb439a3c4.png)

### Type

Improvement

### Context

n/a

### Parts of the app affected / Test plan

For production builds only, this creates a flag that, on a detected reinstall of a different executable, will delete the userdata to work on a clean installation. Relaunching the app from the same executable should not affect the user data, however, 

### Known issues
- It will sometimes cause an internetal crash that I haven't had time to locate, maybe part of the dist script, or something.

### TODO

- [x] Create a cool looking diagram
- [x] MacOS testing (manual flag altering)
- [ ] Windows testing
- [ ] Linux testing
- [ ] Testing on a real update if it actually deletes the flag file
- [ ] Cleanup the check code, it's messy