### PR TITLE
Prevent drag action on topbar buttons/elements

### DIFF
--- a/src/components/TopBar/Breadcrumb/AccountCrumb.js
+++ b/src/components/TopBar/Breadcrumb/AccountCrumb.js
@@ -14,7 +14,7 @@ import { push } from 'react-router-redux'
 import { accountsSelector } from '../../../reducers/accounts'
 import CryptoCurrencyIcon from '../../CryptoCurrencyIcon'
 import DropDown from '../../base/DropDown'
-import Button from '../../base/Button'
+import Button, { Base } from '../../base/Button'
 import { Separator } from './index'
 
 type Props = {
@@ -56,14 +56,15 @@ const TextLink = styled.div`
   align-items: center;
   display: flex;
   flex-direction: row;
-
+  -webkit-app-region: no-drag;
   > :first-child {
     margin-right: 8px;
   }
 
-  > :nth-child(2) {
+  > ${Base} {
     padding: 0px;
-    &:hover {
+    &:hover,
+    &:active {
       background: transparent;
       text-decoration: underline;
     }
@@ -155,11 +156,11 @@ class AccountCrumb extends PureComponent<Props> {
 
     if (!id) {
       return (
-        <>
+        <TextLink>
           <Button onClick={() => push('/accounts/')}>
             <Trans>{'accounts.title'}</Trans>
           </Button>
-        </>
+        </TextLink>
       )
     }
 

--- a/src/components/TopBar/ItemContainer.js
+++ b/src/components/TopBar/ItemContainer.js
@@ -14,6 +14,7 @@ export default styled(Tabbable).attrs({
   horizontal: true,
   borderRadius: 1,
 })`
+  -webkit-app-region: no-drag;
   height: 40px;
   pointer-events: ${p => (p.disabled ? 'none' : 'unset')};
 

--- a/src/components/base/Button/index.js
+++ b/src/components/base/Button/index.js
@@ -159,7 +159,7 @@ function getStyles(props, state) {
   return output
 }
 
-const Base = styled.button.attrs({
+export const Base = styled.button.attrs({
   ff: 'Museo Sans|Regular',
   fontSize: p => p.fontSize || (!p.small ? 4 : 3),
   px: p => (!p.small ? 4 : 3),


### PR DESCRIPTION

<img width="1136" alt="Screenshot 2019-06-09 at 01 59 27" src="https://user-images.githubusercontent.com/4631227/59153476-a74c5c80-8a5a-11e9-8c85-70fa9987bb8e.png">

The green area (without the cutouts) is the current dragable area for the window, at least on mac. This means that we can get some weird behaviour when dragging the window when the event starts on top of  a button/dropdown from topbar.

This pr makes the area exclude the cutouts.

### Type

UX Polish
