### PR TITLE
LL-1362 and LL-1360

### DIFF
--- a/src/components/AutoRepair.js
+++ b/src/components/AutoRepair.js
@@ -1,0 +1,51 @@
+// @flow
+
+import React, { useState, useEffect } from 'react'
+import noop from 'lodash/noop'
+import { Trans } from 'react-i18next'
+import logger from 'logger'
+import RepairModal from 'components/base/Modal/RepairModal'
+import firmwareRepair from 'commands/firmwareRepair'
+
+type Props = {
+  onDone: () => void,
+}
+
+const AutoRepair = ({ onDone }: Props) => {
+  const [error, setError] = useState(null)
+  const [progress, setProgress] = useState(0)
+  useEffect(() => {
+    const sub = firmwareRepair.send({ version: null }).subscribe({
+      next: patch => {
+        if ('progress' in patch) {
+          setProgress(patch.progress)
+        }
+      },
+      error: error => {
+        logger.critical(error)
+        setError(error)
+      },
+      complete: () => onDone(),
+    })
+    return () => sub.unsubscribe()
+  }, [])
+
+  return (
+    <RepairModal
+      isAlreadyBootloader
+      cancellable
+      analyticsName="RepairDevice"
+      isOpened
+      isLoading
+      onClose={onDone}
+      onReject={onDone}
+      repair={noop}
+      title={<Trans i18nKey="settings.repairDevice.title" />}
+      desc={<Trans i18nKey="settings.repairDevice.desc" />}
+      progress={progress}
+      error={error}
+    />
+  )
+}
+
+export default AutoRepair

--- a/src/components/ConnectTroubleshooting.js
+++ b/src/components/ConnectTroubleshooting.js
@@ -1,0 +1,43 @@
+// @flow
+
+import React, { useState, useEffect } from 'react'
+import { Trans } from 'react-i18next'
+import Box from 'components/base/Box'
+import Text from 'components/base/Text'
+import ConnectTroubleshootingHelpButton from 'components/ConnectTroubleshootingHelpButton'
+import RepairDeviceButton from 'components/SettingsPage/RepairDeviceButton'
+
+type Props = {
+  appearsAfterDelay?: number,
+}
+
+const ConnectTroubleshooting = ({ appearsAfterDelay = 20000 }: Props) => {
+  const [visible, setVisible] = useState(false)
+  useEffect(() => {
+    const timeout = setTimeout(() => setVisible(true), appearsAfterDelay)
+    return () => clearTimeout(timeout)
+  }, [])
+
+  return (
+    <Box
+      p={4}
+      alignItems="center"
+      style={{
+        opacity: visible ? 1 : 0,
+        transition: 'opacity 2s',
+      }}
+    >
+      <Box p={2}>
+        <Text ff="Open Sans|SemiBold" fontSize={4}>
+          <Trans i18nKey="connectTroubleshooting.desc" />
+        </Text>
+      </Box>
+      <Box horizontal>
+        <ConnectTroubleshootingHelpButton />
+        <RepairDeviceButton />
+      </Box>
+    </Box>
+  )
+}
+
+export default ConnectTroubleshooting

--- a/src/components/ConnectTroubleshootingHelpButton.js
+++ b/src/components/ConnectTroubleshootingHelpButton.js
@@ -1,0 +1,23 @@
+// @flow
+
+import React from 'react'
+import { Trans } from 'react-i18next'
+import { colors } from 'styles/theme'
+import { openURL } from 'helpers/linking'
+import { urls } from 'config/urls'
+import IconHelp from 'icons/Help'
+import Button from 'components/base/Button'
+import Box from 'components/base/Box'
+
+// $FlowFixMe no idea
+const ConnectTroubleshootingHelpButton = React.memo(() => (
+  <Button onClick={() => openURL(urls.troubleshootingUSB)} style={{ margin: '0 10px' }}>
+    <Box color={colors.wallet} horizontal align="center">
+      <IconHelp size={16} />
+      {' '}
+      <Trans i18nKey="common.help" />
+    </Box>
+  </Button>
+))
+
+export default ConnectTroubleshootingHelpButton

