### PR TITLE
Double icon for tokens

### DIFF
--- a/src/components/AccountsPage/AccountGridItem/Header.js
+++ b/src/components/AccountsPage/AccountGridItem/Header.js
@@ -2,6 +2,7 @@
 
 import React, { PureComponent } from 'react'
 import type { Account, TokenAccount, Currency } from '@ledgerhq/live-common/lib/types'
+import styled from 'styled-components'
 import Box from 'components/base/Box'
 import Bar from 'components/base/Bar'
 import Ellipsis from 'components/base/Ellipsis'
@@ -9,15 +10,27 @@ import FormattedVal from 'components/base/FormattedVal'
 import CryptoCurrencyIcon from 'components/CryptoCurrencyIcon'
 import AccountSyncStatusIndicator from '../AccountSyncStatusIndicator'
 
+const CryptoCurrencyIconWrapper = styled.div`
+  > :nth-child(2) {
+    margin-top: -13px;
+    margin-left: 8px;
+    border: 2px solid white;
+  }
+`
+
 class CurrencyHead extends PureComponent<{
   currency: Currency,
+  parentCurrency?: Currency,
 }> {
   render() {
-    const { currency } = this.props
+    const { currency, parentCurrency } = this.props
+    const double = !!parentCurrency
+
     return (
-      <Box alignItems="center" justifyContent="center">
-        <CryptoCurrencyIcon currency={currency} size={20} />
-      </Box>
+      <CryptoCurrencyIconWrapper>
+        {parentCurrency && <CryptoCurrencyIcon currency={parentCurrency} size={double ? 16 : 20} />}
+        <CryptoCurrencyIcon currency={currency} size={double ? 16 : 20} />
+      </CryptoCurrencyIconWrapper>
     )
   }
 }
@@ -72,7 +85,7 @@ class Header extends PureComponent<{
     return (
       <Box flow={4}>
         <Box horizontal ff="Open Sans|SemiBold" flow={3} alignItems="center">
-          <CurrencyHead currency={currency} />
+          <CurrencyHead currency={currency} parentCurrency={mainAccount && mainAccount.currency} />
           <HeadText name={name} title={title} />
           <AccountSyncStatusIndicator accountId={mainAccount.id} account={account} />
         </Box>

--- a/src/components/CryptoCurrencyIcon.js
+++ b/src/components/CryptoCurrencyIcon.js
@@ -4,19 +4,24 @@ import styled from 'styled-components'
 import { getCurrencyColor } from '@ledgerhq/live-common/lib/currencies'
 import { getCryptoCurrencyIcon } from '@ledgerhq/live-common/lib/react'
 import type { Currency } from '@ledgerhq/live-common/lib/types'
-import { lighten } from 'styles/helpers'
+import { rgba } from 'styles/helpers'
 
 type Props = {
   currency: Currency,
   size: number,
 }
 
+// NB this is to avoid seeing the parent icon through
+const TokenIconWrapper = styled.div`
+  border-radius: 4px;
+  background: white;
+`
 const TokenIcon = styled.div`
   font-size: ${p => p.size / 2}px;
   font-family: 'Open Sans';
   font-weight: bold;
   color: ${p => p.color};
-  background-color: ${p => lighten(p.color, 0.9)};
+  background-color: ${p => rgba(p.color, 0.1)};
   border-radius: 4px;
   display: flex;
   overflow: hidden;
@@ -36,9 +41,11 @@ class CryptoCurrencyIcon extends PureComponent<Props> {
     }
     if (currency.type === 'TokenCurrency') {
       return (
-        <TokenIcon color={color} size={size}>
-          {currency.ticker[0]}
-        </TokenIcon>
+        <TokenIconWrapper>
+          <TokenIcon color={color} size={size}>
+            {currency.ticker[0]}
+          </TokenIcon>
+        </TokenIconWrapper>
       )
     }
     const IconCurrency = getCryptoCurrencyIcon(currency)


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
<img width="258" alt="image" src="https://user-images.githubusercontent.com/4631227/59113428-42531280-8945-11e9-9e59-8e3ac69b157d.png">

### Type

UI Polish

Since https://github.com/LedgerHQ/ledger-live-desktop/pull/2068 will take some time to merge, this one also has a rework of the token icon (the color thing), by the time the other pr is merged this one should be there already 🤷‍♀  I'll rebase