### PR TITLE
LL-1346 Partial fix for overflow on Account balance + tooltip

### DIFF
--- a/src/components/AccountPage/AccountBalanceSummaryHeader.js
+++ b/src/components/AccountPage/AccountBalanceSummaryHeader.js
@@ -111,7 +111,11 @@ class AccountBalanceSummaryHeader extends PureComponent<Props> {
           </SwapButton>
           <BalanceTotal
             key={primaryKey}
-            style={{ cursor: 'pointer' }}
+            style={{
+              cursor: 'pointer',
+              overflow: 'hidden',
+              flexShrink: 1,
+            }}
             onClick={() => setCountervalueFirst(!countervalueFirst)}
             showCryptoEvenIfNotAvailable
             isAvailable={isAvailable}

--- a/src/components/base/FormattedVal/index.js
+++ b/src/components/base/FormattedVal/index.js
@@ -30,6 +30,10 @@ const T = styled(Box).attrs({
 })`
   line-height: 1.2;
   white-space: pre;
+  text-overflow: ellipsis;
+  display: block;
+  width: 100%;
+  overflow: hidden;
 `
 
 const I = ({ color, children }: { color?: string, children: any }) => (


### PR DESCRIPTION
This is not a complete solution but it's what we've settled with, for now, we simply hide the overflowing digits and maintain the box for the range. Should be good enough for now, until we either remove the digit ticker that prevents a proper ellipsis or change the layout a big.

Also, the tooltip was getting broken. The current fix is to ellipsis it but we should make the tooltip a bit wider to accommodate the extra characters maybe.


### Type

UI Polish. 


### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

Account page, and generally anywhere using a balance to check if it broke somewhere 