### PR TITLE
add a new failed indicator on operation list and details

### DIFF
--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -69,7 +69,7 @@ const txToOps = (account: Account) => (tx: Tx): Operation[] => {
       id: `${account.id}-${tx.hash}-OUT`,
       hash: tx.hash,
       type: 'OUT',
-      value: value.plus(fee),
+      value: tx.status ? value.plus(fee) : fee,
       fee,
       blockHeight: tx.block && tx.block.height,
       blockHash: tx.block && tx.block.hash,
@@ -78,6 +78,7 @@ const txToOps = (account: Account) => (tx: Tx): Operation[] => {
       recipients: [tx.to],
       date: new Date(tx.received_at),
       extra: {},
+      hasFailed: !tx.status,
     }
     ops.push(op)
   }

--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -69,7 +69,7 @@ const txToOps = (account: Account) => (tx: Tx): Operation[] => {
       id: `${account.id}-${tx.hash}-OUT`,
       hash: tx.hash,
       type: 'OUT',
-      value: tx.status ? value.plus(fee) : fee,
+      value: tx.status === 0 ? fee : value.plus(fee),
       fee,
       blockHeight: tx.block && tx.block.height,
       blockHash: tx.block && tx.block.hash,
@@ -78,7 +78,7 @@ const txToOps = (account: Account) => (tx: Tx): Operation[] => {
       recipients: [tx.to],
       date: new Date(tx.received_at),
       extra: {},
-      hasFailed: !tx.status,
+      hasFailed: tx.status === 0,
     }
     ops.push(op)
   }

