### PR TITLE
Avoid showing placeholder for ETH account with tokens

### DIFF
--- a/src/components/AccountPage/index.js
+++ b/src/components/AccountPage/index.js
@@ -94,6 +94,7 @@ class AccountPage extends PureComponent<Props> {
 
     const currency = getAccountCurrency(account)
     const color = getCurrencyColor(currency)
+    const hasTokenAccounts = mainAccount.tokenAccounts && mainAccount.tokenAccounts.length
 
     return (
       <Box key={account.id}>
@@ -109,7 +110,7 @@ class AccountPage extends PureComponent<Props> {
           <AccountHeaderActions account={account} parentAccount={parentAccount} />
         </Box>
 
-        {!isAccountEmpty(account) ? (
+        {!isAccountEmpty(account) || hasTokenAccounts ? (
           <>
             <Box mb={7}>
               <BalanceSummary


### PR DESCRIPTION

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/4631227/59800395-da0e1480-92e6-11e9-87bf-10bf0c36e74c.png">

For accounts that don't have ETH balance but do have token accounts with balance we are now able to access them without showing the placeholder.

### Type

Bug fix

