### PR TITLE
LL-1530 Persisting (until relaunch) state for expand/collapsed rows

### DIFF
--- a/src/components/AccountsPage/AccountRowItem/index.js
+++ b/src/components/AccountsPage/AccountRowItem/index.js
@@ -104,15 +104,27 @@ const mapDispatchToProps = {
   openModal,
 }
 
+const expandedStates: { [key: string]: boolean } = {}
+
 class AccountRowItem extends PureComponent<Props, State> {
-  state = {
-    expanded: false,
+  constructor(props) {
+    super(props)
+    const { account, parentAccount } = this.props
+    const accountId = parentAccount ? parentAccount.id : account.id
+
+    this.state = {
+      expanded: expandedStates[accountId],
+    }
   }
 
-  componentWillReceiveProps(nextProps: Props) {
-    this.setState({
-      expanded: !!nextProps.search,
-    })
+  static getDerivedStateFromProps(nextProps: Props) {
+    const { account } = nextProps
+    if (account.tokenAccounts) {
+      return {
+        expanded: expandedStates[account.id] || !!nextProps.search,
+      }
+    }
+    return null
   }
 
   onClick = () => {
@@ -140,7 +152,9 @@ class AccountRowItem extends PureComponent<Props, State> {
 
   toggleAccordion = e => {
     e.stopPropagation()
-    this.setState(prevState => ({ expanded: !prevState.expanded }))
+    const { account } = this.props
+    expandedStates[account.id] = !expandedStates[account.id]
+    this.setState({ expanded: expandedStates[account.id] })
   }
 
   render() {

--- a/src/components/TokenRow.js
+++ b/src/components/TokenRow.js
@@ -55,17 +55,6 @@ const NestedRow = styled(Box)`
   &:last-of-type {
     margin-bottom: 0px;
   }
-  opacity: 0;
-  animation: fadeIn 0.1s ease both;
-  animation-delay: ${p => p.index * 0.1}s;
-  @keyframes fadeIn {
-    0% {
-      opacity: 0;
-    }
-    100% {
-      opacity: 1;
-    }
-  }
 `
 
 class TokenRow extends PureComponent<Props> {


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
> Had to remove the animation on open/close for now.

### Type

UX Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1530

### Parts of the app affected / Test plan

Accounts section, rows of ethereum accounts with tokens. See that when navigating away and coming back, the expand/collapse state is now persisted until we relaunch the app.
