### PR TITLE
Adds the cta button for setting countervalue first

### DIFF
--- a/src/components/AccountPage/AccountBalanceSummaryHeader.js
+++ b/src/components/AccountPage/AccountBalanceSummaryHeader.js
@@ -13,9 +13,11 @@ import { saveSettings } from 'actions/settings'
 import type { TimeRange } from 'reducers/settings'
 
 import { BalanceTotal, BalanceSinceDiff, BalanceSincePercent } from 'components/BalanceInfos'
-import Box from 'components/base/Box'
+import Box, { Tabbable } from 'components/base/Box'
 import FormattedVal from 'components/base/FormattedVal'
 import PillsDaysCount from 'components/PillsDaysCount'
+import styled from 'styled-components'
+import Swap from '../../icons/Swap'
 
 type Props = {
   isAvailable: boolean,
@@ -37,6 +39,34 @@ type Props = {
   countervalueFirst: boolean,
   setCountervalueFirst: boolean => void,
 }
+
+const SwapButton = styled(Tabbable).attrs({
+  color: 'dark',
+  ff: 'Museo Sans',
+  fontSize: 7,
+})`
+  align-items: center;
+  align-self: center;
+  border-radius: 4px;
+  border: 1px solid ${p => p.theme.colors.fog};
+  color: ${p => p.theme.colors.fog};
+  cursor: pointer;
+  display: flex;
+  height: 49px;
+  justify-content: center;
+  margin-right: 12px;
+  margin-top: 2px;
+  width: 25px;
+
+  &:hover {
+    border-color: ${p => p.theme.colors.dark};
+    color: ${p => p.theme.colors.dark};
+  }
+
+  &:active {
+    opacity: 0.5;
+  }
+`
 
 const mapDispatchToProps = {
   saveSettings,
@@ -73,6 +103,9 @@ class AccountBalanceSummaryHeader extends PureComponent<Props> {
     return (
       <Box flow={4} mb={2}>
         <Box horizontal>
+          <SwapButton onClick={() => setCountervalueFirst(!countervalueFirst)}>
+            <Swap />
+          </SwapButton>
           <BalanceTotal
             style={{ cursor: 'pointer' }}
             onClick={() => setCountervalueFirst(!countervalueFirst)}

--- a/src/icons/Swap.js
+++ b/src/icons/Swap.js
@@ -1,0 +1,19 @@
+// @flow
+
+import React from 'react'
+
+const Swap = ({ size = 15, color = 'currentColor', ...props }: { size?: number, color?: string }) => (
+  <svg viewBox="0 0 15 17" width={(size / 15) * 15} height={(size / 15) * 17} {...props}>
+    <path
+      fill="none"
+      fillRule="evenodd"
+      stroke={color}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.5}
+      d="M5.5 1.5v14.4V1.5zm0 0L1.61 5.39 5.5 1.5zm4 14.4V1.5v14.4zm0 0l4-4-4 4z"
+    />
+  </svg>
+)
+
+export default Swap


### PR DESCRIPTION

![Apr-18-2019 17-50-18](https://user-images.githubusercontent.com/4631227/56373983-7857fe00-6202-11e9-9c29-c7ced161f53e.gif)

### Type

UI Polish

### Parts of the app affected / Test plan

Account page header, the functionality was already there. I just implemented the design.
