### PR TITLE
LL-1279 Made Language menu wording non translatable

### DIFF
--- a/src/components/SettingsPage/LanguageSelect.js
+++ b/src/components/SettingsPage/LanguageSelect.js
@@ -20,6 +20,16 @@ type Props = {
 }
 
 class LanguageSelect extends PureComponent<Props> {
+  languageLabels = {
+    en: 'English',
+    fr: 'Français',
+    es: 'Español',
+    ko: '한국어',
+    zh: '简体中文',
+    ja: '日本語',
+    ru: 'Русский',
+  }
+
   handleChangeLanguage = ({ value: languageKey }: *) => {
     const { i18n, setLanguage } = this.props
     i18n.changeLanguage(languageKey)
@@ -28,7 +38,7 @@ class LanguageSelect extends PureComponent<Props> {
   }
 
   languages = [{ value: null, label: this.props.t(`language.system`) }].concat(
-    languageKeys.map(key => ({ value: key, label: this.props.t(`language.${key}`) })),
+    languageKeys.map(key => ({ value: key, label: this.languageLabels[key] })),
   )
 
   render() {

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -603,14 +603,7 @@
     "selectedAccounts_plural": "Accounts to include ({{count}})"
   },
   "language": {
-    "system": "Use system language",
-    "en": "English",
-    "fr": "French",
-    "es": "Spanish",
-    "ko": "Korean",
-    "zh": "Simplified Chinese",
-    "ja": "Japanese",
-    "ru": "Russian"
+    "system": "Use system language"
   },
   "onboarding": {
     "breadcrumb": {

--- a/static/i18n/es/app.json
+++ b/static/i18n/es/app.json
@@ -552,14 +552,7 @@
     "selectedAccounts_plural": "Accounts to include ({{count}})"
   },
   "language": {
-    "system": "Utilizar idioma del sistema",
-    "en": "Inglés",
-    "fr": "Francés",
-    "es": "Español",
-    "ko": "Coreano",
-    "zh": "Chino simplificado",
-    "ja": "Japonés",
-    "ru": "Ruso"
+    "system": "Utilizar idioma del sistema"
   },
   "onboarding": {
     "breadcrumb": {

--- a/static/i18n/fr/app.json
+++ b/static/i18n/fr/app.json
@@ -552,14 +552,7 @@
     "selectedAccounts_plural": "Comptes à inclure ({{count}})"
   },
   "language": {
-    "system": "Utiliser la langue du système",
-    "en": "Anglais",
-    "fr": "Français",
-    "es": "Espagnol",
-    "ko": "Coréen",
-    "zh": "Chinois simplifié",
-    "ja": "Japonais",
-    "ru": "Russe"
+    "system": "Utiliser la langue du système"
   },
   "onboarding": {
     "breadcrumb": {

--- a/static/i18n/ja/app.json
+++ b/static/i18n/ja/app.json
@@ -552,14 +552,7 @@
     "selectedAccounts_plural": "({{count}}) 件のアカウントが選択されました"
   },
   "language": {
-    "system": "システム言語を使用",
-    "en": "英語",
-    "fr": "フランス語",
-    "es": "スペイン語",
-    "ko": "韓国語",
-    "zh": "簡体字中国語",
-    "ja": "日本語",
-    "ru": "ロシア語"
+    "system": "システム言語を使用"
   },
   "onboarding": {
     "breadcrumb": {

--- a/static/i18n/ko/app.json
+++ b/static/i18n/ko/app.json
@@ -552,14 +552,7 @@
     "selectedAccounts_plural": "Accounts to include ({{count}})"
   },
   "language": {
-    "system": "시스템 언어 사용",
-    "en": "영어",
-    "fr": "프랑스어",
-    "es": "스페인어",
-    "ko": "한국어",
-    "zh": "중국어 간체",
-    "ja": "일본어",
-    "ru": "러시아어"
+    "system": "시스템 언어 사용"
   },
   "onboarding": {
     "breadcrumb": {

--- a/static/i18n/ru/app.json
+++ b/static/i18n/ru/app.json
@@ -552,14 +552,7 @@
     "selectedAccounts_plural": "Accounts to include ({{count}})"
   },
   "language": {
-    "system": "Использовать язык системы",
-    "en": "Английский",
-    "fr": "Французский",
-    "es": "Испанский",
-    "ko": "Корейский",
-    "zh": "Китайский упрощенный",
-    "ja": "Японский",
-    "ru": "Русский"
+    "system": "Использовать язык системы"
   },
   "onboarding": {
     "breadcrumb": {

--- a/static/i18n/zh/app.json
+++ b/static/i18n/zh/app.json
@@ -552,14 +552,7 @@
     "selectedAccounts_plural": "要包括的帐户 ({{count}})"
   },
   "language": {
-    "system": "使用系统语言",
-    "en": "英语",
-    "fr": "法语",
-    "es": "西班牙语",
-    "ko": "韩语",
-    "zh": "简体中文",
-    "ja": "日语",
-    "ru": "俄语"
+    "system": "使用系统语言"
   },
   "onboarding": {
     "breadcrumb": {


### PR DESCRIPTION
The language selector was using translated versions of the languages, making it hard to select your language if it was changed. This makes use of the native wording for each language instead of translating it.

![image](https://user-images.githubusercontent.com/4631227/55953156-a7e39500-5c5b-11e9-9fb4-8ba10ef80c13.png)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1279

### Parts of the app affected / Test plan

The language selector should show the language labels in the native wording instead of translated.
There is a known issue that the wording for `"Use system language"` doesn't get translated until refresh. I tried hooking into the callback for changelanguage with no success.