### PR TITLE
Hide error of auto update when it's a simple update failure

### DIFF
--- a/src/commands/autoUpdate.js
+++ b/src/commands/autoUpdate.js
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs'
 import { UPDATE_CHECK_IGNORE } from 'config/constants'
 // import createElectronAppUpdater from 'main/updater/createElectronAppUpdater'
 import type { UpdateStatus } from 'components/Updater/UpdaterContext'
+import logger from 'logger'
 
 type Input = {}
 type Result = {
@@ -47,7 +48,10 @@ const cmd: Command<Input, Result> = createCommand('main:autoUpdate', () =>
     autoUpdater.on('update-not-available', info => sendStatus('update-not-available', info))
     autoUpdater.on('download-progress', p => sendStatus('download-progress', p))
     autoUpdater.on('update-downloaded', handleDownload)
-    autoUpdater.on('error', err => o.error(err))
+    autoUpdater.on('error', err => {
+      logger.error(err)
+      o.complete()
+    })
 
     autoUpdater.autoInstallOnAppQuit = false
     autoUpdater.checkForUpdates()


### PR DESCRIPTION
error will only be used for the check for now. Later we can introduce some sort of "warning" but it shouldn't be displayed as an alarming error, if for instance, it's just that network got interrupted.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

polish

### Context

LL-1278

### Parts of the app affected / Test plan

interrupting the auto update downloading by a network cut should not display the alarming error.