### PR TITLE
Search for list mode on accounts page

### DIFF
--- a/src/components/AccountsPage/AccountList/ListBody.js
+++ b/src/components/AccountsPage/AccountList/ListBody.js
@@ -13,6 +13,7 @@ type Props = {
   lookupParentAccount: (id: string) => ?Account,
   range: PortfolioRange,
   showNewAccount: boolean,
+  search?: string,
 }
 
 class ListBody extends PureComponent<Props> {
@@ -24,6 +25,7 @@ class ListBody extends PureComponent<Props> {
       range,
       onAccountClick,
       lookupParentAccount,
+      search,
     } = this.props
     return (
       <Box>
@@ -31,6 +33,7 @@ class ListBody extends PureComponent<Props> {
           <AccountItem
             key={account.id}
             account={account}
+            search={search}
             parentAccount={
               account.type === 'TokenAccount' ? lookupParentAccount(account.parentId) : null
             }
@@ -44,6 +47,7 @@ class ListBody extends PureComponent<Props> {
             hidden
             key={account.id}
             account={account}
+            search={search}
             parentAccount={
               account.type === 'TokenAccount' ? lookupParentAccount(account.parentId) : null
             }


### PR DESCRIPTION

![Jun-10-2019 14-36-50](https://user-images.githubusercontent.com/4631227/59195818-3bb6dc00-8b8d-11e9-8727-06f3e88ac21e.gif)
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

Allow tokens to be matched when in list mode in accounts page, making the parent row inactive but still showing the tokens that match.

### Type

Feature, UI Polish
