### PR TITLE
LL-1443 Redirect to accounts after account deletion

### DIFF
--- a/src/components/AccountPage/index.js
+++ b/src/components/AccountPage/index.js
@@ -62,7 +62,7 @@ class AccountPage extends PureComponent<Props> {
     } = this.props
 
     if (!account) {
-      return <Redirect to="/" />
+      return <Redirect to="/accounts" />
     }
 
     return (

--- a/src/components/modals/AccountSettingRenderBody.js
+++ b/src/components/modals/AccountSettingRenderBody.js
@@ -289,6 +289,7 @@ class AccountSettingRenderBody extends PureComponent<Props, State> {
             <ConfirmModal
               analyticsName="RemoveAccount"
               isDanger
+              centered
               isOpened={isRemoveAccountModalOpen}
               onClose={this.handleCloseRemoveAccountModal}
               onReject={this.handleCloseRemoveAccountModal}


### PR DESCRIPTION
### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1413

### Parts of the app affected / Test plan

Applications screen from context menu and application screen from settings. In the case of the context menu the scroll should remain the same and we should navigate to /accounts if we were in the account screen.
