### PR TITLE
display infos when currency app is not supported by ledger live

### DIFF
--- a/src/components/ManagerPage/AppsList.js
+++ b/src/components/ManagerPage/AppsList.js
@@ -5,6 +5,8 @@ import React, { PureComponent } from 'react'
 import styled from 'styled-components'
 import { translate } from 'react-i18next'
 import { compose } from 'redux'
+import get from 'lodash/get'
+import { getDeviceModel } from '@ledgerhq/devices'
 
 import type { Device, T } from 'types/common'
 import type { ApplicationVersion, DeviceInfo } from '@ledgerhq/live-common/lib/types/manager'
@@ -12,7 +14,9 @@ import type { CryptoCurrency } from '@ledgerhq/live-common/lib/types/currencies'
 import manager from '@ledgerhq/live-common/lib/manager'
 import { getEnv } from '@ledgerhq/live-common/lib/env'
 import { getFullListSortedCryptoCurrencies } from 'helpers/countervalues'
-import { listCryptoCurrencies } from 'config/cryptocurrencies'
+import { openURL } from 'helpers/linking'
+import { listCryptoCurrencies, supported } from 'config/cryptocurrencies'
+import { urls } from 'config/urls'
 import installApp from 'commands/installApp'
 import uninstallApp from 'commands/uninstallApp'
 import flushDevice from 'commands/flushDevice'
@@ -23,17 +27,17 @@ import Text from 'components/base/Text'
 import ProgressBar from 'components/ProgressBar'
 import Spinner from 'components/base/Spinner'
 import Button from 'components/base/Button'
+import ModalBody from 'components/base/Modal/ModalBody'
 import TranslatedError from 'components/TranslatedError'
 import TrackPage from 'analytics/TrackPage'
 import IconInfoCircle from 'icons/InfoCircle'
+import CheckFull from 'icons/CheckFull'
 import ExclamationCircleThin from 'icons/ExclamationCircleThin'
 import Update from 'icons/Update'
 import Trash from 'icons/Trash'
-import CheckCircle from 'icons/CheckCircle'
 import { FreezeDeviceChangeEvents } from './HookDeviceChange'
 import ManagerApp, { Container as FakeManagerAppContainer } from './ManagerApp'
 import AppSearchBar from './AppSearchBar'
