### PR TITLE
Allow app update from accounts page if no accounts

### DIFF
--- a/src/components/AccountsPage/index.js
+++ b/src/components/AccountsPage/index.js
@@ -9,6 +9,7 @@ import { push } from 'react-router-redux'
 import styled from 'styled-components'
 import type { Account } from '@ledgerhq/live-common/lib/types'
 import type { PortfolioRange } from '@ledgerhq/live-common/lib/types/portfolio'
+import UpdateBanner from 'components/Updater/Banner'
 import AccountsHeader from './AccountsHeader'
 import AccountList from './AccountList'
 import { accountsSelector } from '../../reducers/accounts'
@@ -16,6 +17,7 @@ import { setAccountsViewMode, setSelectedTimeRange } from '../../actions/setting
 import { accountsViewModeSelector, selectedTimeRangeSelector } from '../../reducers/settings'
 import EmptyState from './EmptyState'
 import { Dismiss as NewAccountsDismiss } from '../news/NewAccountsPage'
+import { TopBannerContainer } from '../DashboardPage'
 
 type Props = {
   accounts: Account[],
@@ -62,6 +64,9 @@ class AccountsPage extends PureComponent<Props> {
       return (
         <Fragment>
           <TrackPage category="Accounts" accountsLength={accounts.length} />
+          <TopBannerContainer>
+            <UpdateBanner />
+          </TopBannerContainer>
           <NewAccountsDismiss />
           <EmptyState />
         </Fragment>

--- a/src/components/DashboardPage/index.js
+++ b/src/components/DashboardPage/index.js
@@ -150,7 +150,7 @@ class DashboardPage extends PureComponent<Props> {
   }
 }
 // This forces only one visible top banner at a time
-const TopBannerContainer = styled.div`
+export const TopBannerContainer = styled.div`
   margin-top: -3px; //To hide the separator bar
   z-index: 20;
 

--- a/src/components/MainSideBar/index.js
+++ b/src/components/MainSideBar/index.js
@@ -154,7 +154,7 @@ class MainSideBar extends PureComponent<Props> {
               iconActiveColor="wallet"
               onClick={this.handleClickDashboard}
               isActive={pathname === '/'}
-              NotifComponent={UpdateDot}
+              NotifComponent={noAccounts ? undefined : UpdateDot}
               disabled={noAccounts}
             />
             <SideBarListItem
@@ -163,7 +163,7 @@ class MainSideBar extends PureComponent<Props> {
               iconActiveColor="wallet"
               isActive={pathname === '/accounts'}
               onClick={this.handleClickAccounts}
-              NotifComponent={NewAccountsNotifDot}
+              NotifComponent={(noAccounts && UpdateDot) || NewAccountsNotifDot}
             />
             <SideBarListItem
               label={t('send.title')}


### PR DESCRIPTION
The updater banner should now show on the accounts placeholder only when there are no accounts imported. In the same way, since Portfolio is inactive at this point, the blue dot should appear next to accounts (if there's an update or we have the sidebar banner about the new section).