### PR TITLE
fix list of cryptocurrencies in add account and manager

### DIFF
--- a/src/components/SelectCurrency/index.js
+++ b/src/components/SelectCurrency/index.js
@@ -32,7 +32,7 @@ const SelectCurrency = ({
   autoFocus,
   ...props
 }: Props) => {
-  const availableCC = useCryptocurrencies()
+  const availableCC = useCryptocurrencies({ onlySupported: true })
 
   const cryptos = currencies || availableCC
 

--- a/src/config/cryptocurrencies.js
+++ b/src/config/cryptocurrencies.js
@@ -35,12 +35,12 @@ const supported: CryptoCurrencyIds[] = [
 export const listCryptoCurrencies: (
   withDevCrypto?: boolean,
   onlyTerminated?: boolean,
-  onlyInstallable?: boolean,
+  onlySupported?: boolean,
 ) => CryptoCurrency[] = memoize(
   (withDevCrypto, onlyTerminated = false, onlySupported = true) =>
     listCC(withDevCrypto, true)
       .filter(c => (onlySupported ? supported.includes(c.id) : true))
       .filter(c => (onlyTerminated ? c.terminated : !c.terminated))
       .sort((a, b) => a.name.localeCompare(b.name)),
-  (a?: boolean, b?: boolean) => `${a ? 1 : 0}_${b ? 1 : 0}`,
+  (a?: boolean, b?: boolean, c?: boolean) => `${a ? 1 : 0}_${b ? 1 : 0}_${c ? 1 : 0}`,
 )

--- a/src/hooks/useCryptoCurrencies.js
+++ b/src/hooks/useCryptoCurrencies.js
@@ -4,9 +4,15 @@ import type { CryptoCurrency } from '@ledgerhq/live-common/lib/types'
 import { listCryptoCurrencies } from 'config/cryptocurrencies'
 import useEnv from 'hooks/useEnv'
 
-const useCryptocurrencies = (onlyTerminated: boolean = false): ?(CryptoCurrency[]) => {
+const useCryptocurrencies = ({
+  onlyTerminated = false,
+  onlySupported = true,
+}: {
+  onlyTerminated?: boolean,
+  onlySupported?: boolean,
+}): ?(CryptoCurrency[]) => {
   const devMode = useEnv('MANAGER_DEV_MODE')
-  const cryptos = listCryptoCurrencies(devMode, onlyTerminated)
+  const cryptos = listCryptoCurrencies(devMode, onlyTerminated, onlySupported)
 
   return cryptos
 }


### PR DESCRIPTION
Fixed the memoization function that listed crypto currencies

### Type

Fix

### Context

LL-1313

### Parts of the app affected / Test plan

Manager app list and add account available crypto currencies
