### PR TITLE
UI Bugs caused by changes to FormattedValue and derivates

### DIFF
--- a/src/components/base/AccountsList/AccountRow.js
+++ b/src/components/base/AccountsList/AccountRow.js
@@ -58,7 +58,7 @@ export default class AccountRow extends PureComponent<Props> {
   }
 
   _input = null
-
+  overflowStyles = { textOverflow: 'ellipsis', overflow: 'hidden', whiteSpace: 'nowrap' }
   render() {
     const {
       account,
@@ -78,7 +78,7 @@ export default class AccountRow extends PureComponent<Props> {
         <Box shrink grow ff="Open Sans|SemiBold" color="dark" fontSize={4}>
           {onEditName ? (
             <Input
-              containerProps={{ style: { width: 200 } }}
+              style={this.overflowStyles}
               value={accountName}
               onChange={this.handleChangeName}
               onClick={this.onClickInput}
@@ -90,14 +90,14 @@ export default class AccountRow extends PureComponent<Props> {
               autoFocus={autoFocusInput}
             />
           ) : (
-            <div style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}>{accountName}</div>
+            <div style={this.overflowStyles}>{accountName}</div>
           )}
         </Box>
         {!hideAmount ? (
           <FormattedVal
             val={account.balance}
             unit={account.unit}
-            style={{ textAlign: 'right' }}
+            style={{ textAlign: 'right', width: 'auto' }}
             showCode
             fontSize={4}
             color="grey"

--- a/src/components/modals/Send/steps/01-step-amount.js
+++ b/src/components/modals/Send/steps/01-step-amount.js
@@ -192,6 +192,7 @@ export class StepAmountFooter extends PureComponent<
             {account && (
               <FormattedVal
                 disableRounding
+                style={{ width: 'auto' }}
                 color="dark"
                 val={totalSpent}
                 unit={account.unit}


### PR DESCRIPTION
- Send flow step 1 footer. The countervalue was being pushed to the right into the "Next" button.
- Import accounts flow. The account name was wrapping instead of negotiating the width with the amount.