### PR TITLE
Show half of the last row if scrollable

### DIFF
--- a/src/components/base/Select/index.js
+++ b/src/components/base/Select/index.js
@@ -128,7 +128,7 @@ class Select extends PureComponent<Props> {
       <Comp
         ref={c => (this.ref = c)}
         value={value}
-        maxMenuHeight={rowHeight * 5}
+        maxMenuHeight={rowHeight * 4.5}
         classNamePrefix="select"
         options={options}
         components={{

--- a/src/components/modals/Receive/steps/01-step-account.js
+++ b/src/components/modals/Receive/steps/01-step-account.js
@@ -4,6 +4,7 @@ import React, { useCallback, useMemo } from 'react'
 import { Trans } from 'react-i18next'
 import { getMainAccount } from '@ledgerhq/live-common/lib/account'
 import { listTokensForCryptoCurrency } from '@ledgerhq/live-common/lib/currencies'
+import type { CryptoCurrency, TokenCurrency } from '@ledgerhq/live-common/lib/types/currencies'
 import TrackPage from 'analytics/TrackPage'
 import Box from 'components/base/Box'
 import Label from 'components/base/Label'
@@ -41,7 +42,15 @@ const TokenParentSelection = ({ onChangeAccount, mainAccount }) => {
   )
 }
 
-const TokenSelection = ({ currency, token, onChangeToken }) => {
+const TokenSelection = ({
+  currency,
+  token,
+  onChangeToken,
+}: {
+  currency: CryptoCurrency,
+  token: ?TokenCurrency,
+  onChangeToken: (?TokenCurrency) => void,
+}) => {
   const tokens = useMemo(() => listTokensForCryptoCurrency(currency), [currency])
   return (
     <Box mt={30}>
@@ -53,7 +62,7 @@ const TokenSelection = ({ currency, token, onChangeToken }) => {
           }}
         />
       </Label>
-      <SelectCurrency onChange={onChangeToken} currencies={tokens} value={token} />
+      <SelectCurrency onChange={onChangeToken} currencies={tokens} value={token || tokens[0]} />
     </Box>
   )
 }


### PR DESCRIPTION
Until we have another solution for scrollbars, the display of dropdown selectors will attempt to show half of the last row to indicate there are more items.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/59599980-41b63b00-9100-11e9-9ec3-d5988c9af98f.png)


### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->UI Polish

 ### Context
<img width="378" alt="image" src="https://user-images.githubusercontent.com/4631227/59600043-67434480-9100-11e9-871c-092285f0a76e.png">
