### PR TITLE
feat: LL-1004 Use estimage-gas-limit to prefill gas

### DIFF
--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -460,6 +460,7 @@ const EthereumBridge: WalletBridge<Transaction> = {
     t.amount.isGreaterThan(0) &&
     t.gasPrice &&
     t.gasPrice.isGreaterThan(0) &&
+    t.gasLimit &&
     t.gasLimit.isGreaterThan(0)
       ? Promise.resolve(t.amount.plus(t.gasPrice.times(t.gasLimit)))
       : Promise.resolve(BigNumber(0)),
@@ -498,6 +499,11 @@ const EthereumBridge: WalletBridge<Transaction> = {
       ),
     ),
   }),
+
+  estimateGasLimit: (account, address) => {
+    const api = apiForCurrency(account.currency)
+    return api.estimateGasLimitForERC20(address)
+  },
 }
 
 export default EthereumBridge

--- a/src/bridge/types.js
+++ b/src/bridge/types.js
@@ -113,4 +113,5 @@ export interface WalletBridge<Transaction> {
 
   getDefaultEndpointConfig?: () => string;
   validateEndpointConfig?: (endpointConfig: string) => Promise<void>;
+  estimateGasLimit?: (account: Account, address: string) => Promise<number>;
 }


### PR DESCRIPTION
When using the v3 explorer for Ethereum get the estimated gas limit from the servers instead of using the hardcoded 21k. This will graciously fallback to the 21k for v2. Note that we will need to set the `USE_EXPERIMENTAL_EXPLORERS` flag programmatically for this to work, or flick the switch in the experimental features screen once it's available.

![v2v3gastimate](https://user-images.githubusercontent.com/4631227/55329941-1ec8a300-5490-11e9-8f89-bef81784b345.gif)

### Type

Feature

### Blocked by

https://github.com/LedgerHQ/ledger-live-common/pull/191

Needs to have `live-common` bumped with the code from that pr

### Parts of the app affected / Test plan

Send flow, for Ethereum, try using a contract vs non-contract address, see if the gas limit changes.