### PR TITLE
adds more time between polling so the device is `more` responsive

### DIFF
--- a/src/components/EnsureDeviceApp.js
+++ b/src/components/EnsureDeviceApp.js
@@ -63,6 +63,7 @@ class EnsureDeviceApp extends Component<{
         return address
       },
       {
+        pollingInterval: 1250,
         shouldThrow: (err: Error) => {
           const isWrongDevice = err instanceof WrongDeviceForAccount
           const isCantOpenDevice = err instanceof CantOpenDevice


### PR DESCRIPTION
delay the execution between polling to alleviate the pressure on the device


### Type

Improvement

### Context

LL-1272

### Parts of the app affected / Test plan

Add Account

This will make the device a bit more responsive, however with the current implementation I don't think we can make it completely seamless
