### PR TITLE
fix amount alignment in operations

### DIFF
--- a/src/components/OperationsList/AmountCell.js
+++ b/src/components/OperationsList/AmountCell.js
@@ -14,6 +14,7 @@ const Cell = styled(Box).attrs({
   alignItems: 'flex-end',
 })`
   width: 150px;
+  text-align: right;
 `
 
 type Props = {


### PR DESCRIPTION
Amount is now aligned right

### Type

UI Bug fix

### Context

LL-1495

### Parts of the app affected / Test plan

![image](https://user-images.githubusercontent.com/671786/59672143-3d9d2280-91bf-11e9-80c7-d274ab2c1989.png)

![image](https://user-images.githubusercontent.com/671786/59672210-53aae300-91bf-11e9-9b3f-c2448ae5efa5.png)

