### PR TITLE
Erc20 oveflow scroll accountlist

### DIFF
--- a/src/components/TopBar/Breadcrumb/index.js
+++ b/src/components/TopBar/Breadcrumb/index.js
@@ -37,7 +37,6 @@ export const Separator = styled.div`
 `
 const Breadcrumb = () => (
   <Wrapper>
-    <Route path="/accounts/" component={AccountCrumb} />
     <Route path="/account/" component={AccountCrumb} />
     <Route path="/account/:id/" component={AccountCrumb} />
     <Route path="/account/:parentId/:id/" component={AccountCrumb} />

--- a/src/components/base/DropDown/index.js
+++ b/src/components/base/DropDown/index.js
@@ -19,10 +19,12 @@ const Drop = styled(Box).attrs({
   p: 2,
 })`
   ${p => p.border && `border:1px solid ${p.theme.colors.lightFog}`};
+  max-height: 400px;
   position: absolute;
   right: 0;
   top: 100%;
   z-index: 1;
+  overflow: scroll;
 `
 
 export const DropDownItem = styled(Box).attrs({

--- a/src/components/layout/Default.js
+++ b/src/components/layout/Default.js
@@ -113,7 +113,7 @@ class Default extends Component<Props> {
             <Box grow horizontal bg="white">
               <SideBar />
 
-              <Box shrink grow bg="lightGrey" color="grey" overflow="hidden" relative>
+              <Box shrink grow bg="lightGrey" color="grey" overflow="visible" relative>
                 <HSMStatusBanner />
                 <TopBar />
                 <Main innerRef={n => (this._scrollContainer = n)} tabIndex={-1}>


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/4631227/59180533-7f95eb00-8b65-11e9-9984-37081dd70092.png">

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/4631227/59180607-a6ecb800-8b65-11e9-9b3d-d22bb61a5cf8.png">


This prevents the list of accounts/tokens from stretching too long or cutting under the sidebar.
### Type

UI Polish

