### PR TITLE
LL-1459 Ellipse long asset names for asset distribution, topbanner z-index fix

### DIFF
--- a/src/components/AssetDistribution/Row.js
+++ b/src/components/AssetDistribution/Row.js
@@ -45,6 +45,9 @@ const Asset = styled.div`
   > :first-child {
     margin-right: 10px;
   }
+  > :nth-child(2) {
+    margin-right: 8px;
+  }
 `
 const Price = styled.div`
   width: 20%;
@@ -85,9 +88,9 @@ class Row extends PureComponent<Props, State> {
       <Wrapper>
         <Asset>
           {icon}
-          <Text ff="Open Sans|SemiBold" color="dark" fontSize={3}>
+          <Ellipsis ff="Open Sans|SemiBold" color="dark" fontSize={3}>
             {currency.name}
-          </Text>
+          </Ellipsis>
         </Asset>
         <Price>
           <IconActivity size={12} color={colors.graphite} />

--- a/src/components/DashboardPage/index.js
+++ b/src/components/DashboardPage/index.js
@@ -154,8 +154,8 @@ class DashboardPage extends PureComponent<Props> {
 }
 // This forces only one visible top banner at a time
 export const TopBannerContainer = styled.div`
-  margin-top: -3px; //To hide the separator bar
-  z-index: 20;
+  margin-top: 8px;
+  z-index: 19;
 
   & > *:not(:first-child) {
     display: none;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/59597891-2bf24700-90fb-11e9-8202-807d19ee88c6.png)

In addition to the ellipse on asset distribution, it also allows the top banner to go under the topbar avoiding the glitchy looking behaviour we currently have.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1459
