### PR TITLE
Correct active style for Exchange menu link

### DIFF
--- a/src/components/MainSideBar/index.js
+++ b/src/components/MainSideBar/index.js
@@ -147,7 +147,7 @@ class MainSideBar extends PureComponent<Props> {
               icon={IconExchange}
               iconActiveColor="wallet"
               onClick={this.handleClickExchange}
-              isActive={pathname === '/exchange'}
+              isActive={pathname === '/partners'}
             />
             {developerMode && (
               <KeyboardContent sequence="DEVTOOLS">


### PR DESCRIPTION
too triggering to let alive :doge:

before | after
---|---
![2019-04-03_17-42-53_437x303](https://user-images.githubusercontent.com/315259/55492762-0e532c80-5638-11e9-937c-dd3874e5ad8f.png) | ![2019-04-03_17-42-36_444x303](https://user-images.githubusercontent.com/315259/55492763-0eebc300-5638-11e9-947f-b51db1b6fb3d.png)
