### PR TITLE
fix: Added tickers for apps not supported on Live

### DIFF
--- a/src/components/ManagerPage/AppsList.js
+++ b/src/components/ManagerPage/AppsList.js
@@ -149,7 +149,7 @@ class AppsList extends PureComponent<Props, State> {
       )
 
       const withTickers = filteredAppVersionsList.map(app => {
-        const maybeCrypto = listCryptoCurrencies(true).find(
+        const maybeCrypto = listCryptoCurrencies(true, false, false).find(
           c => c.managerAppName.toLowerCase() === app.name.toLowerCase(),
         )
         const ticker = maybeCrypto ? maybeCrypto.ticker : ''

--- a/src/config/cryptocurrencies.js
+++ b/src/config/cryptocurrencies.js
@@ -35,10 +35,11 @@ const supported: CryptoCurrencyIds[] = [
 export const listCryptoCurrencies: (
   withDevCrypto?: boolean,
   onlyTerminated?: boolean,
+  onlyInstallable?: boolean,
 ) => CryptoCurrency[] = memoize(
-  (withDevCrypto, onlyTerminated = false) =>
+  (withDevCrypto, onlyTerminated = false, onlySupported = true) =>
     listCC(withDevCrypto, true)
-      .filter(c => supported.includes(c.id))
+      .filter(c => (onlySupported ? supported.includes(c.id) : true))
       .filter(c => (onlyTerminated ? c.terminated : !c.terminated))
       .sort((a, b) => a.name.localeCompare(b.name)),
   (a?: boolean, b?: boolean) => `${a ? 1 : 0}_${b ? 1 : 0}`,


### PR DESCRIPTION
The manager search bar was not returning any results for tickers for currencies that are not supported on Live. This allows the merge with the tickers whilst still allowing for memoization.
![Apr-16-2019 10-42-33](https://user-images.githubusercontent.com/4631227/56196548-53635f80-6037-11e9-90cb-415f2e9ed04a.gif)

### Type
Regression

### Context
https://ledgerhq.atlassian.net/browse/LL-1246

### Parts of the app affected / Test plan
In the manager search for an app that's not supported by Live