### PR TITLE
LL-1571 Hide the Receive token button temporarily

### DIFF
--- a/src/components/AccountPage/TokensList.js
+++ b/src/components/AccountPage/TokensList.js
@@ -64,8 +64,9 @@ const mapDispatchToProps = {
   openModal,
 }
 
+// Fixme Temporarily hiding the receive token button
 const ReceiveButton = (props: { onClick: () => void }) => (
-  <Button small primary onClick={props.onClick}>
+  <Button hidden small primary onClick={props.onClick}>
     <Box horizontal flow={1} alignItems="center">
       <IconPlus size={12} />
       <Box>


### PR DESCRIPTION

![gone](https://user-images.githubusercontent.com/4631227/60090290-8c5c3680-9742-11e9-90b7-f94e18ec0126.gif)
>_Gif for illustrative purposes only, no animation on the app._

### Type

UI Temporary polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1571

### Parts of the app affected / Test plan

Ethereum account with tokens, there should be no Receive token button anymore.
