### PR TITLE
LL-1534 Wrap around experimental flags sidebar tag

### DIFF
--- a/src/components/MainSideBar/index.js
+++ b/src/components/MainSideBar/index.js
@@ -95,9 +95,8 @@ const Tag = styled(Link)`
   font-family: 'Open Sans';
   font-weight: bold;
   font-size: 10px;
-  height: 22px;
-  line-height: 22px;
-  padding: 0 8px;
+  padding: 2px 8px;
+  min-height: 22px;
   border-radius: 4px;
   color: ${p => p.theme.colors.smoke};
   background-color: ${p => p.theme.colors.lightFog};


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
<img width="223" alt="image" src="https://user-images.githubusercontent.com/4631227/59666940-26a60280-91b6-11e9-9392-6e1461d2edfc.png">

For languages with a longer translation, the tag was breaking out of the bounds of the container. Maybe we should change the translations but, until then, this is the agreed solution

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1534

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Sidebar with experimental flags active