### PR TITLE
fix passing error to the update firmware steps

### DIFF
--- a/src/components/modals/UpdateFirmware/index.js
+++ b/src/components/modals/UpdateFirmware/index.js
@@ -102,11 +102,11 @@ class UpdateModal extends PureComponent<Props, State> {
     const errorSteps = error ? [stepsId.indexOf(stepId)] : []
 
     const additionalProps = {
-      error,
+      ...props,
       onCloseModal: onClose,
       setError: this.setError,
       firmware,
-      ...props,
+      error,
     }
 
     return (


### PR DESCRIPTION
`error` was always empty due to props having a `null` and overrid the first error passed

### Type

fix

### Context

no context, just bug

### Parts of the app affected / Test plan

firmware update process

![image](https://user-images.githubusercontent.com/671786/56966473-76c1fa80-6b5f-11e9-8056-f4250e8c4ec6.png)
