### PR TITLE
LL-1573 Connected the rate graphs with the user time range selection

### DIFF
--- a/src/components/SettingsPage/sections/CryptoAssets/RateRow/PriceGraph.js
+++ b/src/components/SettingsPage/sections/CryptoAssets/RateRow/PriceGraph.js
@@ -8,15 +8,15 @@ import CounterValues from 'helpers/countervalues'
 import { PlaceholderLine } from 'components/Placeholder'
 import { colors } from 'styles/theme'
 import { rgba } from 'styles/helpers'
+import { getDates } from '@ledgerhq/live-common/lib/portfolio'
 
-const DAY = 24 * 60 * 60 * 1000
 const mapStateToProps = (state, props: *) => {
+  const dates = getDates(props.timeRange)
   const data = []
-  let t = Date.now() - props.days * DAY
   const value = BigNumber(10 ** props.from.units[0].magnitude)
   let nbCounterValueOff = 0
-  for (let i = 0; i < props.days; i++) {
-    const date = new Date(t)
+  for (let i = 0; i < dates.length; i++) {
+    const date = dates[i]
     const cv = CounterValues.calculateSelector(state, {
       ...props,
       date,
@@ -27,15 +27,13 @@ const mapStateToProps = (state, props: *) => {
       date,
       value: cv ? cv.toNumber() : 0,
     })
-    t += DAY
   }
-  return { data, isAvailable: nbCounterValueOff < props.days }
+  return { data, isAvailable: nbCounterValueOff < dates.length }
 }
 
 class PriceGraph extends Component<{
   from: Currency, // eslint-disable-line
   to: Currency, // eslint-disable-line
-  days: number, // eslint-disable-line
   exchange: ?string, // eslint-disable-line
   isAvailable: boolean,
   data: Array<{ date: Date, value: number }>,

--- a/src/components/SettingsPage/sections/CryptoAssets/RateRow/index.js
+++ b/src/components/SettingsPage/sections/CryptoAssets/RateRow/index.js
@@ -12,11 +12,13 @@ import styled from 'styled-components'
 import PriceGraph from './PriceGraph'
 import Price from '../../../../Price'
 import Ellipsis from '../../../../base/Ellipsis'
+import type { TimeRange } from '../../../../../reducers/settings'
 
 type Props = {
   from: Currency,
   to: Currency,
   exchange: ?string,
+  timeRange: TimeRange,
   setExchangePairsAction: any => void,
 }
 
@@ -68,7 +70,7 @@ class RateRow extends PureComponent<Props> {
     ])
   }
   render() {
-    const { from, to, exchange } = this.props
+    const { from, to, exchange, timeRange } = this.props
     return (
       <RateRowWrapper>
         <Box ff="Museo Sans|Regular" horizontal alignItems="center" color="dark" fontSize={4}>
@@ -89,7 +91,14 @@ class RateRow extends PureComponent<Props> {
           </Ellipsis>
         </div>
         <div>
-          <PriceGraph from={from} to={to} width={150} height={40} exchange={exchange} days={30} />
+          <PriceGraph
+            timeRange={timeRange}
+            from={from}
+            to={to}
+            width={150}
+            height={40}
+            exchange={exchange}
+          />
         </div>
         <ExchangeSelect
           small

--- a/src/components/SettingsPage/sections/CryptoAssets/Rates.js
+++ b/src/components/SettingsPage/sections/CryptoAssets/Rates.js
@@ -19,13 +19,17 @@ import {
   SettingsSectionHeader as Header,
   SettingsSectionBody as Body,
 } from '../../SettingsSection'
+import { selectedTimeRangeSelector, timeRangeDaysByKey } from '../../../../reducers/settings'
+import type { TimeRange } from '../../../../reducers/settings'
 
 type Props = {
+  timeRange: TimeRange,
   pairs: { from: Currency, to: Currency, exchange: ?string }[],
   t: T,
 }
 
 const mapStateToProps = createStructuredSelector({
+  timeRange: selectedTimeRangeSelector,
   pairs: pairsSelector,
 })
 
@@ -70,7 +74,8 @@ const RateTooltip = () => (
 
 class Rates extends PureComponent<Props> {
   render() {
-    const { t, pairs } = this.props
+    const { t, pairs, timeRange } = this.props
+    const days = timeRangeDaysByKey[timeRange]
 
     return (
       <Section>
@@ -82,7 +87,7 @@ class Rates extends PureComponent<Props> {
         <Body>
           <RateRowWrapper>
             <Box ff="Open Sans|SemiBold" alignItems="center" horizontal color="dark" fontSize={4}>
-              {'Rate'}
+              <Trans i18nKey="settings.rates.rate" />
               <TooltipButtonWrapper>
                 <Tooltip render={RateTooltip}>
                   <IconInfoCircle size={12} />
@@ -90,17 +95,23 @@ class Rates extends PureComponent<Props> {
               </TooltipButtonWrapper>
             </Box>
             <Box ff="Open Sans|SemiBold" color="dark" fontSize={4}>
-              {'Price'}
+              <Trans i18nKey="settings.rates.rpice" />
             </Box>
             <Box ff="Open Sans|SemiBold" color="dark" fontSize={4}>
-              {'Last 30 days'}
+              <Trans i18nKey={`settings.rates.last`} values={{ days }} />
             </Box>
             <Box ff="Open Sans|SemiBold" color="dark" fontSize={4}>
-              {'Exchange'}
+              <Trans i18nKey="settings.rates.exchange" />
             </Box>
           </RateRowWrapper>
           {pairs.map(({ from, to, exchange }) => (
-            <RateRow key={`${from.ticker}_${to.ticker}`} from={from} to={to} exchange={exchange} />
+            <RateRow
+              key={`${from.ticker}_${to.ticker}`}
+              timeRange={timeRange}
+              from={from}
+              to={to}
+              exchange={exchange}
+            />
           ))}
         </Body>
       </Section>

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -502,7 +502,11 @@
       "desc": "Here are all the rates that are used by Ledger Live to calculate countervalues. \nYou can configure a fiat countervalue and what exchanges are used for each rate.",
       "fromTo": "{{from}} to {{to}}",
       "cryptoToFiat": "Crypto to fiat",
-      "cryptoToCrypto": "Crypto to Crypto"
+      "cryptoToCrypto": "Crypto to Crypto",
+      "rate": "Rate",
+      "last": "Last {{days}} days",
+      "price": "Price",
+      "exchange": "Exchange"
     },
     "profile": {
       "password": "Password lock",


### PR DESCRIPTION

<img width="877" alt="image" src="https://user-images.githubusercontent.com/4631227/60096011-34c4c780-9750-11e9-9011-9e1c3925102e.png">


### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1573

### Parts of the app affected / Test plan

Rate graphs,  the data should correspond to the selected time range in the portfolio
