### PR TITLE
Fixes refuse on device to not show the disclaimer

### DIFF
--- a/src/components/modals/Send/index.js
+++ b/src/components/modals/Send/index.js
@@ -126,7 +126,7 @@ const INITIAL_STATE = {
   bridge: null,
   transaction: null,
   error: null,
-  signed: true,
+  signed: false,
   optimisticOperation: null,
   isAppOpened: false,
 }


### PR DESCRIPTION
I suspect the disclaimer has always ever shown unlike what was initially specified to only appear in broadcast case. This should now fixes the problem.

Before:

<img width="1136" alt="Capture d’écran 2019-05-14 à 08 08 20" src="https://user-images.githubusercontent.com/211411/57674385-7590d300-761f-11e9-936c-1a40151b400e.png">

After:

<img width="1136" alt="Capture d’écran 2019-05-14 à 08 05 33" src="https://user-images.githubusercontent.com/211411/57674325-48dcbb80-761f-11e9-8b91-0dcda12d6ace.png">
<img width="1136" alt="Capture d’écran 2019-05-14 à 08 05 24" src="https://user-images.githubusercontent.com/211411/57674327-48dcbb80-761f-11e9-9c0e-0b2a22a60205.png">


(another error that shows in the screenshot is that we're on step 4. we should not be, we should still be erroring while in step 3, but this one is more work to fix so let's not touch this for now)

### Type

bugfixes
