### PR TITLE
Parallel sync for better performance & remove sync timeout

### DIFF
--- a/src/bridge/BridgeSyncContext.js
+++ b/src/bridge/BridgeSyncContext.js
@@ -5,7 +5,6 @@
 
 import logger from 'logger'
 import shuffle from 'lodash/shuffle'
-import { timeout } from 'rxjs/operators/timeout'
 import React, { Component } from 'react'
 import priorityQueue from 'async/priorityQueue'
 import { connect } from 'react-redux'
@@ -17,7 +16,7 @@ import { bridgeSyncSelector, syncStateLocalSelector } from 'reducers/bridgeSync'
 import type { BridgeSyncState } from 'reducers/bridgeSync'
 import { accountsSelector, isUpToDateSelector } from 'reducers/accounts'
 import { currenciesStatusSelector, currencyDownStatusLocal } from 'reducers/currenciesStatus'
-import { SYNC_MAX_CONCURRENT, SYNC_TIMEOUT } from 'config/constants'
+import { SYNC_MAX_CONCURRENT } from 'config/constants'
 import type { CurrencyStatus } from 'reducers/currenciesStatus'
 import { getBridgeForCurrency } from '.'
 
@@ -89,23 +88,20 @@ class Provider extends Component<BridgeSyncProviderOwnProps, Sync> {
       this.props.setAccountSyncState(accountId, { pending: true, error: null })
 
       // TODO use Subscription to unsubscribe at relevant time
-      bridge
-        .synchronize(account)
-        .pipe(timeout(SYNC_TIMEOUT))
-        .subscribe({
-          next: accountUpdater => {
-            this.props.updateAccountWithUpdater(accountId, accountUpdater)
-          },
-          complete: () => {
-            this.props.setAccountSyncState(accountId, { pending: false, error: null })
-            next()
-          },
-          error: error => {
-            logger.critical(error)
-            this.props.setAccountSyncState(accountId, { pending: false, error })
-            next()
-          },
-        })
+      bridge.synchronize(account).subscribe({
+        next: accountUpdater => {
+          this.props.updateAccountWithUpdater(accountId, accountUpdater)
+        },
+        complete: () => {
+          this.props.setAccountSyncState(accountId, { pending: false, error: null })
+          next()
+        },
+        error: error => {
+          logger.critical(error)
+          this.props.setAccountSyncState(accountId, { pending: false, error })
+          next()
+        },
+      })
     }
 
     const syncQueue = priorityQueue(synchronize, SYNC_MAX_CONCURRENT)

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -45,8 +45,7 @@ export const OUTDATED_CONSIDERED_DELAY = intFromEnv('OUTDATED_CONSIDERED_DELAY',
 export const SYNC_ALL_INTERVAL = 120 * 1000
 export const SYNC_BOOT_DELAY = 2 * 1000
 export const SYNC_PENDING_INTERVAL = 10 * 1000
-export const SYNC_MAX_CONCURRENT = intFromEnv('LEDGER_SYNC_MAX_CONCURRENT', 1)
-export const SYNC_TIMEOUT = intFromEnv('SYNC_TIMEOUT', 5 * 60 * 1000)
+export const SYNC_MAX_CONCURRENT = intFromEnv('LEDGER_SYNC_MAX_CONCURRENT', 4)
 
 // Endpoints...
 


### PR DESCRIPTION
This should significantly increase the speed of Synchronisation when you have more than one account in Ledger Live because it will start doing synchronisation in parallel. It also remove the timeout that was existing on the sync and that was potentially creating issues for very big accounts.

### Type

performance

### Context

LL-1239

### Parts of the app affected / Test plan

We need to test this intensively with many accounts. The risk here is that the libcore can crash because we ask it too much, we can also have race condition **but normally we shouldn't because we use the same codebase as mobile and mobile have this since the beginning**.