### PR TITLE
LL-1531 Avoid overflow on eth countervalue portfolio

### DIFF
--- a/src/components/BalanceInfos.js
+++ b/src/components/BalanceInfos.js
@@ -83,7 +83,7 @@ export function BalanceSinceDiff(props: Props) {
 export function BalanceTotal(props: BalanceTotalProps) {
   const { unit, totalBalance, isAvailable, showCryptoEvenIfNotAvailable, children } = props
   return (
-    <Box grow {...props}>
+    <Box grow shrink {...props}>
       {!isAvailable && !showCryptoEvenIfNotAvailable ? (
         <PlaceholderLine width={150} />
       ) : (


### PR DESCRIPTION
 
![image](https://user-images.githubusercontent.com/4631227/59839963-ccda3f80-9351-11e9-9f2e-993fca9258c8.png)
Similarly to what we had to do with the account page header, this overflow looks.... not great, because by being an animated ticker we can't easily do the ellipsis calculation. Either we make the text smaller, or we have this.


### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1531

Until we have a new design, with a new font size, or a rearrange of elements, this matches the account page solution.
