### PR TITLE
LL-1330 Redirect to dashboard on add account sidebar

### DIFF
--- a/src/components/MainSideBar/index.js
+++ b/src/components/MainSideBar/index.js
@@ -96,7 +96,10 @@ class MainSideBar extends PureComponent<Props> {
   handleClickManager = () => this.push('/manager')
   handleClickExchange = () => this.push('/partners')
   handleClickDev = () => this.push('/dev')
-  handleOpenImportModal = () => this.props.openModal(MODAL_ADD_ACCOUNTS)
+  handleOpenImportModal = () => {
+    this.push('/')
+    this.props.openModal(MODAL_ADD_ACCOUNTS)
+  }
 
   render() {
     const { t, accounts, location, developerMode } = this.props


### PR DESCRIPTION
Similarly to how Send/Receive now redirect to the dashboard to prevent the user from being on the manager https://github.com/LedgerHQ/ledger-live-desktop/pull/1927 do the same for Add account from the sidebar.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1330

### Parts of the app affected / Test plan

Sidebar navigation to Add new account when being on a different screen than dashboard.