### PR TITLE
LL-1414 UI Polishes for Onboarding in French

### DIFF
--- a/src/components/Onboarding/helperComponents.js
+++ b/src/components/Onboarding/helperComponents.js
@@ -131,12 +131,12 @@ const DisclaimerBoxIconContainer = styled(Box).attrs({
 // GENUINE CHECK
 export const GenuineCheckCardWrapper = styled(Box).attrs({
   horizontal: true,
+  alignItems: 'center',
   p: 5,
   borderRadius: '4px',
-  justify: 'space-between',
+  justify: 'flex-start',
 })`
   width: 580px;
-  height: 74px;
   transition: all ease-in-out 0.2s;
   color: ${p => (p.isDisabled ? p.theme.colors.grey : p.theme.colors.black)};
   border: ${p =>
@@ -148,5 +148,10 @@ export const GenuineCheckCardWrapper = styled(Box).attrs({
   opacity: ${p => (p.isDisabled ? 0.7 : 1)};
   &:hover {
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.05);
+  }
+  align-items: center;
+  > :nth-child(3) {
+    flex-grow: 1;
+    justify-content: flex-end;
   }
 `

--- a/src/components/Onboarding/steps/GenuineCheck/index.js
+++ b/src/components/Onboarding/steps/GenuineCheck/index.js
@@ -178,97 +178,77 @@ class GenuineCheck extends PureComponent<StepProps, State> {
         />
         <StepContainerInner>
           <Title>{t('onboarding.genuineCheck.title')}</Title>
-          {onboarding.flowType === 'restoreDevice' ? (
-            <Description>{t('onboarding.genuineCheck.descRestore')}</Description>
-          ) : (
-            <Description>{t('onboarding.genuineCheck.descGeneric')}</Description>
-          )}
-          <Box mt={5}>
-            <GenuineCheckCardWrapper>
+          <Description>
+            {t(
+              onboarding.flowType === 'restoreDevice'
+                ? 'onboarding.genuineCheck.descRestore'
+                : 'onboarding.genuineCheck.descGeneric',
+            )}
+          </Description>
+          <GenuineCheckCardWrapper mt={5}>
+            <IconOptionRow>{'1.'}</IconOptionRow>
+            <CardTitle>{t('onboarding.genuineCheck.step1.title')}</CardTitle>
+            <RadioGroup
+              items={this.getButtonLabel()}
+              activeKey={cachedPinStepButton}
+              onChange={item => this.handleButtonPass(item, 'pinStepPass')}
+            />
+          </GenuineCheckCardWrapper>
+          <GenuineCheckCardWrapper mt={3} isDisabled={!genuine.pinStepPass}>
+            <IconOptionRow color={!genuine.pinStepPass ? 'grey' : 'wallet'}>{'2.'}</IconOptionRow>
+            <CardTitle>{t('onboarding.genuineCheck.step2.title')}</CardTitle>
+            {genuine.pinStepPass && (
+              <RadioGroup
+                items={this.getButtonLabel()}
+                activeKey={cachedRecoveryStepButton}
+                onChange={item => this.handleButtonPass(item, 'recoveryStepPass')}
+              />
+            )}
+          </GenuineCheckCardWrapper>
+          <GenuineCheckCardWrapper
+            mt={3}
+            isDisabled={!genuine.recoveryStepPass}
+            isError={genuine.genuineCheckUnavailable}
+          >
+            <IconOptionRow color={!genuine.recoveryStepPass ? 'grey' : 'wallet'}>
+              {'3.'}
+            </IconOptionRow>
+            <CardTitle>{t('onboarding.genuineCheck.step3.title')}</CardTitle>
+            <Spacer />
+            {genuine.recoveryStepPass && (
               <Box justify="center">
-                <Box horizontal>
-                  <IconOptionRow>{'1.'}</IconOptionRow>
-                  <CardTitle>{t('onboarding.genuineCheck.step1.title')}</CardTitle>
-                </Box>
-              </Box>
-              <Box justify="center">
-                <RadioGroup
-                  items={this.getButtonLabel()}
-                  activeKey={cachedPinStepButton}
-                  onChange={item => this.handleButtonPass(item, 'pinStepPass')}
-                />
-              </Box>
-            </GenuineCheckCardWrapper>
-          </Box>
-          <Box mt={3}>
-            <GenuineCheckCardWrapper isDisabled={!genuine.pinStepPass}>
-              <Box justify="center">
-                <Box horizontal>
-                  <IconOptionRow color={!genuine.pinStepPass ? 'grey' : 'wallet'}>
-                    {'2.'}
-                  </IconOptionRow>
-                  <CardTitle>{t('onboarding.genuineCheck.step2.title')}</CardTitle>
-                </Box>
-              </Box>
-              <Box justify="center">
-                {genuine.pinStepPass && (
-                  <RadioGroup
-                    items={this.getButtonLabel()}
-                    activeKey={cachedRecoveryStepButton}
-                    onChange={item => this.handleButtonPass(item, 'recoveryStepPass')}
-                  />
+                {genuine.isDeviceGenuine ? (
+                  <Box horizontal align="center" flow={1} color={colors.wallet}>
+                    <IconCheck size={16} />
+                    <Box ff="Open Sans|SemiBold" fontSize={4}>
+                      {t('onboarding.genuineCheck.isGenuinePassed')}
+                    </Box>
+                  </Box>
+                ) : genuine.genuineCheckUnavailable ? (
+                  <Box color="alertRed">
+                    <IconCross size={16} />
+                  </Box>
+                ) : (
+                  <Button
+                    primary
+                    disabled={!genuine.recoveryStepPass}
+                    onClick={this.handleOpenGenuineCheckModal}
+                  >
+                    {t('onboarding.genuineCheck.buttons.genuineCheck')}
+                  </Button>
                 )}
               </Box>
-            </GenuineCheckCardWrapper>
-          </Box>
-          <Box mt={3}>
-            <GenuineCheckCardWrapper
-              isDisabled={!genuine.recoveryStepPass}
-              isError={genuine.genuineCheckUnavailable}
-            >
-              <Box justify="center">
-                <Box horizontal>
-                  <IconOptionRow color={!genuine.recoveryStepPass ? 'grey' : 'wallet'}>
-                    {'3.'}
-                  </IconOptionRow>
-                  <CardTitle>{t('onboarding.genuineCheck.step3.title')}</CardTitle>
-                </Box>
-              </Box>
-              {genuine.recoveryStepPass && (
-                <Box justify="center">
-                  {genuine.isDeviceGenuine ? (
-                    <Box horizontal align="center" flow={1} color={colors.wallet}>
-                      <IconCheck size={16} />
-                      <Box ff="Open Sans|SemiBold" fontSize={4}>
-                        {t('onboarding.genuineCheck.isGenuinePassed')}
-                      </Box>
-                    </Box>
-                  ) : genuine.genuineCheckUnavailable ? (
-                    <Box color="alertRed">
-                      <IconCross size={16} />
-                    </Box>
-                  ) : (
-                    <Button
-                      primary
-                      disabled={!genuine.recoveryStepPass}
-                      onClick={this.handleOpenGenuineCheckModal}
-                    >
-                      {t('onboarding.genuineCheck.buttons.genuineCheck')}
-                    </Button>
-                  )}
-                </Box>
-              )}
-            </GenuineCheckCardWrapper>
-            {genuine.genuineCheckUnavailable && (
-              <Box mt={4}>
-                <GenuineCheckUnavailableMessage
-                  handleOpenGenuineCheckModal={this.handleOpenGenuineCheckModal}
-                  onboarding={onboarding}
-                  t={t}
-                />
-              </Box>
             )}
-          </Box>
+          </GenuineCheckCardWrapper>
+          {genuine.genuineCheckUnavailable && (
+            <Box mt={4}>
+              <GenuineCheckUnavailableMessage
+                handleOpenGenuineCheckModal={this.handleOpenGenuineCheckModal}
+                onboarding={onboarding}
+                t={t}
+              />
+            </Box>
+          )}
         </StepContainerInner>
         {genuine.genuineCheckUnavailable ? (
           <GenuineCheckUnavailableFooter nextStep={nextStep} prevStep={prevStep} t={t} />
@@ -303,4 +283,7 @@ export const CardTitle = styled(Box).attrs({
   fontSize: 4,
   textAlign: 'left',
   pl: 2,
-})``
+})`
+  flex-shrink: 1;
+`
+export const Spacer = styled.div``

--- a/src/components/SettingsPage/CounterValueExchangeSelect.js
+++ b/src/components/SettingsPage/CounterValueExchangeSelect.js
@@ -35,7 +35,7 @@ class CounterValueExchangeSelect extends PureComponent<Props> {
           to={counterValueCurrency}
           exchangeId={counterValueExchange}
           onChange={this.handleChangeExchange}
-          minWidth={200}
+          minWidth={260}
         />
       </Fragment>
     ) : null

--- a/src/components/SettingsPage/CounterValueSelect.js
+++ b/src/components/SettingsPage/CounterValueSelect.js
@@ -37,7 +37,7 @@ class CounterValueSelect extends PureComponent<Props> {
         <Track onUpdate event="CounterValueSelect" counterValue={cvOption && cvOption.value} />
         <Select
           small
-          minWidth={250}
+          minWidth={260}
           onChange={this.handleChangeCounterValue}
           itemToString={item => (item ? item.name : '')}
           renderSelected={item => item && item.name}

--- a/src/components/SettingsPage/LanguageSelect.js
+++ b/src/components/SettingsPage/LanguageSelect.js
@@ -57,7 +57,7 @@ const LanguageSelect = ({ i18n, setLanguage, language, useSystem, t }: Props) =>
       />
       <Select
         small
-        minWidth={250}
+        minWidth={260}
         isSearchable={false}
         onChange={handleChangeLanguage}
         renderSelected={item => item && item.name}

--- a/src/components/SettingsPage/PasswordAutoLockSelect.js
+++ b/src/components/SettingsPage/PasswordAutoLockSelect.js
@@ -44,7 +44,7 @@ class PasswordAutoLockSelect extends PureComponent<Props> {
     return (
       <Select
         small
-        minWidth={250}
+        minWidth={260}
         isSearchable={false}
         onChange={this.handleChangeTimeout}
         renderSelected={item => item && item.name}

--- a/src/components/SettingsPage/RegionSelect.js
+++ b/src/components/SettingsPage/RegionSelect.js
@@ -43,7 +43,7 @@ class RegionSelect extends PureComponent<Props> {
         <Track onUpdate event="RegionSelectChange" currentRegion={currentRegion.region} />
         <Select
           small
-          minWidth={250}
+          minWidth={260}
           onChange={this.handleChangeRegion}
           renderSelected={item => item && item.name}
           value={currentRegion}


### PR DESCRIPTION

<img width="1191" alt="image" src="https://user-images.githubusercontent.com/4631227/58874887-50e1c580-86ca-11e9-83a5-48a0fc35677b.png">

Refactored the structure of that step a little bit to reduce the nesting we had and usage of unnecesary Boxes, now the titles can wrap down to more than one line to prevent other languages from breaking the ui.

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1414

### Parts of the app affected / Test plan

Onboarding, genuine-check step. Failed, succeeded, etc. In case some UI breaks here.
