### PR TITLE
Fixes LL-1357 (race condition): glitch affecting ETH experimental

### DIFF
--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -4,7 +4,7 @@ import { BigNumber } from 'bignumber.js'
 import logger from 'logger'
 import React from 'react'
 import FeesField from 'components/FeesField/EthereumKind'
-import AdvancedOptions from 'components/AdvancedOptions/EthereumKind'
+import EditAdvancedOptions from 'components/AdvancedOptions/EthereumKind'
 import throttle from 'lodash/throttle'
 import flatMap from 'lodash/flatMap'
 import uniqBy from 'lodash/uniqBy'
@@ -50,15 +50,6 @@ const EditFees = ({ account, onChange, value }: EditProps<Transaction>) => (
     }}
     gasPrice={value.gasPrice}
     account={account}
-  />
-)
-
-const EditAdvancedOptions = ({ onChange, value }: EditProps<Transaction>) => (
-  <AdvancedOptions
-    gasLimit={value.gasLimit}
-    onChangeGasLimit={gasLimit => {
-      onChange({ ...value, gasLimit })
-    }}
   />
 )
 

--- a/src/components/AdvancedOptions/EthereumKind.js
+++ b/src/components/AdvancedOptions/EthereumKind.js
@@ -1,37 +1,98 @@
 // @flow
-import React from 'react'
+import React, { PureComponent } from 'react'
 import { BigNumber } from 'bignumber.js'
 import { translate } from 'react-i18next'
-
+import type { Account } from '@ledgerhq/live-common/lib/types'
+import type { WalletBridge } from 'bridge/types'
 import Box from 'components/base/Box'
 import Input from 'components/base/Input'
 import Label from 'components/base/Label'
 import Spoiler from 'components/base/Spoiler'
 
 type Props = {
-  gasLimit: BigNumber,
-  onChangeGasLimit: BigNumber => void,
+  onChange: (*) => void,
+  value: *,
+  account: Account,
+  bridge: WalletBridge<*>,
   t: *,
 }
 
-export default translate()(({ gasLimit, onChangeGasLimit, t }: Props) => (
-  <Spoiler title={t('send.steps.amount.advancedOptions')}>
-    <Box horizontal align="center" flow={5}>
-      <Box style={{ width: 200 }}>
-        <Label>
-          <span>{t('send.steps.amount.ethereumGasLimit')}</span>
-        </Label>
-      </Box>
-      <Box grow>
-        <Input
-          value={gasLimit}
-          onChange={str => {
-            const gasLimit = BigNumber(str || 0)
-            if (!gasLimit.isNaN() && gasLimit.isFinite()) onChangeGasLimit(gasLimit)
-            else onChangeGasLimit(BigNumber(0x5208))
-          }}
-        />
-      </Box>
-    </Box>
-  </Spoiler>
-))
+class AdvancedOptions extends PureComponent<Props, *> {
+  state = {
+    loading: false,
+  }
+
+  componentDidMount() {
+    this.resync()
+  }
+
+  componentDidUpdate(nextProps: Props) {
+    if (nextProps.value !== this.props.value) {
+      this.resync()
+    }
+  }
+  componentWillUnmount() {
+    this.syncId++
+    this.isUnmounted = true
+  }
+
+  lastRecipient = this.props.value.recipient
+  isUnmounted = false
+  syncId = 0
+  async resync() {
+    const { bridge, account, value, onChange } = this.props
+    const syncId = ++this.syncId
+    const recipient = bridge.getTransactionRecipient(account, value)
+    if (recipient === this.lastRecipient) return
+    const isValid = await bridge.isRecipientValid(account, recipient)
+    if (syncId !== this.syncId) return
+    if (this.isUnmounted) return
+    if (isValid && bridge.estimateGasLimit) {
+      const { estimateGasLimit } = bridge
+      let gasLimit
+      try {
+        this.setState({ loading: true })
+        gasLimit = await estimateGasLimit(account, recipient)
+      } finally {
+        if (!this.isUnmounted) this.setState({ loading: false })
+      }
+      if (syncId !== this.syncId) return
+      if (this.isUnmounted) return
+      this.lastRecipient = recipient
+      onChange({
+        ...this.props.value,
+        gasLimit: BigNumber(gasLimit),
+      })
+    }
+  }
+
+  onChange = (str: string) => {
+    const { onChange, value } = this.props
+    let gasLimit = BigNumber(str || 0)
+    if (gasLimit.isNaN() || !gasLimit.isFinite()) {
+      gasLimit = BigNumber(0x5208)
+    }
+    onChange({ ...value, gasLimit })
+  }
+
+  render() {
+    const { value, t } = this.props
+    const { loading } = this.state
+    return (
+      <Spoiler title={t('send.steps.amount.advancedOptions')}>
+        <Box horizontal align="center" flow={5}>
+          <Box style={{ width: 200 }}>
+            <Label>
+              <span>{t('send.steps.amount.ethereumGasLimit')}</span>
+            </Label>
+          </Box>
+          <Box grow>
+            <Input value={value.gasLimit} onChange={this.onChange} loading={loading} />
+          </Box>
+        </Box>
+      </Spoiler>
+    )
+  }
+}
+
+export default translate()(AdvancedOptions)

