### PR TITLE
LL-1263 Redirect to portfolio if needed on Send/Receive modal open

### DIFF
--- a/src/components/MainSideBar/index.js
+++ b/src/components/MainSideBar/index.js
@@ -85,8 +85,14 @@ class MainSideBar extends PureComponent<Props> {
   }
 
   handleClickDashboard = () => this.push('/')
-  handleOpenSendModal = () => this.props.openModal(MODAL_SEND)
-  handleOpenReceiveModal = () => this.props.openModal(MODAL_RECEIVE)
+  handleOpenSendModal = () => {
+    this.push('/')
+    this.props.openModal(MODAL_SEND)
+  }
+  handleOpenReceiveModal = () => {
+    this.push('/')
+    this.props.openModal(MODAL_RECEIVE)
+  }
   handleClickManager = () => this.push('/manager')
   handleClickExchange = () => this.push('/partners')
   handleClickDev = () => this.push('/dev')


### PR DESCRIPTION
When a user is in the manager/exchange flow and clicks on send/receive on the sidebar we now redirect to the portfolio screen to prevent the manager from sending commands to the device and causing havoc.

### Type

Bug Fix/Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1263

### Parts of the app affected / Test plan

Start send/receive flow while on the manager.