--- a/src/components/FlashMCU.js
+++ b/src/components/FlashMCU.js
@@ -1,0 +1,58 @@
+// @flow
+
+import React, { Fragment } from 'react'
+import styled from 'styled-components'
+import { translate, Trans } from 'react-i18next'
+import { i } from 'helpers/staticPath'
+import Box from 'components/base/Box'
+import Text from 'components/base/Text'
+import { bootloader } from 'config/nontranslatables'
+
+const Bullet = styled.span`
+  font-weight: 600;
+  color: #142533;
+`
+
+const Separator = styled(Box).attrs({
+  color: 'fog',
+})`
+  height: 1px;
+  width: 100%;
+  background-color: currentColor;
+`
+
+const FlashMCU = React.memo(({ t }) => (
+  <Fragment>
+    <Box mx={7}>
+      <Text ff="Open Sans|Regular" align="center" color="smoke">
+        <Bullet>{'1. '}</Bullet>
+        {t('manager.modal.mcuFirst')}
+      </Text>
+      <img
+        src={i('logos/unplugDevice.png')}
+        style={{ width: '100%', maxWidth: 368, marginTop: 30 }}
+        alt={t('manager.modal.mcuFirst')}
+      />
+    </Box>
+    <Separator my={6} />
+    <Box mx={7}>
+      <Text ff="Open Sans|Regular" align="center" color="smoke">
+        <Bullet>{'2. '}</Bullet>
+        <Trans i18nKey="manager.modal.mcuSecond">
+          {'Press the left button and hold it while you reconnect the USB cable until the '}
+          <Text ff="Open Sans|SemiBold" color="dark">
+            {bootloader}
+          </Text>
+          {' screen appears'}
+        </Trans>
+      </Text>
+      <img
+        src={i('logos/bootloaderMode.png')}
+        style={{ width: '100%', maxWidth: 368, marginTop: 30 }}
+        alt={t('manager.modal.mcuFirst')}
+      />
+    </Box>
+  </Fragment>
+))
+
+export default translate()(FlashMCU)

--- a/src/components/ManagerPage/ManagerGenuineCheck.js
+++ b/src/components/ManagerPage/ManagerGenuineCheck.js
@@ -38,7 +38,7 @@ class ManagerGenuineCheck extends PureComponent<Props> {
           </Text>
         </Box>
         <Space of={40} />
-        <GenuineCheck shouldRenderRetry onSuccess={onSuccess} style={{ width: 400 }} />
+        <GenuineCheck onSuccess={onSuccess} style={{ width: 400 }} />
       </Box>
     )
   }

