### PR TITLE
adds error modal if getLatestFirmwareForDevice fails

### DIFF
--- a/src/components/ManagerPage/FirmwareUpdate.js
+++ b/src/components/ManagerPage/FirmwareUpdate.js
@@ -1,7 +1,6 @@
 // @flow
-/* eslint-disable react/jsx-no-literals */ // FIXME
 
-import React, { PureComponent, Fragment } from 'react'
+import React, { PureComponent } from 'react'
 import { translate } from 'react-i18next'
 import { getDeviceModel } from '@ledgerhq/devices'
 import type { DeviceInfo, FirmwareUpdateContext } from '@ledgerhq/live-common/lib/types/manager'
@@ -51,6 +50,7 @@ type State = {
   modal: ModalStatus,
   stepId: ?StepId,
   ready: boolean,
+  error: ?Error,
 }
 
 const intializeState = ({ deviceInfo }): State => ({
@@ -58,6 +58,7 @@ const intializeState = ({ deviceInfo }): State => ({
   modal: 'closed',
   stepId: deviceInfo.isBootloader ? 'updateMCU' : 'idCheck',
   ready: false,
+  error: null,
 })
 
 class FirmwareUpdate extends PureComponent<Props, State> {
@@ -65,14 +66,25 @@ class FirmwareUpdate extends PureComponent<Props, State> {
 
   async componentDidMount() {
     const { deviceInfo } = this.props
-    const firmware = await getLatestFirmwareForDevice.send(deviceInfo).toPromise()
-    if (firmware && !this._unmounting) {
+    try {
+      const firmware = await getLatestFirmwareForDevice.send(deviceInfo).toPromise()
+      if (firmware && !this._unmounting) {
+        /* eslint-disable */
+        this.setState({
+          firmware,
+          ready: true,
+          modal: deviceInfo.isOSU ? 'install' : 'closed',
+          stepId: deviceInfo.isOSU ? 'updateMCU' : 'idCheck',
+        })
+        /* eslint-enable */
+      }
+    } catch (error) {
       /* eslint-disable */
       this.setState({
-        firmware,
         ready: true,
         modal: deviceInfo.isOSU ? 'install' : 'closed',
-        stepId: deviceInfo.isOSU ? 'updateMCU' : 'idCheck',
+        stepId: 'finish',
+        error,
       })
       /* eslint-enable */
     }
@@ -92,7 +104,7 @@ class FirmwareUpdate extends PureComponent<Props, State> {
 
   render() {
     const { deviceInfo, t, device } = this.props
-    const { firmware, modal, stepId, ready } = this.state
+    const { firmware, modal, stepId, ready, error } = this.state
 
     const deviceSpecs = getDeviceModel(device.modelId)
 
@@ -122,7 +134,7 @@ class FirmwareUpdate extends PureComponent<Props, State> {
           <UpdateFirmwareButton firmware={firmware} onClick={this.handleDisclaimerModal} />
         </Box>
         {ready ? (
-          <Fragment>
+          <>
             <DisclaimerModal
               firmware={firmware}
               status={modal}
@@ -134,8 +146,9 @@ class FirmwareUpdate extends PureComponent<Props, State> {
               stepId={stepId}
               onClose={this.handleCloseModal}
               firmware={firmware}
+              error={error}
             />
-          </Fragment>
+          </>
         ) : null}
       </Card>
     )

--- a/src/components/modals/UpdateFirmware/index.js
+++ b/src/components/modals/UpdateFirmware/index.js
@@ -49,6 +49,8 @@ const createSteps = ({ t }: { t: T }): Array<*> => {
   return [updateStep, mcuStep, finalStep]
 }
 
+const stepsId = ['idCheck', 'updateMCU', 'finish']
+
 export type StepProps = DefaultStepProps & {
   firmware: FirmwareUpdateContext,
   onCloseModal: () => void,
@@ -64,6 +66,7 @@ type Props = {
   onClose: () => void,
   firmware: FirmwareUpdateContext,
   stepId: StepId | string,
+  error: ?Error,
 }
 
 type State = {
@@ -75,7 +78,7 @@ type State = {
 class UpdateModal extends PureComponent<Props, State> {
   state = {
     stepId: this.props.stepId,
-    error: null,
+    error: this.props.error || null,
     nonce: 0,
   }
 
@@ -95,6 +98,8 @@ class UpdateModal extends PureComponent<Props, State> {
   render(): React$Node {
     const { status, t, firmware, onClose, ...props } = this.props
     const { stepId, error, nonce } = this.state
+
+    const errorSteps = error ? [stepsId.indexOf(stepId)] : []
 
     const additionalProps = {
       error,
@@ -119,6 +124,7 @@ class UpdateModal extends PureComponent<Props, State> {
             title={t('manager.firmware.update')}
             initialStepId={stepId}
             steps={this.STEPS}
+            errorSteps={errorSteps}
             {...additionalProps}
           >
             <FreezeDeviceChangeEvents />


### PR DESCRIPTION
If `getLatestFirmwareForDevice` fails, display a modal with Error

### Type

Improvement

### Context

LL-1245

### Parts of the app affected / Test plan

Manager / Firmware Update

![image](https://user-images.githubusercontent.com/671786/56303128-8e4ebb80-613b-11e9-8cd3-41a4ede3e4c9.png)
