### PR TITLE
Workaround to fix bug when moving from old version

### DIFF
--- a/src/helpers/accountModel.js
+++ b/src/helpers/accountModel.js
@@ -96,12 +96,13 @@ const accountModel: DataModel<AccountRaw, Account> = createDataModel({
     } = rawAccount
     const currency = getCryptoCurrencyById(currencyId)
     const unit = currency.units.find(u => u.magnitude === unitMagnitude) || currency.units[0]
-    const convertOperation = ({ date, value, fee, ...op }) => ({
+    const convertOperation = ({ date, value, fee, extra, ...op }) => ({
       ...op,
       accountId: acc.id,
       date: new Date(date),
       value: BigNumber(value),
       fee: BigNumber(fee),
+      extra: extra || {},
     })
     return {
       ...acc,


### PR DESCRIPTION
Fixes a bug where extra end up being null or undefined. No clear idea how this can happen but this will protect it.

### Type

edge case bug fix

### Context

LIVE-DESKTOP-3CNN

### Parts of the app affected / Test plan

you should still see the **tag** extra field in a XRP operation detail when you use one.