--- a/src/components/SettingsPage/RepairDeviceButton.js
+++ b/src/components/SettingsPage/RepairDeviceButton.js
@@ -16,6 +16,7 @@ import RepairModal from 'components/base/Modal/RepairModal'
 type Props = {
   t: T,
   push: string => void,
+  buttonProps?: *,
 }
 
 type State = {
@@ -75,12 +76,12 @@ class RepairDeviceButton extends PureComponent<Props, State> {
   }
 
   render() {
-    const { t } = this.props
+    const { t, buttonProps } = this.props
     const { opened, isLoading, error, progress } = this.state
 
     return (
       <Fragment>
-        <Button small primary onClick={this.open} event="RepairDeviceButton">
+        <Button {...buttonProps} primary onClick={this.open} event="RepairDeviceButton">
           {t('settings.repairDevice.button')}
         </Button>
 

--- a/src/components/SettingsPage/sections/Help.js
+++ b/src/components/SettingsPage/sections/Help.js
@@ -77,7 +77,7 @@ class SectionHelp extends PureComponent<Props> {
             title={t('settings.repairDevice.title')}
             desc={t('settings.repairDevice.descSettings')}
           >
-            <RepairDeviceButton />
+            <RepairDeviceButton buttonProps={{ small: true }} />
           </Row>
         </Body>
       </Section>

--- a/src/components/modals/UpdateFirmware/steps/02-step-flash-mcu.js
+++ b/src/components/modals/UpdateFirmware/steps/02-step-flash-mcu.js
@@ -1,19 +1,12 @@
 // @flow
 
-import React, { PureComponent, Fragment } from 'react'
-import { Trans } from 'react-i18next'
+import React, { PureComponent } from 'react'
 import styled from 'styled-components'
-
-import { i } from 'helpers/staticPath'
 import firmwareMain from 'commands/firmwareMain'
-
-import { bootloader } from 'config/nontranslatables'
 import TrackPage from 'analytics/TrackPage'
 import Box from 'components/base/Box'
-import Text from 'components/base/Text'
-
+import FlashMCU from 'components/FlashMCU'
 import type { StepProps } from '../'
-
 import Installing from '../Installing'
 
 const Container = styled(Box).attrs({
@@ -27,19 +20,6 @@ const Title = styled(Box).attrs({
   fontSize: 5,
   mb: 3,
 })``
-
-const Bullet = styled.span`
-  font-weight: 600;
-  color: #142533;
-`
-
-const Separator = styled(Box).attrs({
-  color: 'fog',
-})`
-  height: 1px;
-  width: 100%;
-  background-color: currentColor;
-`
 
 type Props = StepProps
 
@@ -79,42 +59,12 @@ class StepFlashMcu extends PureComponent<Props, State> {
 
   renderBody = () => {
     const { installing, progress } = this.state
-    const { firmware, t } = this.props
+    const { firmware } = this.props
 
     return installing || !firmware.shouldFlashMCU ? (
       <Installing installing={installing} progress={progress} />
     ) : (
-      <Fragment>
-        <Box mx={7}>
-          <Text ff="Open Sans|Regular" align="center" color="smoke">
-            <Bullet>{'1. '}</Bullet>
-            {t('manager.modal.mcuFirst')}
-          </Text>
-          <img
-            src={i('logos/unplugDevice.png')}
-            style={{ width: '100%', maxWidth: 368, marginTop: 30 }}
-            alt={t('manager.modal.mcuFirst')}
-          />
-        </Box>
-        <Separator my={6} />
-        <Box mx={7}>
-          <Text ff="Open Sans|Regular" align="center" color="smoke">
-            <Bullet>{'2. '}</Bullet>
-            <Trans i18nKey="manager.modal.mcuSecond">
-              {'Press the left button and hold it while you reconnect the USB cable until the '}
-              <Text ff="Open Sans|SemiBold" color="dark">
-                {bootloader}
-              </Text>
-              {' screen appears'}
-            </Trans>
-          </Text>
-          <img
-            src={i('logos/bootloaderMode.png')}
-            style={{ width: '100%', maxWidth: 368, marginTop: 30 }}
-            alt={t('manager.modal.mcuFirst')}
-          />
-        </Box>
-      </Fragment>
+      <FlashMCU />
     )
   }
 

--- a/src/config/nontranslatables.js
+++ b/src/config/nontranslatables.js
@@ -9,7 +9,9 @@ export const seedNext = 'Next'
 export const seedConfirmation = 'Confirmation'
 
 export const bootloader = 'Bootloader'
+export const mcuOutdated = 'MCU outdated'
 export const mcuNotGenuine = 'MCU not genuine'
 export const followDeviceRepair = 'Follow device repair instructions'
+export const followDeviceUpdate = 'Follow device update instructions'
 
 export const repairProcessing = 'Processing'

--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -18,11 +18,12 @@ export const urls = {
   noDeviceBuyNew: 'https://www.ledgerwallet.com/',
   noDeviceTrackOrder: 'http://order.ledgerwallet.com/',
   noDeviceLearnMore: 'https://www.ledgerwallet.com/',
-  managerHelpRequest: 'https://support.ledgerwallet.com/hc/en-us/articles/360006523674 ',
+  managerHelpRequest: 'https://support.ledger.com/hc/en-us/articles/360006523674 ',
   contactSupport: 'https://support.ledgerwallet.com/hc/en-us/requests/new?ticket_form_id=248165',
-  feesMoreInfo: 'https://support.ledgerwallet.com/hc/en-us/articles/360006535873',
+  feesMoreInfo: 'https://support.ledger.com/hc/en-us/articles/360006535873',
   recipientAddressInfo: 'https://support.ledger.com/hc/en-us/articles/360006433934',
   privacyPolicy: 'https://www.ledger.com/pages/privacy-policy',
+  troubleshootingUSB: 'https://support.ledger.com/hc/en-us/articles/115005165269',
 
   githubIssues:
     'https://github.com/LedgerHQ/ledger-live-desktop/issues?q=is%3Aissue+is%3Aopen+label%3Abug+sort%3Acomments-desc',
@@ -45,7 +46,7 @@ export const urls = {
 
   // Errors
   errors: {
-    CantOpenDevice: 'https://support.ledgerwallet.com/hc/en-us/articles/115005165269',
+    CantOpenDevice: 'https://support.ledger.com/hc/en-us/articles/115005165269',
   },
 
   // Currencies status

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -209,7 +209,8 @@
   "genuinecheck": {
     "modal": {
       "title": "Genuine check"
-    }
+    },
+    "deviceInBootloader": "Your device is in Bootloader mode. Click {{button}} to update it."
   },
   "addAccounts": {
     "title": "Add accounts",
@@ -296,7 +297,7 @@
         "flash-mcu": "MCU updating...",
         "flash-bootloader": "Bootloader updating...",
         "firmware": "Firmware updating...",
-        "flash": "Flashing your device..."
+        "flash": "Updating your device..."
       },
       "confirmIdentifier": "Verify the identifier",
       "confirmIdentifierText":
@@ -828,6 +829,9 @@
       "desc": "Install some apps on your device and access the Portfolio",
       "openAppButton": "Open Ledger Live"
     }
+  },
+  "connectTroubleshooting": {
+    "desc": "Having a hard time connecting your device?"
   },
   "errors": {
     "generic": {


### PR DESCRIPTION
Improve Firmware Update recovery experience. This should recover all possible stuck case for a better UX.

## (1) Manager Troubleshooting footer

when opening Manager, after 10s of being stuck in first step, a footer will appear

<img width="1136" alt="Capture d’écran 2019-05-10 à 20 18 47" src="https://user-images.githubusercontent.com/211411/57548314-ef476900-7360-11e9-9c1d-31fa4d80b026.png">

The same footer appear in onboarding

<img width="1136" alt="Capture d’écran 2019-05-10 à 20 20 09" src="https://user-images.githubusercontent.com/211411/57548369-0a19dd80-7361-11e9-9a65-2a79f4c6ac84.png">

The **Help** button link to https://support.ledger.com/hc/en-us/articles/115005165269

The Repair opens the Repair modal

<img width="1136" alt="Capture d’écran 2019-05-10 à 20 20 47" src="https://user-images.githubusercontent.com/211411/57548400-1d2cad80-7361-11e9-8c83-2ec071b48bfe.png">

## (2) If opening Manager in Bootloader, repair is automatically started

![repair](https://user-images.githubusercontent.com/211411/57548553-83b1cb80-7361-11e9-8d33-e8d8b5d4a4da.gif)
