### PR TITLE
FormattedValue ui glitches from ellipse pr

### DIFF
--- a/src/components/base/AccountsList/AccountRow.js
+++ b/src/components/base/AccountsList/AccountRow.js
@@ -97,6 +97,7 @@ export default class AccountRow extends PureComponent<Props> {
           <FormattedVal
             val={account.balance}
             unit={account.unit}
+            style={{ textAlign: 'right' }}
             showCode
             fontSize={4}
             color="grey"

--- a/src/components/base/FormattedVal/index.js
+++ b/src/components/base/FormattedVal/index.js
@@ -32,6 +32,7 @@ const T = styled(Box).attrs({
   white-space: pre;
   text-overflow: ellipsis;
   display: block;
+  flex-shrink: 1;
   width: 100%;
   overflow: hidden;
 `


### PR DESCRIPTION
After the merge of https://github.com/LedgerHQ/ledger-live-desktop/pull/1977 we introduced at least one glitch in the UI affecting the imported accounts. This addresses it. I've gone through all formattedValue component usages that I can find where we might be using an ellipsis (when it's not animated) if I find any more I'll commit here too

![image](https://user-images.githubusercontent.com/4631227/57769698-7cdedc00-7706-11e9-81fc-6990fb4a45e0.png)


### Type

UI Polish
