### PR TITLE
Make Spacebar trigger tabbable events

### DIFF
--- a/src/components/base/Box/Tabbable.js
+++ b/src/components/base/Box/Tabbable.js
@@ -9,6 +9,7 @@ import { rgba } from 'styles/helpers'
 import Box from './Box'
 
 const KEY_ENTER = 13
+const KEY_SPACE = 32
 
 export const focusedShadowStyle = `
   0 0 0 1px ${rgba('#0a84ff', 0.5)} inset,
@@ -42,7 +43,8 @@ export default class Tabbable extends Component<
   handleKeyPress = (e: SyntheticKeyboardEvent<*>) => {
     const { isFocused } = this.state
     const { onClick } = this.props
-    const canPress = e.which === KEY_ENTER && isGlobalTabEnabled() && isFocused
+    const canPress =
+      (e.which === KEY_ENTER || e.which === KEY_SPACE) && isGlobalTabEnabled() && isFocused
     if (canPress && onClick) onClick(e)
   }
 


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

UX improvement

### Context

n/a

### Parts of the app affected / Test plan

Tabbable elements, such as the send max checkbox can be triggered with enter **and** space keys now. In the send flow, use Tab to reach the checkbox as the selected element, then press the space key.
