### PR TITLE
Max account decimals before trim and tooltip for whole value

### DIFF
--- a/src/components/DashboardPage/AccountCard/index.js
+++ b/src/components/DashboardPage/AccountCard/index.js
@@ -39,6 +39,7 @@ class AccountCard extends PureComponent<{
               unit={account.unit}
               showCode
               val={account.balance}
+              maxLength={18}
             />
           </Box>
         </Box>

--- a/src/components/base/FormattedVal/index.js
+++ b/src/components/base/FormattedVal/index.js
@@ -21,6 +21,7 @@ import FlipTicker from 'components/base/FlipTicker'
 
 import IconBottom from 'icons/Bottom'
 import IconTop from 'icons/Top'
+import Tooltip from 'components/base/Tooltip'
 
 const T = styled(Box).attrs({
   ff: 'Rubik',
@@ -49,6 +50,7 @@ type OwnProps = {
   animateTicker?: boolean,
   disableRounding?: boolean,
   isPercent?: boolean,
+  maxLength?: number,
 }
 
 const mapStateToProps = (state: State, _props: OwnProps) => ({
@@ -73,6 +75,7 @@ function FormattedVal(props: Props) {
     locale,
     marketIndicator,
     color,
+    maxLength,
     ...p
   } = props
   let { val } = props
@@ -82,6 +85,7 @@ function FormattedVal(props: Props) {
   const isNegative = val.isNegative() && !val.isZero()
 
   let text = ''
+  let showTooltip = false
 
   if (isPercent) {
     // FIXME move out the % feature of this component... totally unrelated to currency & annoying for flow type.
@@ -102,6 +106,11 @@ function FormattedVal(props: Props) {
       showCode,
       locale,
     })
+
+    if (maxLength && text.length > maxLength) {
+      text = `${text.substring(0, maxLength)}...`
+      showTooltip = true
+    }
   }
 
   if (animateTicker && !DISABLE_TICKER_ANIMATION) {
@@ -113,7 +122,7 @@ function FormattedVal(props: Props) {
     isNegative,
   })
 
-  return (
+  const content = (
     <T color={color || marketColor} withIcon={withIcon} {...p}>
       {withIcon ? (
         <Box horizontal alignItems="center" flow={1}>
@@ -131,6 +140,11 @@ function FormattedVal(props: Props) {
       )}
     </T>
   )
+
+  if (showTooltip) {
+    return <Tooltip render={() => unit && formatCurrencyUnit(unit, val)}> {content} </Tooltip>
+  }
+  return content
 }
 
 export default connect(mapStateToProps)(FormattedVal)


### PR DESCRIPTION

![maxLength](https://user-images.githubusercontent.com/29690241/56600990-47a90780-65fa-11e9-83ed-16273e5a58c1.gif)

### Type

Bug Fix, UI Polish...

### Context

Account's balance was overflowing the wrapper where there are lot of decimal values in a small screen

### Parts of the app affected / Test plan

![before maxLength](https://user-images.githubusercontent.com/29690241/56601491-9014f500-65fb-11e9-8878-41c0ba278eed.png)