--- a/src/components/modals/Send/fields/RecipientField.js
+++ b/src/components/modals/Send/fields/RecipientField.js
@@ -10,7 +10,6 @@ import LabelWithExternalIcon from 'components/base/LabelWithExternalIcon'
 import RecipientAddress from 'components/RecipientAddress'
 import { track } from 'analytics/segment'
 import { createCustomErrorClass, CantScanQRCode } from '@ledgerhq/errors'
-import { BigNumber } from 'bignumber.js'
 
 type Props<Transaction> = {
   t: T,
@@ -50,7 +49,7 @@ class RecipientField<Transaction> extends Component<
   isUnmounted = false
   syncId = 0
   async resync() {
-    const { account, bridge, transaction, onChangeTransaction } = this.props
+    const { account, bridge, transaction } = this.props
     const syncId = ++this.syncId
     const recipient = bridge.getTransactionRecipient(account, transaction)
     const isValid = await bridge.isRecipientValid(account, recipient)
@@ -58,13 +57,6 @@ class RecipientField<Transaction> extends Component<
     if (syncId !== this.syncId) return
     if (this.isUnmounted) return
     this.setState({ isValid, warning })
-
-    if (isValid && bridge.estimateGasLimit) {
-      // $FlowFixMe
-      transaction.gasLimit = BigNumber(await bridge.estimateGasLimit(account, recipient))
-      if (syncId !== this.syncId) return
-      onChangeTransaction(transaction)
-    }
   }
 
   onChange = async (recipient: string, maybeExtra: ?Object) => {

--- a/src/components/modals/Send/fields/RecipientField.js
+++ b/src/components/modals/Send/fields/RecipientField.js
@@ -62,6 +62,7 @@ class RecipientField<Transaction> extends Component<
     if (isValid && bridge.estimateGasLimit) {
       // $FlowFixMe
       transaction.gasLimit = BigNumber(await bridge.estimateGasLimit(account, recipient))
+      if (syncId !== this.syncId) return
       onChangeTransaction(transaction)
     }
   }

--- a/src/components/modals/Send/steps/01-step-amount.js
+++ b/src/components/modals/Send/steps/01-step-amount.js
@@ -71,6 +71,7 @@ export default ({
 
             {AdvancedOptionsField && (
               <AdvancedOptionsField
+                bridge={bridge}
                 account={account}
                 value={transaction}
                 onChange={onChangeTransaction}


### PR DESCRIPTION
A race condition can happen in this case:
- if estimateGasLimit is slow
- in the meantime user edit any of the transaction fields

to cover this problem, we use the same protection as for all the resync() code: using a syncId

---

There is however room for improvement in the current implementation that we will have to tackle.

- ⚠️ current code will call `estimateGasLimit` for EVERY CHANGE of transaction changes, this means every key stroke, even if it's not needed (because it's done in a resync) will trigger an http request and will be prone to the present bug. Instead we need to only change if recipient changes.

proof when editing the amount:
<img width="1056" alt="Capture d’écran 2019-05-09 à 14 27 26" src="https://user-images.githubusercontent.com/211411/57453402-9e534a00-7266-11e9-8ff2-a1a5f7b64639.png">


- RecipientField is in fact not the correct place to call this `estimateGasLimit`. Conceptually `gasLimit` is part of the transaction object but is also the asynchronous result of that same transaction object. For this kind of effect, either we need to abstract out this concept in the bridge OR we could move the current logic in the GasLimit field itself (which would somehow make sense, it's part of the same component afterall). I would suggest solution 2 for now because bridge will be refactored soon.
- ⚠️ If user have started modifying the gasLimit, it's getting **overridden** each time something else is modified. the correct behavior should be to no longer touch it if user have, or alternatively, only if address changes (which would be easy with the first point).

### Type

Bugfix

### Context

LL-1357

### Parts of the app affected / Test plan

Send, step 1