### PR TITLE
LL-1219 Reduce flex-shrink to allow seeing more in modals

### DIFF
--- a/src/components/base/Modal/index.js
+++ b/src/components/base/Modal/index.js
@@ -224,7 +224,7 @@ const BODY_WRAPPER_STYLE = {
   borderRadius: 3,
   boxShadow: 'box-shadow: 0 10px 20px 0 rgba(0, 0, 0, 0.2)',
   color: colors.smoke,
-  flexShrink: 1,
+  flexShrink: 0.5,
   display: 'flex',
   flexDirection: 'column',
 }


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/57767006-5158f300-7700-11e9-8e2c-c1757fe8dfb9.png)

### Type

Reduce flex shrink to allow more visible fields. I still think we should _eventually_ split the first step of the send flow instead of gaining a little bit of height like this, but that's a different battle.

### Context

https://ledgerhq.atlassian.net/browse/LL-1219

### Parts of the app affected / Test plan

Modals