--- a/src/components/OperationsList/ConfirmationCell.js
+++ b/src/components/OperationsList/ConfirmationCell.js
@@ -58,6 +58,7 @@ class ConfirmationCell extends PureComponent<Props> {
           type={operation.type}
           isConfirmed={isConfirmed}
           marketColor={marketColor}
+          hasFailed={operation.hasFailed}
           t={t}
         />
       </Cell>

--- a/src/components/OperationsList/ConfirmationCheck.js
+++ b/src/components/OperationsList/ConfirmationCheck.js
@@ -17,14 +17,21 @@ import Box from 'components/base/Box'
 import Tooltip from 'components/base/Tooltip'
 
 const border = p =>
-  p.isConfirmed
-    ? 0
-    : `1px solid ${p.type === 'IN' ? p.marketColor : rgba(p.theme.colors.grey, 0.2)}`
+  p.hasFailed
+    ? `1px solid ${p.theme.colors.alertRed}`
+    : p.isConfirmed
+      ? 0
+      : `1px solid ${p.type === 'IN' ? p.marketColor : rgba(p.theme.colors.grey, 0.2)}`
 
 const Container = styled(Box).attrs({
   bg: p =>
-    p.isConfirmed ? rgba(p.type === 'IN' ? p.marketColor : p.theme.colors.grey, 0.2) : 'none',
-  color: p => (p.type === 'IN' ? p.marketColor : p.theme.colors.grey),
+    p.hasFailed
+      ? rgba(p.theme.colors.alertRed, 0.05)
+      : p.isConfirmed
+        ? rgba(p.type === 'IN' ? p.marketColor : p.theme.colors.grey, 0.2)
+        : 'none',
+  color: p =>
+    p.hasFailed ? p.theme.colors.alertRed : p.type === 'IN' ? p.marketColor : p.theme.colors.grey,
   align: 'center',
   justify: 'center',
 })`
@@ -52,6 +59,7 @@ class ConfirmationCheck extends PureComponent<{
   t: T,
   type: OperationType,
   withTooltip?: boolean,
+  hasFailed?: boolean,
 }> {
   static defaultProps = {
     withTooltip: true,
@@ -63,10 +71,16 @@ class ConfirmationCheck extends PureComponent<{
   }
 
   render() {
-    const { marketColor, isConfirmed, t, type, withTooltip, ...props } = this.props
+    const { marketColor, isConfirmed, t, type, withTooltip, hasFailed, ...props } = this.props
 
     const content = (
-      <Container type={type} isConfirmed={isConfirmed} marketColor={marketColor} {...props}>
+      <Container
+        type={type}
+        isConfirmed={isConfirmed}
+        marketColor={marketColor}
+        hasFailed={hasFailed}
+        {...props}
+      >
         {type === 'IN' ? <IconReceive size={12} /> : <IconSend size={12} />}
         {!isConfirmed && (
           <WrapperClock>

--- a/src/components/modals/OperationDetails.js
+++ b/src/components/modals/OperationDetails.js
@@ -144,6 +144,8 @@ const OperationDetails = connect(mapStateToProps)((props: Props) => {
   const url = getAccountOperationExplorer(account, operation)
   const uniqueSenders = uniq(senders)
 
+  const { hasFailed } = operation
+
   return (
     <ModalBody
       title={t('operationDetails.title')}
@@ -154,6 +156,7 @@ const OperationDetails = connect(mapStateToProps)((props: Props) => {
             <ConfirmationCheck
               marketColor={marketColor}
               isConfirmed={isConfirmed}
+              hasFailed={hasFailed}
               style={{
                 transform: 'scale(1.5)',
               }}
@@ -161,8 +164,10 @@ const OperationDetails = connect(mapStateToProps)((props: Props) => {
               type={type}
               withTooltip={false}
             />
-            <Box my={4} alignItems="center">
-              <Box selectable>
+          </Box>
+          <Box my={4} alignItems="center">
+            <Box selectable>
+              {hasFailed ? null : (
                 <FormattedVal
                   color={amount.isNegative() ? 'smoke' : undefined}
                   unit={unit}
@@ -172,8 +177,10 @@ const OperationDetails = connect(mapStateToProps)((props: Props) => {
                   fontSize={7}
                   disableRounding
                 />
-              </Box>
-              <Box mt={1} selectable>
+              )}
+            </Box>
+            <Box mt={1} selectable>
+              {hasFailed ? null : (
                 <CounterValue
                   color="grey"
                   fontSize={5}
@@ -181,7 +188,7 @@ const OperationDetails = connect(mapStateToProps)((props: Props) => {
                   currency={currency}
                   value={amount}
                 />
-              </Box>
+              )}
             </Box>
           </Box>
           <Box horizontal flow={2}>
@@ -210,13 +217,19 @@ const OperationDetails = connect(mapStateToProps)((props: Props) => {
             </Box>
             <Box flex={1}>
               <OpDetailsTitle>{t('operationDetails.status')}</OpDetailsTitle>
-              <OpDetailsData color={isConfirmed ? 'positiveGreen' : null} horizontal flow={1}>
+              <OpDetailsData
+                color={hasFailed ? 'alertRed' : isConfirmed ? 'positiveGreen' : null}
+                horizontal
+                flow={1}
+              >
                 <Box>
-                  {isConfirmed
-                    ? t('operationDetails.confirmed')
-                    : t('operationDetails.notConfirmed')}
+                  {hasFailed
+                    ? t('operationDetails.failed')
+                    : isConfirmed
+                      ? t('operationDetails.confirmed')
+                      : t('operationDetails.notConfirmed')}
                 </Box>
-                <Box>{`(${confirmations})`}</Box>
+                {hasFailed ? null : <Box>{`(${confirmations})`}</Box>}
               </OpDetailsData>
             </Box>
           </Box>

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -254,6 +254,7 @@
     "date": "Date",
     "status": "Status",
     "confirmed": "Confirmed",
+    "failed": "Failed",
     "notConfirmed": "Not confirmed",
     "fees": "Fees",
     "noFees": "No fee",


### PR DESCRIPTION
Adds a new indicator for failed ETH transactions in OperationsList and OperationDetails

### Type

Improvement

### Context

LL-1316

### Parts of the app affected / Test plan

Account page and Operation Details

![image](https://user-images.githubusercontent.com/671786/57632052-f3fa6000-75a0-11e9-871d-18e8b0c1fd93.png)

![image](https://user-images.githubusercontent.com/671786/57632059-fceb3180-75a0-11e9-88f5-3ad00ce43bf7.png)

