### PR TITLE
Remove 'New accounts page' box as it's no longer new

### DIFF
--- a/src/components/AccountsPage/index.js
+++ b/src/components/AccountsPage/index.js
@@ -16,7 +16,6 @@ import { accountsSelector } from '../../reducers/accounts'
 import { setAccountsViewMode, setSelectedTimeRange } from '../../actions/settings'
 import { accountsViewModeSelector, selectedTimeRangeSelector } from '../../reducers/settings'
 import EmptyState from './EmptyState'
-import { Dismiss as NewAccountsDismiss } from '../news/NewAccountsPage'
 import { TopBannerContainer } from '../DashboardPage'
 
 type Props = {
@@ -67,14 +66,12 @@ class AccountsPage extends PureComponent<Props> {
           <TopBannerContainer>
             <UpdateBanner />
           </TopBannerContainer>
-          <NewAccountsDismiss />
           <EmptyState />
         </Fragment>
       )
     }
     return (
       <Box>
-        <NewAccountsDismiss />
         <TrackPage category="Accounts" accountsLength={accounts.length} />
         <AccountsHeader />
         <AccountList

--- a/src/components/MainSideBar/index.js
+++ b/src/components/MainSideBar/index.js
@@ -31,10 +31,6 @@ import TopGradient from './TopGradient'
 import KeyboardContent from '../KeyboardContent'
 import useExperimental from '../../hooks/useExperimental'
 import { darken } from '../../styles/helpers'
-import {
-  UpdateNotice as NewAccountsUpdateNotice,
-  NotifDot as NewAccountsNotifDot,
-} from '../news/NewAccountsPage'
 
 const mapStateToProps = state => ({
   noAccounts: accountsSelector(state).length === 0,
@@ -163,7 +159,7 @@ class MainSideBar extends PureComponent<Props> {
               iconActiveColor="wallet"
               isActive={pathname === '/accounts'}
               onClick={this.handleClickAccounts}
-              NotifComponent={(noAccounts && UpdateDot) || NewAccountsNotifDot}
+              NotifComponent={noAccounts ? UpdateDot : undefined}
             />
             <SideBarListItem
               label={t('send.title')}
@@ -205,7 +201,6 @@ class MainSideBar extends PureComponent<Props> {
               </KeyboardContent>
             )}
             <Space of={30} />
-            <NewAccountsUpdateNotice />
           </SideBarList>
           <Space grow />
           <TagContainer />


### PR DESCRIPTION
we'll keep this good practice to have `src/components/news` being the "temporary banners / helpers" and we can keep the source for future reference. this allows to have minimal code to "remove" the feature like this present PR.

### Parts of the app affected / Test plan

"new accounts" modal no longer display