### PR TITLE
LL-1375 Allow select options to overflow container

### DIFF
--- a/src/components/base/Select/createStyles.js
+++ b/src/components/base/Select/createStyles.js
@@ -43,9 +43,14 @@ export default ({
     ...styles,
     background: 'none',
   }),
+  noOptionsMessage: (styles: Object) => ({
+    ...styles,
+    fontSize: small ? 12 : 13,
+  }),
   option: (styles: Object, { isFocused, isSelected }: Object) => ({
     ...styles,
     ...ff('Open Sans|Regular'),
+    fontSize: small ? 12 : 13,
     color: colors.dark,
     padding: '10px 15px 10px 15px',
     ...(isFocused
@@ -71,6 +76,7 @@ export default ({
     background: 'white',
     borderRadius: 3,
   }),
+  menuPortal: (styles: Object) => ({ ...styles, zIndex: 101 }),
   container: (styles: Object) => ({
     ...styles,
     fontSize: small ? 12 : 13,

--- a/src/components/base/Select/index.js
+++ b/src/components/base/Select/index.js
@@ -106,6 +106,7 @@ class Select extends PureComponent<Props> {
         blurInputOnSelect={false}
         backspaceRemovesValue
         menuShouldBlockScroll
+        menuPortalTarget={document.body}
         {...props}
         onChange={this.handleChange}
       />

--- a/src/components/modals/AccountSettingRenderBody.js
+++ b/src/components/modals/AccountSettingRenderBody.js
@@ -234,6 +234,7 @@ class AccountSettingRenderBody extends PureComponent<Props, State> {
               </Box>
               <Box style={{ width: 230 }}>
                 <Select
+                  isSearchable={false}
                   onChange={this.handleChangeUnit}
                   getOptionValue={unitGetOptionValue}
                   renderValue={renderUnitItemCode}


### PR DESCRIPTION
In many places of the app we had issues with the dropdown menu options not being allowed to overflow the modal containing them which meant sometimes the options remained hidden, or got cut and it made the experience a bit awkward. By using [portaling](https://react-select.com/advanced#portaling) we can extract the options container to a higher level and allow it to _overflow_ the perceived one.

![image](https://user-images.githubusercontent.com/4631227/57793923-c6e5b300-7742-11e9-94bf-e98184b427cc.png)


The main drawback is that the scrolling will be disabled while the dropdown menu is open, but since it's already the case for the context menu on account cards it makes it something not so bad.

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1375

### Parts of the app affected / Test plan

Modals mostly, anywhere using a dropdown selector.
