### PR TITLE
Breadcrumbs functionality for Accounts

### DIFF
--- a/src/components/AccountPage/index.js
+++ b/src/components/AccountPage/index.js
@@ -92,7 +92,7 @@ class AccountPage extends PureComponent<Props> {
     const color = getCurrencyColor(currency)
 
     return (
-      <Box>
+      <Box key={account.id}>
         <TrackPage
           category="Account"
           currency={currency.id}

--- a/src/components/AccountsPage/AccountRowItem/Header.js
+++ b/src/components/AccountsPage/AccountRowItem/Header.js
@@ -17,8 +17,7 @@ type Props = {
 // NB Inside Head to not break alignment with parent row;
 const NestedIndicator = styled.div`
   border-left: 1px solid ${p => p.theme.colors.lightFog};
-  min-height: 40px;
-  height: 100%;
+  height: 44px;
   margin-left: 9px;
   padding-left: 5px;
 `
@@ -44,7 +43,7 @@ class Header extends PureComponent<Props> {
         horizontal
         ff="Open Sans|SemiBold"
         flow={3}
-        flex={`${nested ? 30 : 42}%`}
+        flex={`${nested ? 42 : 30}%`}
         pr={1}
         alignItems="center"
       >
@@ -53,11 +52,12 @@ class Header extends PureComponent<Props> {
           <CryptoCurrencyIcon currency={currency} size={20} />
         </Box>
         <Box grow>
-          {nested && (
-            <Box style={{ textTransform: 'uppercase' }} fontSize={9} color="grey">
-              {title}
-            </Box>
-          )}
+          {!nested &&
+            account.type === 'Account' && (
+              <Box style={{ textTransform: 'uppercase' }} fontSize={9} color="grey">
+                {title}
+              </Box>
+            )}
           <Ellipsis fontSize={12} color="dark">
             {name}
           </Ellipsis>

--- a/src/components/AccountsPage/AccountRowItem/index.js
+++ b/src/components/AccountsPage/AccountRowItem/index.js
@@ -36,7 +36,7 @@ const Row = styled(Box)`
   flex: 1;
   font-weight: 600;
   justify-content: flex-start;
-  margin-bottom: ${p => (p.tokens ? 9 : 18)}px;
+  margin-bottom: ${p => (p.tokens && !p.expanded ? 18 : 9)}px;
   padding: 16px 20px;
   position: relative;
   :hover {
@@ -55,7 +55,7 @@ const TokenContent = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  margin-top: 8px;
+  margin-top: 20px;
 `
 
 const TokenAccountIndicator = styled.div`
@@ -155,7 +155,7 @@ class AccountRowItem extends PureComponent<Props, State> {
     const showTokensIndicator = tokens && tokens.length > 0 && !hidden
     return (
       <Wrapper hidden={hidden}>
-        <Row expanded={expanded} key={mainAccount.id}>
+        <Row expanded={expanded} tokens={showTokensIndicator} key={mainAccount.id}>
           <ContextMenuItem items={this.contextMenuItems}>
             <RowContent onClick={this.onClick}>
               <Header account={account} name={mainAccount.name} />

--- a/src/components/CryptoCurrencyIcon.js
+++ b/src/components/CryptoCurrencyIcon.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import { getCurrencyColor } from '@ledgerhq/live-common/lib/currencies'
 import { getCryptoCurrencyIcon } from '@ledgerhq/live-common/lib/react'
 import type { Currency } from '@ledgerhq/live-common/lib/types'
-import { lighten } from 'styles/helpers'
+import { rgba } from 'styles/helpers'
 
 type Props = {
   currency: Currency,
@@ -16,7 +16,7 @@ const TokenIcon = styled.div`
   font-family: 'Open Sans';
   font-weight: bold;
   color: ${p => p.color};
-  background-color: ${p => lighten(p.color, 0.9)};
+  background-color: ${p => rgba(p.color, 0.1)};
   border-radius: 4px;
   display: flex;
   overflow: hidden;

--- a/src/components/TokenRow.js
+++ b/src/components/TokenRow.js
@@ -45,7 +45,6 @@ const TopLevelRow = styled(Box)`
 
 const NestedRow = styled(Box)`
   flex: 1;
-  height: 40px;
   font-weight: 600;
   align-items: center;
   justify-content: flex-start;
@@ -53,10 +52,12 @@ const NestedRow = styled(Box)`
   flex-direction: row;
   cursor: pointer;
   position: relative;
-
+  &:last-of-type {
+    margin-bottom: 0px;
+  }
   opacity: 0;
-  animation: fadeIn 0.3s ease both;
-  animation-delay: ${p => p.index * 0.3}s;
+  animation: fadeIn 0.1s ease both;
+  animation-delay: ${p => p.index * 0.1}s;
   @keyframes fadeIn {
     0% {
       opacity: 0;
@@ -87,7 +88,6 @@ class TokenRow extends PureComponent<Props> {
     return (
       <Row index={index} onClick={this.onClick}>
         <Header nested={nested} account={account} name={token.name} />
-        <Box flex="12%" />
         <Balance unit={unit} balance={account.balance} disableRounding={disableRounding} />
         <Countervalue account={account} currency={token} range={range} />
         <Delta account={account} range={range} />

--- a/src/components/TopBar/Breadcrumb/AccountCrumb.js
+++ b/src/components/TopBar/Breadcrumb/AccountCrumb.js
@@ -1,0 +1,229 @@
+// @flow
+
+import React, { PureComponent } from 'react'
+import styled from 'styled-components'
+import { Trans, translate } from 'react-i18next'
+import IconAngleDown from 'icons/AngleDown'
+import IconCheck from 'icons/Check'
+import { createStructuredSelector } from 'reselect'
+import { compose } from 'redux'
+import { connect } from 'react-redux'
+import type { TokenAccount, Account } from '@ledgerhq/live-common/lib/types'
+import { push } from 'react-router-redux'
+
+import { accountsSelector } from '../../../reducers/accounts'
+import CryptoCurrencyIcon from '../../CryptoCurrencyIcon'
+import DropDown from '../../base/DropDown'
+import Button from '../../base/Button'
+import { Separator } from './index'
+
+type Props = {
+  match: {
+    params: {
+      id: string,
+      parentId?: string,
+    },
+    isExact: boolean,
+    path: string,
+    url: string,
+  },
+  accounts: Account[],
+  push: string => void,
+}
+
+const Item = styled.div`
+  font-family: 'Open Sans';
+  font-size: 13px;
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  padding: 12px;
+  min-width: 200px;
+  color: ${p => (p.isActive ? p.theme.colors.dark : p.theme.colors.smoke)};
+  > :first-child {
+    margin-right: 10px;
+  }
+
+  &:hover {
+    background: ${p => p.theme.colors.lightGrey};
+    border-radius: 4px;
+  }
+`
+
+const TextLink = styled.div`
+  font-family: 'Open Sans';
+  font-size: 12px;
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+
+  > :first-child {
+    margin-right: 8px;
+  }
+
+  > :nth-child(2) {
+    padding: 0px;
+    &:hover {
+      background: transparent;
+      text-decoration: underline;
+    }
+    margin-right: 7px;
+  }
+`
+const AngleDown = styled.div`
+  width: 14px;
+  height: 14px;
+  border-radius: 20px;
+  text-align: center;
+  line-height: 14px;
+
+  &:hover {
+    background: ${p => p.theme.colors.fog};
+  }
+`
+
+const Check = styled.div`
+  color: ${p => p.theme.colors.wallet};
+  flex: 1;
+  text-align: right;
+  margin-left: 20px;
+`
+
+const mapStateToProps = createStructuredSelector({
+  accounts: accountsSelector,
+})
+
+const mapDispatchToProps = {
+  push,
+}
+
+class AccountCrumb extends PureComponent<Props> {
+  renderItem = ({ item, isActive }) => {
+    const { parentId } = this.props.match.params
+
+    return (
+      <Item key={item.account.id} isActive={isActive}>
+        <CryptoCurrencyIcon
+          size={16}
+          currency={parentId ? item.account.token : item.account.currency}
+        />
+        {parentId ? item.account.token.name : item.account.name}
+        {isActive && (
+          <Check>
+            <IconCheck size={14} />
+          </Check>
+        )}
+      </Item>
+    )
+  }
+
+  onAccountSelected = ({ selectedItem: item }) => {
+    if (!item) {
+      return
+    }
+
+    const { push, match } = this.props
+    const { parentId } = match.params
+    const {
+      account: { id },
+    } = item
+
+    if (parentId) {
+      push(`/account/${parentId}/${id}`)
+    } else {
+      push(`/account/${id}`)
+    }
+  }
+
+  openActiveAccount = e => {
+    e.preventDefault()
+    const { push, match } = this.props
+    const { parentId, id } = match.params
+    if (parentId) {
+      push(`/account/${parentId}/${id}`)
+    } else {
+      push(`/account/${id}`)
+    }
+  }
+
+  processItemsForDropdown = (items: any[]) =>
+    items.map(item => ({ key: item.id, label: item.id, account: item }))
+
+  render() {
+    const { parentId, id } = this.props.match.params
+    const { accounts, push } = this.props
+
+    if (!id) {
+      return (
+        <>
+          <Button onClick={() => push('/accounts/')}>
+            <Trans>{'accounts.title'}</Trans>
+          </Button>
+        </>
+      )
+    }
+
+    let account: ?Account
+    let tokenAccount: ?TokenAccount
+    let currency
+    let name
+    let items
+
+    if (parentId) {
+      const parentAccount: ?Account = accounts.find(a => a.id === parentId)
+
+      if (parentAccount && parentAccount.tokenAccounts) {
+        items = parentAccount.tokenAccounts
+        tokenAccount = items.find(t => t.id === id)
+
+        if (tokenAccount) {
+          currency = tokenAccount.token
+          name = tokenAccount.token.name
+        }
+      }
+      items = parentAccount && parentAccount.tokenAccounts
+    } else {
+      account = accounts.find(a => a.id === id)
+      items = accounts
+
+      if (account) {
+        currency = account.currency
+        name = account.name
+      }
+    }
+
+    const processedItems = this.processItemsForDropdown(items || [])
+
+    return (
+      <>
+        <Separator />
+        <DropDown
+          flow={1}
+          offsetTop={0}
+          border
+          horizontal
+          items={processedItems}
+          renderItem={this.renderItem}
+          onStateChange={this.onAccountSelected}
+          value={processedItems.find(a => a.key === id)}
+        >
+          <TextLink>
+            {currency && <CryptoCurrencyIcon size={14} currency={currency} />}
+            <Button onClick={this.openActiveAccount}>{name}</Button>
+            <AngleDown>
+              <IconAngleDown size={16} />
+            </AngleDown>
+          </TextLink>
+        </DropDown>
+      </>
+    )
+  }
+}
+
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+  translate(),
+)(AccountCrumb)

--- a/src/components/TopBar/Breadcrumb/index.js
+++ b/src/components/TopBar/Breadcrumb/index.js
@@ -1,0 +1,47 @@
+// @flow
+
+import React from 'react'
+import styled from 'styled-components'
+import { Route } from 'react-router'
+
+import { translate } from 'react-i18next'
+import AccountCrumb from './AccountCrumb'
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  > * {
+    font-family: 'Open Sans';
+    font-weight: 600;
+    font-size: 12px;
+    color: ${p => p.theme.colors.grey};
+  }
+
+  > :first-child {
+    padding: 0px;
+    &:hover {
+      background: transparent;
+      text-decoration: underline;
+    }
+  }
+`
+
+export const Separator = styled.div`
+  &::after {
+    content: '/';
+    font-size: 13px;
+    color: ${p => p.theme.colors.fog};
+    padding: 0 15px;
+  }
+`
+const Breadcrumb = () => (
+  <Wrapper>
+    <Route path="/accounts/" component={AccountCrumb} />
+    <Route path="/account/" component={AccountCrumb} />
+    <Route path="/account/:id/" component={AccountCrumb} />
+    <Route path="/account/:parentId/:id/" component={AccountCrumb} />
+  </Wrapper>
+)
+
+export default translate()(Breadcrumb)

--- a/src/components/TopBar/index.js
+++ b/src/components/TopBar/index.js
@@ -16,7 +16,6 @@ import { hasAccountsSelector } from 'reducers/accounts'
 import { openModal } from 'reducers/modals'
 
 import IconLock from 'icons/Lock'
-import IconAngleLeft from 'icons/AngleLeft'
 import IconSettings from 'icons/Settings'
 
 import Box from 'components/base/Box'
@@ -25,6 +24,7 @@ import CurrenciesStatusBanner from 'components/CurrenciesStatusBanner'
 
 import ActivityIndicator from './ActivityIndicator'
 import ItemContainer from './ItemContainer'
+import Breadcrumb from './Breadcrumb'
 
 const Container = styled(Box).attrs({
   px: 6,
@@ -43,18 +43,6 @@ const Inner = styled(Box).attrs({
   flow: 4,
   align: 'center',
 })``
-
-const BreadCrumbBack = styled(Box)`
-  flex-direction: row;
-  align-items: center;
-  font-family: 'Open Sans';
-  font-size: 13px;
-  font-weight: 600;
-  color: ${p => p.theme.colors.grey};
-  :hover {
-    color: ${p => p.theme.colors.dark};
-  }
-`
 
 const Bar = styled.div`
   margin-left: 5px;
@@ -105,29 +93,14 @@ class TopBar extends PureComponent<Props> {
     }
   }
 
-  goBack = () => this.props.history.goBack()
-
   render() {
-    const {
-      location: { pathname },
-      hasPassword,
-      hasAccounts,
-      t,
-    } = this.props
-    const showBack = pathname.startsWith('/account/')
+    const { hasPassword, hasAccounts, t } = this.props
 
     return (
       <Container bg="lightGrey" color="graphite">
         <Inner>
           <Box grow horizontal>
-            {showBack && (
-              <BreadCrumbBack onClick={this.goBack}>
-                <Box mr={1}>
-                  <IconAngleLeft size={16} />
-                </Box>
-                {t('common.back')}
-              </BreadCrumbBack>
-            )}
+            <Breadcrumb />
             <Box grow />
             <CurrenciesStatusBanner />
             {hasAccounts && (

--- a/src/components/base/Box/Box.js
+++ b/src/components/base/Box/Box.js
@@ -51,6 +51,7 @@ export default styled.div`
     `
     user-select: text;
     `};
+  right: auto;
 
   ${p =>
     p.sticky &&

--- a/src/components/base/DropDown/index.js
+++ b/src/components/base/DropDown/index.js
@@ -18,6 +18,7 @@ const Drop = styled(Box).attrs({
   borderRadius: 1,
   p: 2,
 })`
+  ${p => p.border && `border:1px solid ${p.theme.colors.lightFog}`};
   position: absolute;
   right: 0;
   top: 100%;
@@ -51,6 +52,7 @@ type Props = {
   items: Array<DropDownItemType>,
   keepOpenOnChange?: boolean,
   offsetTop: number | string,
+  border?: boolean,
   onChange?: DropDownItemType => void,
   onStateChange?: Function,
   renderItem: Object => any,
@@ -115,11 +117,11 @@ class DropDown extends PureComponent<Props> {
     selectedItem: DropDownItemType,
     downshiftProps: Object,
   ) => {
-    const { offsetTop, renderItem } = this.props
+    const { offsetTop, renderItem, border } = this.props
     const { getItemProps, highlightedIndex } = downshiftProps
 
     return (
-      <Drop mt={offsetTop}>
+      <Drop mt={offsetTop} border={border}>
         {items.map((item, i) => {
           const { key, ...props } = item
           return (


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
<img width="409" alt="image" src="https://user-images.githubusercontent.com/4631227/59110999-80016c80-8940-11e9-8b8a-5f4c97a0cb78.png">

### Type
Feature

Also updates the token icon, forces refresh of the account page on navigation, decreases the animation of tokens (remove it altogether maybe?), and fixes some alignment issues on the rows.

> @gre I didn't manage to fix the issue I mentioned on Slack about the nested token row left border. It'd be great if you can take a look