### PR TITLE
LL-1336 Disable value on animation on countervalue switch Account page

### DIFF
--- a/src/components/AccountPage/AccountBalanceSummaryHeader.js
+++ b/src/components/AccountPage/AccountBalanceSummaryHeader.js
@@ -100,6 +100,9 @@ class AccountBalanceSummaryHeader extends PureComponent<Props> {
       data.reverse()
     }
 
+    const primaryKey = data[0].unit.code
+    const secondaryKey = data[1].unit.code
+
     return (
       <Box flow={4} mb={2}>
         <Box horizontal>
@@ -107,6 +110,7 @@ class AccountBalanceSummaryHeader extends PureComponent<Props> {
             <Swap />
           </SwapButton>
           <BalanceTotal
+            key={primaryKey}
             style={{ cursor: 'pointer' }}
             onClick={() => setCountervalueFirst(!countervalueFirst)}
             showCryptoEvenIfNotAvailable
@@ -115,7 +119,7 @@ class AccountBalanceSummaryHeader extends PureComponent<Props> {
             unit={data[0].unit}
           >
             <FormattedVal
-              key={account.id}
+              key={secondaryKey}
               animateTicker
               disableRounding
               alwaysShowSign={false}
@@ -130,7 +134,7 @@ class AccountBalanceSummaryHeader extends PureComponent<Props> {
             <PillsDaysCount selected={selectedTimeRange} onChange={this.handleChangeSelectedTime} />
           </Box>
         </Box>
-        <Box horizontal justifyContent="center" flow={7}>
+        <Box key={primaryKey} horizontal justifyContent="center" flow={7}>
           <BalanceSincePercent
             isAvailable={isAvailable}
             t={t}

--- a/src/icons/Swap.js
+++ b/src/icons/Swap.js
@@ -2,7 +2,14 @@
 
 import React from 'react'
 
-const Swap = ({ size = 15, color = 'currentColor', ...props }: { size?: number, color?: string }) => (
+const Swap = ({
+  size = 15,
+  color = 'currentColor',
+  ...props
+}: {
+  size?: number,
+  color?: string,
+}) => (
   <svg viewBox="0 0 15 17" width={(size / 15) * 15} height={(size / 15) * 17} {...props}>
     <path
       fill="none"


### PR DESCRIPTION
![noanim](https://user-images.githubusercontent.com/4631227/57373771-118a8c80-7191-11e9-8ceb-d008507e2c44.gif)

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1336

### Parts of the app affected / Test plan

Account Page, switch between fiat/crypto
