### PR TITLE
Second iteration of Experimental USB

### DIFF
--- a/src/actions/devices.js
+++ b/src/actions/devices.js
@@ -2,12 +2,6 @@
 
 import type { Device } from 'types/common'
 
-export type SetCurrentDevice = (Device | null) => { type: string, payload: Device | null }
-export const setCurrentDevice: SetCurrentDevice = payload => ({
-  type: 'SET_CURRENT_DEVICE',
-  payload,
-})
-
 type AddDevice = Device => { type: string, payload: Device }
 export const addDevice: AddDevice = payload => ({
   type: 'ADD_DEVICE',

--- a/src/commands/appAndVersionPolling.js
+++ b/src/commands/appAndVersionPolling.js
@@ -1,0 +1,64 @@
+// @flow
+import { createCommand, Command } from 'helpers/ipc'
+import isEqual from 'lodash/isEqual'
+import { from, concat, defer, interval } from 'rxjs'
+import { catchError, first, concatMap, distinctUntilChanged, tap } from 'rxjs/operators'
+import type TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
+import type { DeviceModelId } from '@ledgerhq/devices'
+import getAppAndVersion from '@ledgerhq/live-common/lib/hw/getAppAndVersion'
+import { withDevice } from '@ledgerhq/live-common/lib/hw/deviceAccess'
+
+type Result =
+  | { connected: false }
+  | {
+      connected: true,
+      name?: string,
+      version?: string,
+      deviceModelId: ?DeviceModelId,
+    }
+
+const appAndVersion = defer(() =>
+  // $FlowFixMe
+  withDevice('')((transport: TransportNodeHid) =>
+    from(
+      getAppAndVersion(transport).then(
+        ({ name, version }) => ({
+          connected: true,
+          name,
+          version,
+          deviceModelId: transport.deviceModel && transport.deviceModel.id,
+        }),
+        () => ({
+          // some error are legit (e.g. bootloader don't answer to that apdu) so we just fallback
+          connected: true,
+          deviceModelId: transport.deviceModel && transport.deviceModel.id,
+        }),
+      ),
+    ),
+  ),
+)
+
+const cmd: Command<void, Result> = createCommand('appAndVersionPolling', () => {
+  let errorCount = 0
+  const rec = () =>
+    concat(
+      appAndVersion.pipe(
+        tap(() => {
+          errorCount = 0
+        }),
+        catchError(() => {
+          if (++errorCount === 3) {
+            return from([{ connected: false }])
+          }
+          return from([])
+        }),
+      ),
+      interval(1000).pipe(
+        first(),
+        concatMap(rec),
+      ),
+    )
+  return rec().pipe(distinctUntilChanged(isEqual))
+})
+
+export default cmd

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -3,13 +3,14 @@
 import invariant from 'invariant'
 import type { Command } from 'helpers/ipc'
 
-import getAppAndVersion from 'commands/getAppAndVersion'
+import appAndVersionPolling from 'commands/appAndVersionPolling'
 import autoUpdate from 'commands/autoUpdate'
-import firmwarePrepare from 'commands/firmwarePrepare'
 import firmwareMain from 'commands/firmwareMain'
+import firmwarePrepare from 'commands/firmwarePrepare'
 import firmwareRepair from 'commands/firmwareRepair'
 import flushDevice from 'commands/flushDevice'
 import getAddress from 'commands/getAddress'
+import getAppAndVersion from 'commands/getAppAndVersion'
 import getDeviceInfo from 'commands/getDeviceInfo'
 import getIsGenuine from 'commands/getIsGenuine'
 import getLatestFirmwareForDevice from 'commands/getLatestFirmwareForDevice'
@@ -33,13 +34,14 @@ import testInterval from 'commands/testInterval'
 import uninstallApp from 'commands/uninstallApp'
 
 const all: Array<Command<any, any>> = [
+  appAndVersionPolling,
   autoUpdate,
-  getAppAndVersion,
-  firmwarePrepare,
   firmwareMain,
+  firmwarePrepare,
   firmwareRepair,
   flushDevice,
   getAddress,
+  getAppAndVersion,
   getDeviceInfo,
   getIsGenuine,
   getLatestFirmwareForDevice,

--- a/src/components/DeviceIcon.js
+++ b/src/components/DeviceIcon.js
@@ -1,0 +1,19 @@
+// @flow
+
+import React from 'react'
+import NanoS from 'icons/device/NanoS'
+import NanoX from 'icons/device/NanoX'
+import Blue from 'icons/device/Blue'
+
+const DeviceIcon = ({ type, size }: { type: string, size: number }) => {
+  switch (type) {
+    case 'blue':
+      return <Blue size={size} />
+    case 'nanoX':
+      return <NanoX size={size} />
+    default:
+      return <NanoS size={size} />
+  }
+}
+
+export default DeviceIcon

--- a/src/components/DeviceInteraction/index.js
+++ b/src/components/DeviceInteraction/index.js
@@ -36,13 +36,13 @@ const INITIAL_STATE = {
 }
 
 class DeviceInteraction extends PureComponent<Props, State> {
-  state = INITIAL_STATE
-
   static defaultProps = {
     renderError: (error: *, retry: *) => (
       <ErrorDescContainer error={error} onRetry={retry} mt={4} />
     ),
   }
+
+  state = INITIAL_STATE
 
   componentWillUnmount() {
     this._unmounted = true

--- a/src/components/ListenDevices.js
+++ b/src/components/ListenDevices.js
@@ -2,16 +2,47 @@
 import { useEffect } from 'react'
 import { connect } from 'react-redux'
 import listenDevices from 'commands/listenDevices'
+import appAndVersionPolling from 'commands/appAndVersionPolling'
 import { addDevice, removeDevice, resetDevices } from 'actions/devices'
 import useEnv from 'hooks/useEnv'
+import logger from 'logger'
 
 const ListenDevices = ({ addDevice, removeDevice, resetDevices }) => {
   const experimentalUSB = useEnv('EXPERIMENTAL_USB')
   useEffect(
     () => {
-      if (experimentalUSB) return () => {}
+      if (experimentalUSB) {
+        let sub
+        const syncDevices = () => {
+          sub = appAndVersionPolling.send().subscribe(
+            e => {
+              if (e.connected) {
+                addDevice({
+                  path: '',
+                  modelId: e.deviceModelId || 'nanoS',
+                  appName: e.name,
+                  version: e.version,
+                })
+              } else {
+                resetDevices()
+              }
+            },
+            e => {
+              logger.error(e)
+              syncDevices()
+            },
+            () => syncDevices(),
+          )
+        }
+
+        syncDevices()
+        return () => sub.unsubscribe()
+      }
+
+      // STABLE implementation (legacy?)
+
       let sub
-      function syncDevices() {
+      const syncDevices = () => {
         sub = listenDevices.send().subscribe(
           ({ device, deviceModel, type }) => {
             if (device) {

--- a/src/components/ManagerPage/FirmwareUpdate.js
+++ b/src/components/ManagerPage/FirmwareUpdate.js
@@ -15,27 +15,13 @@ import UpdateModal from 'components/modals/UpdateFirmware'
 import Tooltip from 'components/base/Tooltip'
 import Box, { Card } from 'components/base/Box'
 import Text from 'components/base/Text'
-
-import NanoS from 'icons/device/NanoS'
-import NanoX from 'icons/device/NanoX'
-import Blue from 'icons/device/Blue'
+import DeviceIcon from 'components/DeviceIcon'
 import CheckFull from 'icons/CheckFull'
 
 import UpdateFirmwareButton from './UpdateFirmwareButton'
 
 export const getCleanVersion = (input: string): string =>
   input.endsWith('-osu') ? input.replace('-osu', '') : input
-
-const Icon = ({ type }: { type: string }) => {
-  switch (type) {
-    case 'blue':
-      return <Blue size={30} />
-    case 'nanoX':
-      return <NanoX size={30} />
-    default:
-      return <NanoS size={30} />
-  }
-}
 
 export type ModalStatus = 'closed' | 'disclaimer' | 'install' | 'error' | 'success'
 
@@ -112,7 +98,7 @@ class FirmwareUpdate extends PureComponent<Props, State> {
       <Card p={4}>
         <Box horizontal align="center" flow={2}>
           <Box color="dark">
-            <Icon type={deviceSpecs.id} />
+            <DeviceIcon size={30} type={deviceSpecs.id} />
           </Box>
           <Box>
             <Box horizontal align="center">

--- a/src/components/TopBar/index.js
+++ b/src/components/TopBar/index.js
@@ -13,6 +13,7 @@ import type { T } from 'types/common'
 import { lock } from 'reducers/application'
 import { hasPasswordSelector } from 'reducers/settings'
 import { hasAccountsSelector } from 'reducers/accounts'
+import { getCurrentDevice } from 'reducers/devices'
 import { openModal } from 'reducers/modals'
 
 import IconLock from 'icons/Lock'
@@ -22,9 +23,29 @@ import IconSettings from 'icons/Settings'
 import Box from 'components/base/Box'
 import Tooltip from 'components/base/Tooltip'
 import CurrenciesStatusBanner from 'components/CurrenciesStatusBanner'
+import KeyboardContent from 'components/KeyboardContent'
+import DeviceIcon from 'components/DeviceIcon'
 
 import ActivityIndicator from './ActivityIndicator'
 import ItemContainer from './ItemContainer'
+
+const ExperimentalDeviceC = ({ device }: *) => (
+  <Tooltip
+    render={() =>
+      !device ? 'disconnected' : `${device.appName || 'Unknown'} ${device.version || ''}`
+    }
+  >
+    <ItemContainer
+      style={{ color: device ? '#66be54' : '#ea2e49' }}
+      isInteractive
+      justifyContent="center"
+    >
+      <DeviceIcon size={20} type={(device && device.modelId) || 'nanoS'} />
+    </ItemContainer>
+  </Tooltip>
+)
+
+const ExperimentalDevice = connect(s => ({ device: getCurrentDevice(s) }))(ExperimentalDeviceC)
 
 const Container = styled(Box).attrs({
   px: 6,
@@ -129,6 +150,14 @@ class TopBar extends PureComponent<Props> {
               </BreadCrumbBack>
             )}
             <Box grow />
+            <KeyboardContent sequence="SHOWMYDEVICE">
+              <Fragment>
+                <ExperimentalDevice />
+                <Box justifyContent="center">
+                  <Bar />
+                </Box>
+              </Fragment>
+            </KeyboardContent>
             <CurrenciesStatusBanner />
             {hasAccounts && (
               <Fragment>

--- a/src/components/base/Chart/index.js
+++ b/src/components/base/Chart/index.js
@@ -74,8 +74,6 @@ class Chart extends Component<Props> {
     mapValue: (d: *) => d.value.toNumber(),
   }
 
-  subResize: *
-
   componentDidMount() {
     const { width } = this._ruler.getBoundingClientRect()
     this._width = width
@@ -86,10 +84,6 @@ class Chart extends Component<Props> {
         this.refreshChart(this.props)
       }
     })
-  }
-
-  componentWillUnmount() {
-    if (this.subResize) this.subResize()
   }
 
   shouldComponentUpdate(nextProps: Props) {
@@ -113,6 +107,11 @@ class Chart extends Component<Props> {
     this.refreshChart(prevProps)
   }
 
+  componentWillUnmount() {
+    if (this.subResize) this.subResize()
+  }
+
+  subResize: *
   _ruler: any
   _node: any
   _width: number

--- a/src/helpers/promise.js
+++ b/src/helpers/promise.js
@@ -1,7 +1,6 @@
 // @flow
 // small utilities for Promises
 
-import logger from 'logger'
 import { TimeoutTagged } from '@ledgerhq/errors'
 import { genericCanRetryOnError } from '@ledgerhq/live-common/lib/hw/deviceAccess'
 
@@ -23,10 +22,9 @@ export function retry<A>(f: () => Promise<A>, options?: $Shape<typeof defaults>)
       return result
     }
     // In case of failure, wait the interval, retry the action
-    return result.catch(e => {
-      logger.warn('retry failed', e.message)
-      return delay(interval).then(() => rec(remainingTry - 1, interval * intervalMultiplicator))
-    })
+    return result.catch(() =>
+      delay(interval).then(() => rec(remainingTry - 1, interval * intervalMultiplicator)),
+    )
   }
 }
 

--- a/src/reducers/devices.js
+++ b/src/reducers/devices.js
@@ -6,54 +6,29 @@ import type { Device } from 'types/common'
 
 export type DevicesState = {
   currentDevice: ?Device,
-  devices: Device[],
 }
 
 const initialState: DevicesState = {
   currentDevice: null,
-  devices: [],
-}
-
-function setCurrentDevice(state) {
-  const currentDevice = state.devices.length ? state.devices[state.devices.length - 1] : null
-  return { ...state, currentDevice }
 }
 
 const handlers: Object = {
   RESET_DEVICES: () => initialState,
-  ADD_DEVICE: (state: DevicesState, { payload: device }: { payload: Device }) =>
-    setCurrentDevice({
-      ...state,
-      devices: [...state.devices, device].filter(
-        (v, i, s) => s.findIndex(t => t.path === v.path) === i,
-      ),
-    }),
+  ADD_DEVICE: (state: DevicesState, { payload: currentDevice }: { payload: Device }) => ({
+    currentDevice,
+  }),
   REMOVE_DEVICE: (state: DevicesState, { payload: device }: { payload: Device }) => ({
-    ...state,
     currentDevice:
       state.currentDevice && state.currentDevice.path === device.path ? null : state.currentDevice,
-    devices: state.devices.filter(d => d.path !== device.path),
-  }),
-  SET_CURRENT_DEVICE: (state: DevicesState, { payload: currentDevice }: { payload: Device }) => ({
-    ...state,
-    currentDevice,
   }),
 }
 
 export function getCurrentDevice(state: { devices: DevicesState }) {
-  if (getEnv('EXPERIMENTAL_USB') || getEnv('DEVICE_PROXY_URL')) {
+  if (getEnv('DEVICE_PROXY_URL')) {
     // bypass the listen devices (we should remove modelId here by instead get it at open time if needed)
     return { path: '', modelId: 'nanoS' }
   }
   return state.devices.currentDevice
-}
-
-export function getDevices(state: { devices: DevicesState }) {
-  if (getEnv('EXPERIMENTAL_USB') || getEnv('DEVICE_PROXY_URL')) {
-    // bypass the listen devices
-    return [{ path: '', modelId: 'nanoS' }]
-  }
-  return state.devices.devices
 }
 
 export default handleActions(handlers, initialState)

--- a/src/types/common.js
+++ b/src/types/common.js
@@ -4,6 +4,9 @@ import type { DeviceModelId } from '@ledgerhq/devices'
 export type Device = {
   path: string,
   modelId: DeviceModelId,
+  // EXPERIMENTAL
+  appName?: string,
+  version?: string,
 }
 
 // -------------------- Settings


### PR DESCRIPTION
Experimental second implementation of USB: this time, it will correct reflect the USB state (connected or not) as well as the device model (nanos, nanox,..)

This should also improve the performance by not closing the HID device but keeping the transport opened and polling it.

We'll give lot of test to this implementation on different systems and computers.

To test:

- make sure the default implementation is untouched and works like before.
- make sure everything works with Experimental USB. Firmware Update to be tested too.