### PR TITLE
LL-1546 Made the Parent account name ellipse when needed

### DIFF
--- a/src/components/TopBar/Breadcrumb/AccountCrumb.js
+++ b/src/components/TopBar/Breadcrumb/AccountCrumb.js
@@ -60,8 +60,12 @@ const TextLink = styled.div`
   > :first-child {
     margin-right: 8px;
   }
+  ${p => (p.shrink ? 'flex: 1;' : '')}
 
   > ${Base} {
+    text-overflow: ellipsis;
+    flex-shrink: 1;
+    overflow: hidden;
     padding: 0px;
     &:hover,
     &:active {
@@ -72,11 +76,11 @@ const TextLink = styled.div`
   }
 `
 const AngleDown = styled.div`
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   border-radius: 20px;
   text-align: center;
-  line-height: 14px;
+  line-height: 16px;
 
   &:hover {
     background: ${p => p.theme.colors.fog};
@@ -199,7 +203,8 @@ class AccountCrumb extends PureComponent<Props> {
       <>
         <Separator />
         <DropDown
-          flow={1}
+          flex={1}
+          shrink={parentId ? '0' : '1'}
           offsetTop={0}
           border
           horizontal
@@ -208,7 +213,7 @@ class AccountCrumb extends PureComponent<Props> {
           onStateChange={this.onAccountSelected}
           value={processedItems.find(a => a.key === id)}
         >
-          <TextLink>
+          <TextLink {...{ shrink: !parentId }}>
             {currency && <CryptoCurrencyIcon size={14} currency={currency} />}
             <Button onClick={this.openActiveAccount}>{name}</Button>
             <AngleDown>

--- a/src/components/TopBar/Breadcrumb/index.js
+++ b/src/components/TopBar/Breadcrumb/index.js
@@ -11,6 +11,12 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
+  flex: 1;
+  width: 0;
+  flex-shrink: 1;
+  text-overflow: ellipsis;
+  break-word: break-all;
+  white-space: nowrap;
   > * {
     font-family: 'Open Sans';
     font-weight: 600;

--- a/src/components/TopBar/index.js
+++ b/src/components/TopBar/index.js
@@ -99,35 +99,36 @@ class TopBar extends PureComponent<Props> {
     return (
       <Container bg="lightGrey" color="graphite">
         <Inner>
-          <Box grow horizontal>
+          <Box grow horizontal justifyContent="space-between">
             <Breadcrumb />
-            <Box grow />
-            <CurrenciesStatusBanner />
-            {hasAccounts && (
-              <Fragment>
-                <ActivityIndicator />
-                <Box justifyContent="center">
-                  <Bar />
-                </Box>
-              </Fragment>
-            )}
-            <Tooltip render={() => t('settings.title')} data-e2e="setting_button">
-              <ItemContainer isInteractive onClick={this.navigateToSettings}>
-                <IconSettings size={16} />
-              </ItemContainer>
-            </Tooltip>
-            {hasPassword && ( // FIXME this should be a dedicated component. therefore this component don't need to connect()
-              <Fragment>
-                <Box justifyContent="center">
-                  <Bar />
-                </Box>
-                <Tooltip render={() => t('common.lock')}>
-                  <ItemContainer isInteractive justifyContent="center" onClick={this.handleLock}>
-                    <IconLock size={16} />
-                  </ItemContainer>
-                </Tooltip>
-              </Fragment>
-            )}
+            <Box horizontal>
+              <CurrenciesStatusBanner />
+              {hasAccounts && (
+                <Fragment>
+                  <ActivityIndicator />
+                  <Box justifyContent="center">
+                    <Bar />
+                  </Box>
+                </Fragment>
+              )}
+              <Tooltip render={() => t('settings.title')} data-e2e="setting_button">
+                <ItemContainer isInteractive onClick={this.navigateToSettings}>
+                  <IconSettings size={16} />
+                </ItemContainer>
+              </Tooltip>
+              {hasPassword && (
+                <Fragment>
+                  <Box justifyContent="center">
+                    <Bar />
+                  </Box>
+                  <Tooltip render={() => t('common.lock')}>
+                    <ItemContainer isInteractive justifyContent="center" onClick={this.handleLock}>
+                      <IconLock size={16} />
+                    </ItemContainer>
+                  </Tooltip>
+                </Fragment>
+              )}
+            </Box>
           </Box>
         </Inner>
         <SeparatorBar />

--- a/src/components/base/DropDown/index.js
+++ b/src/components/base/DropDown/index.js
@@ -40,6 +40,10 @@ export const DropDownItem = styled(Box).attrs({
   white-space: nowrap;
 `
 
+export const Wrapper = styled(Box)`
+  flex-shrink: 1;
+  ${p => p.shrink && `flex-shrink:${p.shrink};`}
+`
 function itemToString(item) {
   return item ? item.label : ''
 }
@@ -59,6 +63,7 @@ type Props = {
   onStateChange?: Function,
   renderItem: Object => any,
   value?: DropDownItemType | null,
+  shrink?: string,
 }
 
 class DropDown extends PureComponent<Props> {
@@ -141,7 +146,7 @@ class DropDown extends PureComponent<Props> {
   }
 
   render() {
-    const { children, items, value, onChange, ...props } = this.props
+    const { children, items, value, onChange, shrink, ...props } = this.props
     return (
       <Downshift
         onChange={onChange}
@@ -156,12 +161,12 @@ class DropDown extends PureComponent<Props> {
           selectedItem,
           ...downshiftProps
         }) => (
-          <Box {...getRootProps({ refKey: 'innerRef' })} horizontal relative>
+          <Wrapper shrink={shrink} {...getRootProps({ refKey: 'innerRef' })} horizontal relative>
             <Trigger {...getToggleButtonProps()} tabIndex={0} {...props}>
               {children}
             </Trigger>
             {isOpen && this.renderItems(items, selectedItem, downshiftProps)}
-          </Box>
+          </Wrapper>
         )}
       />
     )


### PR DESCRIPTION

![Jun-25-2019 17-24-41](https://user-images.githubusercontent.com/4631227/60111573-7ebca600-976e-11e9-929b-435c50a33b0e.gif)
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1546

### Parts of the app affected / Test plan

Account breadcrumbs that used to overflow, now should behave nicer. Note that the original name of the account is _"There once was a very long account name that overf"_ because I couldn't keep on typing after that many characters.
