### PR TITLE
Fixes the implementation of the Ledger Core RNG’s interface.

### DIFF
--- a/src/helpers/init-libcore.js
+++ b/src/helpers/init-libcore.js
@@ -131,7 +131,7 @@ const NJSLogPrinter = new lib.NJSLogPrinter({
 })
 
 const NJSRandomNumberGenerator = new lib.NJSRandomNumberGenerator({
-  getRandomBytes: size => crypto.randomBytes(size),
+  getRandomBytes: size => Array.from(Buffer.from(crypto.randomBytes(size), 'hex')),
   getRandomInt: () => Math.random() * MAX_RANDOM,
   getRandomLong: () => Math.random() * MAX_RANDOM * MAX_RANDOM,
 })


### PR DESCRIPTION
This fixes LLC-196. A proper fix has also been pushed to Ledger Core to
have a better error message for when such a tricky incorrectly
implemented interface is detected. See [#194](https://github.com/LedgerHQ/lib-ledger-core/pull/194) for a PR in Ledger Core for a pre-emptive bug fix (you haven’t come across it yet but my unit tests found it). I also added a way to detect the RNG issue.