### PR TITLE
Integrate react-window into the MenuList component of react-select 

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "react-router-redux": "5.0.0-alpha.9",
     "react-select": "2.4.2",
     "react-spring": "^5.3.15",
+    "react-window": "^1.8.2",
     "redux": "^4.0.1",
     "redux-actions": "^2.4.0",
     "redux-thunk": "^2.3.0",

--- a/src/components/base/Select/index.js
+++ b/src/components/base/Select/index.js
@@ -4,6 +4,8 @@ import React, { PureComponent } from 'react'
 import ReactSelect from 'react-select'
 import AsyncReactSelect from 'react-select/lib/Async'
 import { translate } from 'react-i18next'
+import { FixedSizeList as List } from 'react-window'
+import styled from 'styled-components'
 
 import createStyles from './createStyles'
 import createRenderers from './createRenderers'
@@ -39,6 +41,40 @@ export type Option = {
   data: any,
 }
 
+const Row = styled.div`
+  &:hover {
+    background: ${p => p.theme.colors.lightGraphite};
+  }
+`
+const rowHeight = 40 // Fixme We should pass this as a prop for dynamic rows?
+class MenuList extends PureComponent<*> {
+  render() {
+    const { options, children, maxHeight, getValue } = this.props
+    const [value] = getValue()
+    const initialOffset = options.indexOf(value) * rowHeight
+    const minHeight = Math.min(...[maxHeight, rowHeight * children.length])
+
+    children.length &&
+      children.map(key => {
+        delete key.props.innerProps.onMouseMove // NB: Removes lag on hover, see https://github.com/JedWatson/react-select/issues/3128#issuecomment-433834170
+        delete key.props.innerProps.onMouseOver
+        return null
+      })
+
+    return (
+      <List
+        width="100%"
+        height={minHeight}
+        overscanCount={8}
+        itemCount={children.length}
+        itemSize={rowHeight}
+        initialScrollOffset={initialOffset}
+      >
+        {({ index, style }) => <Row style={style}>{children[index]}</Row>}
+      </List>
+    )
+  }
+}
 class Select extends PureComponent<Props> {
   componentDidMount() {
     if (this.ref && this.props.autoFocus) {
@@ -92,10 +128,13 @@ class Select extends PureComponent<Props> {
       <Comp
         ref={c => (this.ref = c)}
         value={value}
-        maxMenuHeight={200}
+        maxMenuHeight={rowHeight * 5}
         classNamePrefix="select"
         options={options}
-        components={createRenderers({ renderOption, renderValue })}
+        components={{
+          MenuList,
+          ...createRenderers({ renderOption, renderValue }),
+        }}
         styles={createStyles({ width, minWidth, small, isRight, isLeft })}
         placeholder={placeholder}
         isDisabled={isDisabled}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1495,6 +1495,13 @@
     core-js "^2.5.6"
     regenerator-runtime "^0.11.1"
 
+"@babel/runtime@^7.0.0":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/runtime@^7.1.2":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.4.tgz#dc2e34982eb236803aa27a07fea6857af1b9171d"
@@ -11318,6 +11325,11 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
+"memoize-one@>=3.1.1 <6":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.4.tgz#005928aced5c43d890a4dfab18ca908b0ec92cbc"
+  integrity sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA==
+
 memoize-one@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.1.tgz#35a709ffb6e5f0cb79f9679a96f09ec3a35addfa"
@@ -13858,6 +13870,14 @@ react-treebeard@^2.1.0:
     radium "^0.19.0"
     shallowequal "^0.2.2"
     velocity-react "^1.3.1"
+
+react-window@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.2.tgz#edd0effe302196263ac3eac20a14c041acd4c17d"
+  integrity sha512-Qo9Z5qYvigRbSlCaWTor53G3EWVtHxXXny86EYsMG57H+4LJEEyh22PuWW6ECCkOh7sY6wWF78+wNGwPnMBCAg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react@*, react@^16.2.0, react@^16.8.6:
   version "16.8.6"


### PR DESCRIPTION
Make use of react-window in order to virtualize the list and avoid rendering hundreds of rows at once. This should prevent the lag on opening and scrolling on the tokens list or any other list with many rows.

![Jun-14-2019 17-12-52](https://user-images.githubusercontent.com/4631227/59519230-adfa2a00-8ec7-11e9-909c-e577000ea6d2.gif)
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Performance

### Parts of the app affected / Test plan
All lists really

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
