### PR TITLE
LL-1275 feat: Allow user to search accounts by name, currency, ticker

### DIFF
--- a/src/components/SelectAccount/index.js
+++ b/src/components/SelectAccount/index.js
@@ -62,7 +62,8 @@ type Props = {
   t: T,
 }
 
-const getOptionValue = account => account.id
+const getOptionValue = account =>
+  `${account.currency.ticker}|${account.currency.name}|${account.name}`
 
 const RawSelectAccount = ({ accounts, onChange, value, t, ...props }: Props) => {
   const selectedOption = value ? accounts.find(o => o.id === value.id) : null


### PR DESCRIPTION
On the send/receive flow, add the ability to search for an account using the currency ticker, currency name, or account name. It used to be using `account.id` which after talking with @gre justifies some weird matches for some currencies.

![Apr-11-2019 16-57-22](https://user-images.githubusercontent.com/4631227/55968140-b80b6c80-5c7b-11e9-99d8-7a1ee0a40081.gif)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1275

### Parts of the app affected / Test plan

Send/Receive full, make sure account selection is not broken after this.