### PR TITLE
add learn more button to send and receive flow

### DIFF
--- a/src/components/CurrentAddress/index.js
+++ b/src/components/CurrentAddress/index.js
@@ -11,10 +11,13 @@ import noop from 'lodash/noop'
 import type { T } from 'types/common'
 
 import { rgba } from 'styles/helpers'
+import { urls } from 'config/urls'
+import { openURL } from 'helpers/linking'
 
 import Box from 'components/base/Box'
-import CopyToClipboard from 'components/base/CopyToClipboard'
 import QRCode from 'components/base/QRCode'
+import CopyToClipboard from 'components/base/CopyToClipboard'
+import LinkWithExternalIcon from 'components/base/LinkWithExternalIcon'
 
 import IconRecheck from 'icons/Recover'
 import IconCopy from 'icons/Copy'
@@ -224,6 +227,10 @@ class CurrentAddress extends PureComponent<Props, { copyFeedback: boolean }> {
               : isAddressVerified
                 ? t('currentAddress.messageIfAccepted', { currencyName })
                 : t('currentAddress.messageIfSkipped', { currencyName })}
+            <LinkWithExternalIcon
+              onClick={() => openURL(urls.recipientAddressInfo)}
+              label={t('common.learnMore')}
+            />
           </Box>
         </Box>
         <Footer>

