### PR TITLE
Correctly name the shasum file (in some rare cases)

### DIFF
--- a/scripts/create-release-shasums.sh
+++ b/scripts/create-release-shasums.sh
@@ -11,10 +11,10 @@ set -e
 function main {
   ASSETS_FILTER="(AppImage|zip|exe)"
   PKG_VER=$(grep version package.json | sed -E 's/.*: "(.*)",/\1/g')
-  OUTPUT_FILE="ledger-live-desktop-$PKG_VER.sha512sum"
 
   read -p "> release version ($PKG_VER): " -r RELEASE_VERSION
   RELEASE_VERSION=${RELEASE_VERSION:-$PKG_VER}
+  OUTPUT_FILE="ledger-live-desktop-$RELEASE_VERSION.sha512sum"
 
   RELEASES=$(do_request "/repos/LedgerHQ/ledger-live-desktop/releases")
   printf """


### PR DESCRIPTION
Should never occur, but this ensure the shasum file name is correctly generated if we choose to generate it for a different release than the one pointed in `package.json` (case occured during the tests :) ).