### PR TITLE
Brings back the No options message

### DIFF
--- a/src/components/base/Select/index.js
+++ b/src/components/base/Select/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { PureComponent } from 'react'
-import ReactSelect from 'react-select'
+import ReactSelect, { components } from 'react-select'
 import AsyncReactSelect from 'react-select/lib/Async'
 import { translate } from 'react-i18next'
 import { FixedSizeList as List } from 'react-window'
@@ -49,10 +49,20 @@ const Row = styled.div`
 const rowHeight = 40 // Fixme We should pass this as a prop for dynamic rows?
 class MenuList extends PureComponent<*> {
   render() {
-    const { options, children, maxHeight, getValue } = this.props
+    const {
+      options,
+      children,
+      maxHeight,
+      getValue,
+      selectProps: { noOptionsMessage },
+    } = this.props
     const [value] = getValue()
     const initialOffset = options.indexOf(value) * rowHeight
     const minHeight = Math.min(...[maxHeight, rowHeight * children.length])
+
+    if (!children.length && noOptionsMessage) {
+      return <components.NoOptionsMessage {...this.props} />
+    }
 
     children.length &&
       children.map(key => {


### PR DESCRIPTION
I noticed during the braindstorm meeting that there was a regression where we lost the _"no option message"_ on selectors all over the app. This brings them back.
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/4631227/59857163-a5e33400-9378-11e9-8335-02396d6ebb9b.png">


### Type

Regression fix

### Context

No issue

### Parts of the app affected / Test plan

Currency/Token/Account selectors