--- a/src/components/base/Label.js
+++ b/src/components/base/Label.js
@@ -5,8 +5,8 @@ import fontFamily from 'styles/styled/fontFamily'
 
 export default styled.label.attrs({
   fontSize: p => p.fontSize || 3,
-  ff: 'Museo Sans|Regular',
-  color: 'grey',
+  ff: p => p.ff || 'Museo Sans|Regular',
+  color: p => p.color || 'grey',
   align: 'center',
   display: 'block',
 })`

--- a/src/components/base/LabelWithExternalIcon.js
+++ b/src/components/base/LabelWithExternalIcon.js
@@ -7,8 +7,17 @@ import Label from 'components/base/Label'
 import Box from 'components/base/Box'
 import IconExternalLink from 'icons/ExternalLink'
 
+const LabelWrapper = styled(Label).attrs({})`
+  &:hover {
+    color: ${p => p.theme.colors.wallet};
+    cursor: pointer;
+  }
+`
+
+type Props = { onClick: ?() => void, label: string }
+
 // can add more dynamic options if needed
-export function LabelWithExternalIcon({ onClick, label }: { onClick: ?() => void, label: string }) {
+export function LabelWithExternalIcon({ onClick, label }: Props) {
   return (
     <LabelWrapper onClick={onClick}>
       <span>{label}</span>
@@ -20,10 +29,3 @@ export function LabelWithExternalIcon({ onClick, label }: { onClick: ?() => void
 }
 
 export default LabelWithExternalIcon
-
-const LabelWrapper = styled(Label).attrs({})`
-  &:hover {
-    color: ${p => p.theme.colors.wallet};
-    cursor: pointer;
-  }
-`

--- a/src/components/base/LinkWithExternalIcon.js
+++ b/src/components/base/LinkWithExternalIcon.js
@@ -1,0 +1,40 @@
+// @flow
+
+import React from 'react'
+import styled from 'styled-components'
+
+import Box from 'components/base/Box'
+import IconExternalLink from 'icons/ExternalLink'
+
+import Label from './Label'
+import { rgba } from '../../styles/helpers'
+
+const Wrapper = styled(Label).attrs({
+  ff: 'Open Sans|SemiBold',
+  color: 'wallet',
+  fontSize: 4,
+  align: 'center',
+})`
+  display: flex;
+  cursor: pointer;
+
+  &:hover {
+    color: ${p => rgba(p.theme.colors.wallet, 0.9)};
+  }
+`
+
+type Props = { onClick: ?() => void, label: string }
+
+// can add more dynamic options if needed
+export function LinkWithExternalIcon({ onClick, label }: Props) {
+  return (
+    <Wrapper onClick={onClick}>
+      <span>{label}</span>
+      <Box ml={1}>
+        <IconExternalLink size={12} />
+      </Box>
+    </Wrapper>
+  )
+}
+
+export default LinkWithExternalIcon

--- a/src/components/modals/Receive/steps/03-step-confirm-address.js
+++ b/src/components/modals/Receive/steps/03-step-confirm-address.js
@@ -5,12 +5,14 @@ import React, { Fragment, PureComponent } from 'react'
 
 import TrackPage from 'analytics/TrackPage'
 import { urls } from 'config/urls'
+import { openURL } from 'helpers/linking'
 import Box from 'components/base/Box'
 import Button from 'components/base/Button'
 import DeviceConfirm from 'components/DeviceConfirm'
 import ExternalLinkButton from 'components/base/ExternalLinkButton'
 import RetryButton from 'components/base/RetryButton'
 import NanoXStates from 'components/NanoXStates'
+import LinkWithExternalIcon from 'components/base/LinkWithExternalIcon'
 
 import type { StepProps } from '../index'
 import TranslatedError from '../../../TranslatedError'
@@ -48,6 +50,10 @@ export default class StepConfirmAddress extends PureComponent<StepProps> {
               {account &&
                 t('receive.steps.confirmAddress.text', { currencyName: account.currency.name })}
             </Text>
+            <LinkWithExternalIcon
+              onClick={() => openURL(urls.recipientAddressInfo)}
+              label={t('common.learnMore')}
+            />
             <Button mt={4} mb={2} primary onClick={() => transitionTo('receive')}>
               {t('common.continue')}
             </Button>

--- a/src/components/modals/Send/steps/03-step-verification.js
+++ b/src/components/modals/Send/steps/03-step-verification.js
@@ -6,7 +6,10 @@ import styled from 'styled-components'
 import { multiline } from 'styles/helpers'
 
 import TrackPage from 'analytics/TrackPage'
+import { urls } from 'config/urls'
+import { openURL } from 'helpers/linking'
 import Box from 'components/base/Box'
+import LinkWithExternalIcon from 'components/base/LinkWithExternalIcon'
 import WarnBox from 'components/WarnBox'
 import DeviceConfirm from 'components/DeviceConfirm'
 import NanoXStates from 'components/NanoXStates'
@@ -35,7 +38,13 @@ export default class StepVerification extends PureComponent<StepProps<*>> {
     return (
       <Container>
         <TrackPage category="Send Flow" name="Step 3" />
-        <WarnBox>{multiline(t('send.steps.verification.warning'))}</WarnBox>
+        <WarnBox>
+          {multiline(t('send.steps.verification.warning'))}
+          <LinkWithExternalIcon
+            onClick={() => openURL(urls.recipientAddressInfo)}
+            label={t('common.learnMore')}
+          />
+        </WarnBox>
         <Info>{t('send.steps.verification.body')}</Info>
         {device && device.modelId === 'nanoX' ? <NanoXStates validate /> : <DeviceConfirm />}
       </Container>

--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -21,7 +21,7 @@ export const urls = {
   managerHelpRequest: 'https://support.ledgerwallet.com/hc/en-us/articles/360006523674 ',
   contactSupport: 'https://support.ledgerwallet.com/hc/en-us/requests/new?ticket_form_id=248165',
   feesMoreInfo: 'https://support.ledgerwallet.com/hc/en-us/articles/360006535873',
-  recipientAddressInfo: 'https://support.ledgerwallet.com/hc/en-us/articles/360006433934',
+  recipientAddressInfo: 'https://support.ledger.com/hc/en-us/articles/360006433934',
   privacyPolicy: 'https://www.ledger.com/pages/privacy-policy',
 
   githubIssues:


### PR DESCRIPTION
add a `Learn More` button to Send and Receive flow

### Type

Improvement

### Context

LL-730

### Parts of the app affected / Test plan

Send and Receive flow
