### PR TITLE
Add sendMax status to fees hash function

### DIFF
--- a/src/bridge/LibcoreBridge.js
+++ b/src/bridge/LibcoreBridge.js
@@ -99,9 +99,9 @@ const feesLoaded = (a, t) => {
 const feesHashFunction = (a, t) =>
   `${a.id}_${a.blockHeight || 0}_${(t.amount || '0').toString()}_${t.recipient}_${
     t.feePerByte ? t.feePerByte.toString() : ''
-  }_${t.gasLimit ? t.gasLimit.toString() : ''}_${t.gasPrice ? t.gasPrice.toString() : ''}_${
-    t.fee ? t.fee.toString() : ''
-  }`
+  }_${t.useAllAmount ? 'sendMax' : 'noSendMax'}_${t.gasLimit ? t.gasLimit.toString() : ''}_${
+    t.gasPrice ? t.gasPrice.toString() : ''
+  }_${t.fee ? t.fee.toString() : ''}`
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 const startSync = (initialAccount, _observation) =>


### PR DESCRIPTION
There is an issue the fees calculation cache not taking into account the  send max status. This adds that status to the hash function.

### Type

Bug Fix
