### PR TITLE
Clear experimental flags on LL version changes

### DIFF
--- a/src/helpers/experimental.js
+++ b/src/helpers/experimental.js
@@ -82,6 +82,7 @@ export const experimentalFeatures: Feature[] = [
 ]
 
 const lsKey = 'experimentalFlags'
+const lsKeyVersion = `${lsKey}_llversion`
 
 export const getLocalStorageEnvs = (): { [_: string]: any } => {
   const maybeData = window.localStorage.getItem(lsKey)
@@ -94,6 +95,11 @@ export const getLocalStorageEnvs = (): { [_: string]: any } => {
     }
   })
   return obj
+}
+
+if (window.localStorage.getItem(lsKeyVersion) !== __APP_VERSION__) {
+  window.localStorage.removeItem(lsKey)
+  window.localStorage.setItem(lsKeyVersion, __APP_VERSION__)
 }
 
 const envs = getLocalStorageEnvs()


### PR DESCRIPTION
when LL version changes, we want to reset all experimental flags: user need to opt-in again because a release is likely to invalidate them each time & it's safer that way.

### Type

polish

### Parts of the app affected / Test plan

- experimental should be back to default as soon as you enter this PR & also when the LL version changes.
- experimental should be restored if LL version didn't change.