### PR TITLE
CI: Start Ledger Live and wait for loading success

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,4 +28,4 @@ jobs:
           paths:
             - node_modules
       - run: yarn ci
-      - run: yarn start
+      - run: bash scripts/startApp.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,4 +28,5 @@ jobs:
           paths:
             - node_modules
       - run: yarn ci
+      - run: yarn add electron@1.8.8
       - run: bash scripts/startApp.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,3 +28,4 @@ jobs:
           paths:
             - node_modules
       - run: yarn ci
+      - run: yarn start

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "chance": "^1.0.13",
     "concurrently": "3.5.1",
     "dotenv": "^5.0.1",
-    "electron": "1.8.8",
+    "electron": "^2.0.17",
     "electron-builder": "~20.34",
     "electron-devtools-installer": "^2.2.3",
     "electron-rebuild": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "chance": "^1.0.13",
     "concurrently": "3.5.1",
     "dotenv": "^5.0.1",
-    "electron": "^2.0.17",
+    "electron": "1.8.8",
     "electron-builder": "~20.34",
     "electron-devtools-installer": "^2.2.3",
     "electron-rebuild": "^1.7.3",

--- a/scripts/startApp.sh
+++ b/scripts/startApp.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+yarn start > test-e2e/logs.txt &
+sleep 60 &
+( tail -f -n0 test-e2e/logs.txt & ) | grep -q 'info: libcore {"intVersion":'
+if [ $? -eq 0 ] ; then
+    echo "Libcore loaded properly - SUCCESS"
+else
+    echo FAIL
+    exit 1
+fi
+sleep 5
+killall -9 Electron
+rm test-e2e/logs.txt

--- a/scripts/startApp.sh
+++ b/scripts/startApp.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+set -e
+
 yarn start > test-e2e/logs.txt &
+pid=$!
 sleep 60 &
 ( tail -f -n0 test-e2e/logs.txt & ) | grep -q 'info: libcore {"intVersion":'
 if [ $? -eq 0 ] ; then
@@ -10,5 +13,5 @@ else
     exit 1
 fi
 sleep 5
-killall -9 Electron
+kill -9 $pid
 rm test-e2e/logs.txt


### PR DESCRIPTION
The aim is to check if LL starts without error, in order to be sure that the app started properly I check in the logs that the libcore has been loaded.

**Known issue**
I'm not able to kill the running process so the job never ends in circle ci.