### PR TITLE
feat: LL-1077 Add failsafe to the send flow when fees are too high

### DIFF
--- a/src/components/base/Modal/ConfirmModal.js
+++ b/src/components/base/Modal/ConfirmModal.js
@@ -17,7 +17,7 @@ type Props = {
   isDanger: boolean,
   title: string,
   subTitle?: string,
-  desc: string,
+  desc?: string,
   renderIcon?: Function,
   confirmText?: string,
   cancelText?: string,
@@ -30,6 +30,7 @@ type Props = {
   cancellable?: boolean,
   centered?: boolean,
   children?: *,
+  narrow?: boolean,
 }
 
 class ConfirmModal extends PureComponent<Props> {
@@ -52,13 +53,14 @@ class ConfirmModal extends PureComponent<Props> {
       analyticsName,
       centered,
       children,
+      narrow,
       ...props
     } = this.props
 
     const realConfirmText = confirmText || t('common.confirm')
     const realCancelText = cancelText || t('common.cancel')
     return (
-      <Modal isOpened={isOpened} centered={centered}>
+      <Modal isOpened={isOpened} centered={centered} width={narrow && 380}>
         <ModalBody
           preventBackdropClick={isLoading}
           {...props}
@@ -90,9 +92,11 @@ class ConfirmModal extends PureComponent<Props> {
                   {renderIcon()}
                 </Box>
               )}
-              <Box ff="Open Sans" color="smoke" fontSize={4} textAlign="center">
-                {desc}
-              </Box>
+              {desc && (
+                <Box ff="Open Sans" color="smoke" fontSize={4} textAlign="center">
+                  {desc}
+                </Box>
+              )}
               {children}
             </Box>
           )}

--- a/src/components/base/Modal/index.js
+++ b/src/components/base/Modal/index.js
@@ -59,6 +59,7 @@ type Props = {
   render?: RenderProps => any,
   data?: any,
   preventBackdropClick?: boolean,
+  width?: number,
 
   name?: string, // eslint-disable-line
   onBeforeOpen?: ({ data: * }) => *, // eslint-disable-line
@@ -146,7 +147,7 @@ class Modal extends PureComponent<Props, State> {
 
   render() {
     const { animShowHide, isInDOM } = this.state
-    const { children, render, centered, onClose, data, isOpened } = this.props
+    const { children, render, centered, onClose, data, isOpened, width } = this.props
 
     if (!isInDOM) {
       return null
@@ -173,6 +174,7 @@ class Modal extends PureComponent<Props, State> {
       ...BODY_WRAPPER_STYLE,
       opacity: animShowHide,
       transform: [{ scale }],
+      width: width || BODY_WRAPPER_STYLE.width,
     }
 
     const renderProps = {

--- a/src/components/modals/Send/HighFeeConfirmation.js
+++ b/src/components/modals/Send/HighFeeConfirmation.js
@@ -1,0 +1,65 @@
+// @flow
+import React, { PureComponent } from 'react'
+import { Trans, translate } from 'react-i18next'
+import type { T } from 'types/common'
+import IconExclamationCircleThin from 'icons/ExclamationCircleThin'
+
+import Box from 'components/base/Box'
+import Text from 'components/base/Text'
+import { BigNumber } from 'bignumber.js'
+import type { Unit } from '@ledgerhq/live-common/lib/types/currencies'
+import { formatCurrencyUnit } from '@ledgerhq/live-common/lib/currencies/formatCurrencyUnit'
+import ConfirmModal from '../../base/Modal/ConfirmModal'
+
+type Props = {
+  t: T,
+  isOpened?: boolean,
+  fees: BigNumber,
+  amount: BigNumber,
+  onReject: () => void,
+  onAccept: () => void,
+  unit: Unit,
+}
+
+class HighFeeConfirmation extends PureComponent<Props, *> {
+  render() {
+    const { t, onReject, onAccept, fees, amount, unit, isOpened } = this.props
+
+    return (
+      <ConfirmModal
+        analyticsName="HighFeeModal"
+        isDanger={false}
+        centered
+        narrow
+        isOpened={isOpened}
+        onReject={onReject}
+        onConfirm={onAccept}
+        confirmText={t('common.continue')}
+        title={t('send.steps.amount.highFeeModal.title')}
+        renderIcon={() => (
+          <Box color="alertRed" align="center">
+            <IconExclamationCircleThin size={43} />
+          </Box>
+        )}
+      >
+        <Box>
+          <Box ff="Open Sans" color="smoke" fontSize={4} pr={20} pl={20} textAlign="center">
+            <Trans i18nKey="send.steps.amount.highFeeModal.desc" parent="div">
+              {'Be careful, the transaction fees  ('}
+              <Text ff="Open Sans|SemiBold" color="dark">
+                {formatCurrencyUnit(unit, fees, { showCode: true })}
+              </Text>
+              {'). represent more than 10% of the amount ('}
+              <Text ff="Open Sans|SemiBold" color="dark">
+                {formatCurrencyUnit(unit, amount, { showCode: true })}
+              </Text>
+              {'). Do you want to continue?'}
+            </Trans>
+          </Box>
+        </Box>
+      </ConfirmModal>
+    )
+  }
+}
+
+export default translate()(HighFeeConfirmation)

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -355,7 +355,11 @@
         "message": "Leave a message (140)",
         "rippleTag": "Tag",
         "ethereumGasLimit": "Gas limit",
-        "unitPerByte": "{{unit}} per byte"
+        "unitPerByte": "{{unit}} per byte",
+        "highFeeModal": {
+          "title": "High fees",
+          "desc": "Be careful, the transaction fees (<1><0>{{fees}}</0></1>) represent more than 10% of the amount (<3><0>{{amount}}</0></3>). Do you want to continue?"
+        }
       },
       "connectDevice": {
         "title": "Device"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/55422683-7fcda500-557c-11e9-8a69-72fb0fccdefc.png)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1077

### Parts of the app affected / Test plan

The send flow, try to send an amount with fees representing more than 10% of the amount, you should be prompted with the above modal to confirm that unusual transaction. The modal should not be dismissable by clicking outside, the user needs to either confirm and go to the next step, or cancel and remain on the first step of the flow.