### PR TITLE
LL-1388 Add Bitcoin in the list of possible countervalues

### DIFF
--- a/src/components/SettingsPage/CounterValueSelect.js
+++ b/src/components/SettingsPage/CounterValueSelect.js
@@ -3,21 +3,19 @@
 import React, { Fragment, PureComponent } from 'react'
 import { connect } from 'react-redux'
 import { createStructuredSelector } from 'reselect'
-import { listFiatCurrencies } from '@ledgerhq/live-common/lib/currencies'
+import { getCryptoCurrencyById, listFiatCurrencies } from '@ledgerhq/live-common/lib/currencies'
 import type { Currency } from '@ledgerhq/live-common/lib/types'
 import { setCounterValue } from 'actions/settings'
 import { counterValueCurrencySelector } from 'reducers/settings'
 import Select from 'components/base/Select'
 import Track from 'analytics/Track'
 
-const fiats = listFiatCurrencies()
-  .map(f => f.units[0])
-  // For now we take first unit, in the future we'll need to figure out something else
-  .map(fiat => ({
-    value: fiat.code,
-    label: `${fiat.name} - ${fiat.code}`,
-    fiat,
-  }))
+// TODO allow more cryptos as countervalues, then refactor this to common
+const currencies = [...listFiatCurrencies(), getCryptoCurrencyById('bitcoin')].map(currency => ({
+  value: currency.ticker,
+  label: `${currency.name} - ${currency.ticker}`,
+  currency,
+}))
 
 type Props = {
   counterValueCurrency: Currency,
@@ -27,12 +25,12 @@ type Props = {
 class CounterValueSelect extends PureComponent<Props> {
   handleChangeCounterValue = (item: Object) => {
     const { setCounterValue } = this.props
-    setCounterValue(item.fiat.code)
+    setCounterValue(item.currency.ticker)
   }
 
   render() {
     const { counterValueCurrency } = this.props
-    const cvOption = fiats.find(f => f.value === counterValueCurrency.ticker)
+    const cvOption = currencies.find(f => f.value === counterValueCurrency.ticker)
 
     return (
       <Fragment>
@@ -43,7 +41,7 @@ class CounterValueSelect extends PureComponent<Props> {
           onChange={this.handleChangeCounterValue}
           itemToString={item => (item ? item.name : '')}
           renderSelected={item => item && item.name}
-          options={fiats}
+          options={currencies}
           value={cvOption}
         />
       </Fragment>

--- a/src/components/SettingsPage/sections/Display.js
+++ b/src/components/SettingsPage/sections/Display.js
@@ -8,6 +8,7 @@ import {
   hasPasswordSelector,
   langAndRegionSelector,
   counterValueCurrencySelector,
+  intermediaryCurrency,
 } from 'reducers/settings'
 import type { Currency } from '@ledgerhq/live-common/lib/types'
 import type { T } from 'types/common'
@@ -58,18 +59,20 @@ class TabGeneral extends PureComponent<Props> {
           >
             <CounterValueSelect />
           </Row>
-          <Row
-            title={t('settings.display.exchange', {
-              ticker: counterValueCurrency.ticker,
-              fiat: counterValueCurrency.name,
-            })}
-            desc={t('settings.display.exchangeDesc', {
-              fiat: counterValueCurrency.name,
-              ticker: counterValueCurrency.ticker,
-            })}
-          >
-            <CounterValueExchangeSelect />
-          </Row>
+          {counterValueCurrency.ticker !== intermediaryCurrency.ticker && (
+            <Row
+              title={t('settings.display.exchange', {
+                ticker: counterValueCurrency.ticker,
+                fiat: counterValueCurrency.name,
+              })}
+              desc={t('settings.display.exchangeDesc', {
+                fiat: counterValueCurrency.name,
+                ticker: counterValueCurrency.ticker,
+              })}
+            >
+              <CounterValueExchangeSelect />
+            </Row>
+          )}
           <Row title={t('settings.display.language')} desc={t('settings.display.languageDesc')}>
             <LanguageSelect />
           </Row>


### PR DESCRIPTION
Adds Bitcoin to the list of possible countervalues. It's shown as lowercase bitcoin as it uses the first unit, don't know if we want to change that in common, or in js, or in styles @gre

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1388