-import ModalBody from '../base/Modal/ModalBody'
 
 const List = styled(Box).attrs({
   horizontal: true,
@@ -54,6 +58,29 @@ const List = styled(Box).attrs({
       }
     }
   }
+`
+
+const IconWrapper = styled(Box).attrs({})`
+  \position: relative;
+`
+
+const AppIcon = styled.img`
+  display: block;
+  width: 56px;
+  height: 56px;
+  pointer-events: none;
+`
+
+const AppCheck = styled(Box).attrs({
+  align: 'center',
+  justify: 'center',
+})`
+  color: ${({ theme }) => theme.colors.positiveGreen};
+  border-radius: 24px;
+  border: 4px solid white;
+  position: absolute;
+  top: -18px;
+  right: -12px;
 `
 
 const ICONS_FALLBACK = {
@@ -80,7 +107,7 @@ type State = {
   error: ?Error,
   filteredAppVersionsList: Array<ApplicationVersion>,
   appsLoaded: boolean,
-  app: string,
+  app: ?ApplicationVersion,
   mode: Mode,
   progress: number,
 }
@@ -119,7 +146,7 @@ class AppsList extends PureComponent<Props, State> {
     error: null,
     filteredAppVersionsList: [],
     appsLoaded: false,
-    app: '',
+    app: null,
     mode: 'home',
     progress: 0,
   }
@@ -181,7 +208,7 @@ class AppsList extends PureComponent<Props, State> {
 
   sub: *
   runAppScript = (app: ApplicationVersion, mode: *, cmd: *) => {
-    this.setState({ status: 'busy', app: app.name, mode, progress: 0 })
+    this.setState({ status: 'busy', app, mode, progress: 0 })
     const {
       device: { path: devicePath },
       deviceInfo: { targetId },
@@ -194,7 +221,7 @@ class AppsList extends PureComponent<Props, State> {
         this.setState({ status: 'success' })
       },
       error: error => {
-        this.setState({ status: 'error', error, app: '', mode: 'home' })
+        this.setState({ status: 'error', error, mode: 'home' })
       },
     })
   }
@@ -211,13 +238,27 @@ class AppsList extends PureComponent<Props, State> {
     this.setState({ status: 'idle', mode: 'home' })
   }
 
+  handleLearnMore = () => {
+    openURL(urls.appSupport)
+    this.handleCloseModal()
+  }
+
+  getIconUrl = () => {
+    const { app } = this.state
+    const icon = app ? ICONS_FALLBACK[app.icon] || app.icon : ''
+    return `https://api.ledgerwallet.com/update/assets/icons/${icon}`
+  }
+
   renderBody = () => {
-    const { t } = this.props
+    const { t, device } = this.props
     const { app, status, error, mode, progress } = this.state
+
+    const isSupported = supported.includes(get(app, 'name', '').toLowerCase())
+    const isInstalling = mode === 'installing'
 
     return ['busy', 'idle'].includes(status) ? (
       <Box grow align="center" justify="center">
-        {mode === 'installing' ? (
+        {isInstalling ? (
           <Box color="grey" grow align="center" mb={5}>
             <Update size={30} />
           </Box>
@@ -227,7 +268,7 @@ class AppsList extends PureComponent<Props, State> {
           </Box>
         )}
         <Text ff="Museo Sans|Regular" fontSize={6} color="dark">
-          {mode !== 'home' ? t(`manager.apps.${mode}`, { app }) : null}
+          {mode !== 'home' ? t(`manager.apps.${mode}`, { app: get(app, 'name', '') }) : null}
         </Text>
         <Box mt={6}>
           <ProgressBar width={150} progress={progress} />
@@ -235,7 +276,12 @@ class AppsList extends PureComponent<Props, State> {
       </Box>
     ) : status === 'error' ? (
       <Box>
-        <TrackPage category="Manager" name="Error Modal" error={error && error.name} app={app} />
+        <TrackPage
+          category="Manager"
+          name="Error Modal"
+          error={error && error.name}
+          app={get(app, 'name', '')}
+        />
         <Box grow align="center" justify="center" mt={5}>
           <Box color="alertRed">
             <ExclamationCircleThin size={44} />
@@ -264,9 +310,12 @@ class AppsList extends PureComponent<Props, State> {
       </Box>
     ) : status === 'success' ? (
       <Box grow align="center" justify="center" mt={5}>
-        <Box color="positiveGreen">
-          <CheckCircle size={44} />
-        </Box>
+        <IconWrapper>
+          <AppCheck>
+            <CheckFull size={24} />
+          </AppCheck>
+          <AppIcon src={this.getIconUrl()} />
+        </IconWrapper>
         <Box
           color="dark"
           mt={4}
@@ -275,17 +324,45 @@ class AppsList extends PureComponent<Props, State> {
           textAlign="center"
           style={{ maxWidth: 350 }}
         >
-          {t(`manager.apps.${mode === 'installing' ? 'installSuccess' : 'uninstallSuccess'}`, {
-            app,
+          {t(`manager.apps.${isInstalling ? 'installSuccess' : 'uninstallSuccess'}`, {
+            app: get(app, 'name', ''),
           })}
         </Box>
+        {app && app.currency && isInstalling ? (
+          <Box
+            color="smoke"
+            mt={2}
+            fontSize={4}
+            ff="Open Sans|Regular"
+            textAlign="center"
+            style={{ maxWidth: 350 }}
+          >
+            {t(`manager.apps.${isSupported ? 'supportedCurrency' : 'unsupportedCurrency'}`, {
+              app: app.name,
+              device: get(getDeviceModel(device.modelId), 'productName', ''),
+            })}
+          </Box>
+        ) : null}
       </Box>
     ) : null
   }
 
   renderFooter = () => {
     const { t } = this.props
-    return (
+    const { app, mode } = this.state
+
+    const isInstalling = mode === 'installing'
+    const isCurrency = app && app.currency
+    const isSupported = app && supported.includes(app.name.toLowerCase())
+
+    return isInstalling && isCurrency && !isSupported ? (
+      <Box horizontal justifyContent="flex-end" style={{ width: '100%' }}>
+        <Button onClick={this.handleCloseModal}>{t('common.close')}</Button>
+        <Button style={{ marginLeft: 10 }} primary onClick={this.handleLearnMore}>
+          {t('common.learnMore')}
+        </Button>
+      </Box>
+    ) : (
       <Box horizontal justifyContent="flex-end" style={{ width: '100%' }}>
         <Button primary onClick={this.handleCloseModal}>
           {t('common.close')}
@@ -296,17 +373,23 @@ class AppsList extends PureComponent<Props, State> {
 
   renderModal = () => {
     const { status, mode } = this.state
+    const { t } = this.props
+    const shouldDisplayTitle = mode !== 'home' && status === 'success'
     return (
       <Modal
         isOpened={status !== 'idle' && status !== 'loading'}
         preventBackdropClick={['installing', 'uninstalling'].includes(mode)}
         centered
-        onClose={this.handleCloseModal}
+        onClose={null}
       >
         <ModalBody
           align="center"
           justify="center"
-          title={''}
+          title={
+            shouldDisplayTitle
+              ? t(`manager.apps.${mode === 'installing' ? 'installed' : 'uninstalled'}`)
+              : ''
+          }
           render={this.renderBody}
           onClose={this.handleCloseModal}
           renderFooter={['error', 'success'].includes(status) ? this.renderFooter : undefined}

--- a/src/config/cryptocurrencies.js
+++ b/src/config/cryptocurrencies.js
@@ -3,7 +3,7 @@ import memoize from 'lodash/memoize'
 import { listCryptoCurrencies as listCC } from '@ledgerhq/live-common/lib/currencies'
 import type { CryptoCurrencyIds, CryptoCurrency } from '@ledgerhq/live-common/lib/types'
 
-const supported: CryptoCurrencyIds[] = [
+export const supported: CryptoCurrencyIds[] = [
   'bitcoin',
   'ethereum',
   'ripple',

--- a/src/config/cryptocurrencies.js
+++ b/src/config/cryptocurrencies.js
@@ -3,7 +3,7 @@ import memoize from 'lodash/memoize'
 import { listCryptoCurrencies as listCC } from '@ledgerhq/live-common/lib/currencies'
 import type { CryptoCurrencyIds, CryptoCurrency } from '@ledgerhq/live-common/lib/types'
 
-export const supported: CryptoCurrencyIds[] = [
+const supported: CryptoCurrencyIds[] = [
   'bitcoin',
   'ethereum',
   'ripple',
@@ -32,6 +32,8 @@ export const supported: CryptoCurrencyIds[] = [
   'bitcoin_testnet',
   'ethereum_ropsten',
 ]
+
+export const isCurrencySupported = (currency: CryptoCurrency) => supported.includes(currency.id)
 
 export const listCryptoCurrencies: (
   withDevCrypto?: boolean,

--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -25,6 +25,7 @@ export const urls = {
   privacyPolicy: 'https://www.ledger.com/pages/privacy-policy',
   troubleshootingUSB: 'https://support.ledger.com/hc/en-us/articles/115005165269',
   managerERC20: 'https://support.ledger.com/hc/en-us/articles/115005197845-Manage-ERC20-tokens',
+  appSupport: 'https://support.ledger.com/hc/en-us/categories/115000811829-Apps',
 
   githubIssues:
     'https://github.com/LedgerHQ/ledger-live-desktop/issues?q=is%3Aissue+is%3Aopen+label%3Abug+sort%3Acomments-desc',

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -299,6 +299,7 @@
       "installing": "Installing {{app}}...",
       "uninstalling": "Uninstalling {{app}}...",
       "installSuccess": "{{app}} was successfully installed",
+      "unsupportedSuccess": "Learn how to use {{app}}",
       "uninstallSuccess": "{{app}} uninstalled",
       "supportedCurrency": "{{app}} is now installed on your {{device}}. Add an account so you can send and receive funds",
       "unsupportedCurrency": "{{app}} is not supported in Ledger Live. Click the button to learn how to use it",
@@ -333,10 +334,8 @@
       "mcuFirst": "Disconnect the USB cable from your device",
       "mcuSecond": "Press the left button and hold it while you reconnect the USB cable until the <1><0>{{repairProcessing}}</0></1> screen appears",
       "mcuPin": "Please be patient while the update is finalized",
-      "mcuBlueFirst":
-        "Press and hold the side button for 10 seconds to turn off the device. Release the button.",
-      "mcuBlueSecond":
-        "Press and hold the button for at least 5 seconds until the Boot Options are displayed. Tap Bootloader Mode",
+      "mcuBlueFirst": "Press and hold the side button for 10 seconds to turn off the device. Release the button.",
+      "mcuBlueSecond": "Press and hold the button for at least 5 seconds until the Boot Options are displayed. Tap Bootloader Mode",
       "successTitle": "Firmware updated",
       "successText": "Please re-install the apps on your device",
       "resetTitle": "Prepare Device",
@@ -352,10 +351,8 @@
         "recoveryMode": "Tap {{mode}} Mode. Wait until the dashboard appears.",
         "third": "3. Uninstall all apps",
         "openLive": "Open the Manager in Ledger Live.",
-        "uninstall":
-          "Click on the grey trash icon for all apps currently installed on the {{deviceName}}. This makes room for the firmware installer.",
-        "disclaimer":
-          "Note: Your funds are not affected by this operation, the private keys to access your crypto assets in the blockchain remain secured on your Recovery sheet."
+        "uninstall": "Click on the grey trash icon for all apps currently installed on the {{deviceName}}. This makes room for the firmware installer.",
+        "disclaimer": "Note: Your funds are not affected by this operation, the private keys to access your crypto assets in the blockchain remain secured on your Recovery sheet."
       }
     },
     "title": "Manager",
@@ -459,7 +456,6 @@
       "about": "About",
       "experimental": "Experimental features"
     },
-
     "export": {
       "accounts": {
         "title": "Export accounts",

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -298,9 +298,13 @@
       "all": "App catalog",
       "installing": "Installing {{app}}...",
       "uninstalling": "Uninstalling {{app}}...",
-      "installSuccess": "Successfully installed {{app}}",
+      "installSuccess": "{{app}} was successfully installed",
       "uninstallSuccess": "{{app}} uninstalled",
-      "help": "Check on your device to see which apps are already installed"
+      "supportedCurrency": "{{app}} is now installed on your {{device}}. Add an account so you can send and receive funds",
+      "unsupportedCurrency": "{{app}} is not supported in Ledger Live. Click the button to learn how to use it",
+      "help": "Check on your device to see which apps are already installed",
+      "installed": "App installed",
+      "uninstalled": "App uninstalled"
     },
     "firmware": {
       "installed": "Firmware version {{version}}",


### PR DESCRIPTION
show a Learn More link when installing a cryptocyurrency app that is not supported by ledger live

Also reworked the whole modal when installing / uninstalling apps

### Type

UI Improvement

### Context

LL-1482

### Parts of the app affected / Test plan

Install supported app

![image](https://user-images.githubusercontent.com/671786/59782165-a9fe4b80-92bd-11e9-97c9-e99e64f32cd5.png)

Install unsupported app

![image](https://user-images.githubusercontent.com/671786/59776497-37886e00-92b3-11e9-8cc4-d5d5c6204188.png)

Uninstall app

![image](https://user-images.githubusercontent.com/671786/59776364-f728f000-92b2-11e9-8b64-3806978c00e6.png)

@khalilbenihoud @bscholving @dekkaki are the design ok witchu ?