### PR TITLE
LL-1326 Desktop: prevent backdrop click while installing/uninstalling

### DIFF
--- a/src/components/ManagerPage/AppsList.js
+++ b/src/components/ManagerPage/AppsList.js
@@ -295,10 +295,11 @@ class AppsList extends PureComponent<Props, State> {
   }
 
   renderModal = () => {
-    const { status } = this.state
+    const { status, mode } = this.state
     return (
       <Modal
         isOpened={status !== 'idle' && status !== 'loading'}
+        preventBackdropClick={['installing', 'uninstalling'].includes(mode)}
         centered
         onClose={this.handleCloseModal}
       >


### PR DESCRIPTION
### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1326

### Parts of the app affected / Test plan

Clicking outside of the modal (in the backdrop) should not close the modal while installing or uninstalling an app.