### PR TITLE
use close in account import when no more account can be created

### DIFF
--- a/src/components/modals/AddAccounts/steps/03-step-import.js
+++ b/src/components/modals/AddAccounts/steps/03-step-import.js
@@ -339,11 +339,15 @@ export const StepImportFooter = ({
   })
 
   const count = checkedAccountsIds.length
+  const willClose = !willCreateAccount && !willAddAccounts
 
   const ctaWording =
-    scanStatus === 'scanning' ? t('common.sync.syncing') : t('addAccounts.cta.add', { count })
+    scanStatus === 'scanning'
+      ? t('common.sync.syncing')
+      : willClose
+        ? t('common.close')
+        : t('addAccounts.cta.add', { count })
 
-  const willClose = !willCreateAccount && !willAddAccounts
   const onClick = willClose
     ? onCloseModal
     : async () => {
@@ -366,11 +370,7 @@ export const StepImportFooter = ({
         </Button>
       )}
       {scanStatus !== 'error' && (
-        <Button
-          primary
-          disabled={scanStatus !== 'finished' || !(willCreateAccount || willAddAccounts)}
-          onClick={onClick}
-        >
+        <Button primary disabled={scanStatus !== 'finished'} onClick={onClick}>
           {ctaWording}
         </Button>
       )}


### PR DESCRIPTION
adds a close button if you cannot create or import more account in Add Account step 3

### Type

Improvement

### Context

LL-1271

### Parts of the app affected / Test plan

Add Account

![image](https://user-images.githubusercontent.com/671786/56037931-e0a16e00-5d30-11e9-82b6-8021523c5429.png)

