### PR TITLE
Pixel polish for ERC20 Desktop

### DIFF
--- a/src/components/AccountPage/AccountHeader.js
+++ b/src/components/AccountPage/AccountHeader.js
@@ -38,11 +38,7 @@ class AccountHeader extends PureComponent<Props> {
     return (
       <Box horizontal align="center" flow={2} grow>
         <Box>
-          <ParentCryptoCurrencyIcon
-            currency={currency}
-            parentCurrency={currency.type === 'TokenAccount' ? currency.parentCurrency : undefined}
-            borderColor="lightGrey"
-          />
+          <ParentCryptoCurrencyIcon currency={currency} borderColor="lightGrey" />
         </Box>
         <Box grow>
           <CurName>{account.type === 'Account' ? currency.name : 'token'}</CurName>

--- a/src/components/AccountsPage/AccountGridItem/Header.js
+++ b/src/components/AccountsPage/AccountGridItem/Header.js
@@ -56,10 +56,7 @@ class Header extends PureComponent<{
     return (
       <Box flow={4}>
         <Box horizontal ff="Open Sans|SemiBold" flow={3} alignItems="center">
-          <ParentCryptoCurrencyIcon
-            currency={currency}
-            parentCurrency={parentAccount && parentAccount.currency}
-          />
+          <ParentCryptoCurrencyIcon currency={currency} parent={parentAccount} />
           <HeadText name={name} title={title} />
           <AccountSyncStatusIndicator
             accountId={(parentAccount && parentAccount.id) || account.id}

--- a/src/components/AccountsPage/AccountList/Header.js
+++ b/src/components/AccountsPage/AccountList/Header.js
@@ -71,9 +71,7 @@ class Header extends PureComponent<Props, { focused: boolean }> {
           onChange={onTextChange}
           value={search}
         />
-        <Box>
-          <AccountsRange onRangeChange={onRangeChange} range={range} />
-        </Box>
+        <AccountsRange onRangeChange={onRangeChange} range={range} />
         <Box ml={4} mr={4}>
           <AccountsOrder />
         </Box>

--- a/src/components/AccountsPage/AccountList/Header.js
+++ b/src/components/AccountsPage/AccountList/Header.js
@@ -3,7 +3,6 @@
 import React, { PureComponent } from 'react'
 
 import Box from 'components/base/Box'
-import Text from 'components/base/Text'
 import styled from 'styled-components'
 import SearchIcon from 'icons/Search'
 import type { PortfolioRange } from '@ledgerhq/live-common/lib/types/portfolio'
@@ -72,9 +71,9 @@ class Header extends PureComponent<Props, { focused: boolean }> {
           onChange={onTextChange}
           value={search}
         />
-        <Text color="dark" ff="Museo Sans" fontSize={6} data-e2e="dashboard_AccountCount">
+        <Box>
           <AccountsRange onRangeChange={onRangeChange} range={range} />
-        </Text>
+        </Box>
         <Box ml={4} mr={4}>
           <AccountsOrder />
         </Box>

--- a/src/components/AccountsPage/AccountRowItem/index.js
+++ b/src/components/AccountsPage/AccountRowItem/index.js
@@ -7,6 +7,8 @@ import type { Account, TokenAccount } from '@ledgerhq/live-common/lib/types/acco
 import type { PortfolioRange } from '@ledgerhq/live-common/lib/types/portfolio'
 import { openModal } from 'reducers/modals'
 import { connect } from 'react-redux'
+import { Trans } from 'react-i18next'
+import Text from 'components/base/Text'
 import IconAngleDown from 'icons/AngleDown'
 import Header from './Header'
 import Balance from './Balance'
@@ -64,25 +66,26 @@ const TokenContent = styled.div`
   margin-top: 20px;
 `
 
-const TokenAccountIndicator = styled.div`
-  background: #ffffff;
+const TokenShowMoreIndicator = styled.div`
+  margin: 15px -20px -16px;
+  display: flex;
+  color: ${p => p.theme.colors.wallet};
+  align-items: center;
+  justify-content: center;
+  border-top: 1px solid ${p => p.theme.colors.lightFog};
+  background: white;
   border-radius: 0px 0px 4px 4px;
-  box-shadow: 0 4px 8px 0 #00000007;
-  height: 7px;
-  margin: -18px 10px 8px 10px;
-`
-
-export const TokenShowMoreIndicator = styled.button`
-  background-color: ${p => p.color || p.theme.colors.pillActiveBackground};
-  border-radius: ${p => p.size}px;
-  border-width: 0px;
-  color: ${p => p.color || p.theme.colors.wallet};
-  height: ${p => p.size}px;
-  line-height: ${p => p.size}px;
+  height: 32px;
   text-align: center;
-  transform: ${p => (p.expanded ? 'rotate(180deg)' : 'none')};
-  width: ${p => p.size}px;
-  transition: all 0.3s linear;
+
+  &:hover ${Text} {
+    text-decoration: underline;
+  }
+
+  > :nth-child(2) {
+    margin-left: 8px;
+    transform: rotate(${p => (p.expanded ? '180deg' : '0deg')});
+  }
 `
 
 type Props = {
@@ -197,17 +200,6 @@ class AccountRowItem extends PureComponent<Props, State> {
               <Balance unit={unit} balance={account.balance} disableRounding={disableRounding} />
               <Countervalue account={account} currency={currency} range={range} />
               <Delta account={account} range={range} />
-              {showTokensIndicator && !disabled ? (
-                <TokenShowMoreIndicator
-                  size={18}
-                  expanded={expanded}
-                  onClick={this.toggleAccordion}
-                >
-                  <IconAngleDown size={16} />
-                </TokenShowMoreIndicator>
-              ) : (
-                <div style={{ width: 18 }} />
-              )}
             </RowContent>
           </ContextMenuItem>
           {showTokensIndicator && expanded && (
@@ -226,8 +218,18 @@ class AccountRowItem extends PureComponent<Props, State> {
                 ))}
             </TokenContent>
           )}
+          {showTokensIndicator && !disabled && tokens && (
+            <TokenShowMoreIndicator expanded={expanded} onClick={this.toggleAccordion}>
+              <Text color="wallet" ff="Open Sans|SemiBold" fontSize={4}>
+                <Trans
+                  i18nKey={expanded ? 'tokensList.hideTokens' : 'tokensList.seeTokens'}
+                  values={{ tokenCount: tokens.length }}
+                />
+              </Text>
+              <IconAngleDown size={16} />
+            </TokenShowMoreIndicator>
+          )}
         </Row>
-        {showTokensIndicator && !expanded && <TokenAccountIndicator />}
       </Wrapper>
     )
   }

--- a/src/components/AssetDistribution/Row.js
+++ b/src/components/AssetDistribution/Row.js
@@ -126,7 +126,7 @@ class Row extends PureComponent<Props, State> {
                 currency={currency}
                 value={amount}
                 disableRounding
-                color="graphite"
+                color="dark"
                 fontSize={3}
                 showCode
                 alwaysShowSign={false}

--- a/src/components/ParentCryptoCurrencyIcon.js
+++ b/src/components/ParentCryptoCurrencyIcon.js
@@ -2,12 +2,17 @@
 import React, { PureComponent } from 'react'
 import styled from 'styled-components'
 import get from 'lodash/get'
-import type { Currency } from '@ledgerhq/live-common/lib/types'
+import type { Currency, Account } from '@ledgerhq/live-common/lib/types'
+import Tooltip from 'components/base/Tooltip'
+import Text from 'components/base/Text'
+import { Trans } from 'react-i18next'
+import { colors } from 'styles/theme'
 import CryptoCurrencyIcon from './CryptoCurrencyIcon'
+import { rgba } from '../styles/helpers'
 
 type Props = {
   currency: Currency,
-  parentCurrency?: Currency,
+  parent?: Account,
   borderColor?: string,
 }
 
@@ -18,18 +23,42 @@ const ParentCryptoCurrencyIconWrapper = styled.div`
     border: 2px solid ${p => get(p.theme.colors, p.borderColor || 'white')};
   }
 `
+const TooltipWrapper = styled.div`
+  display: flex;
+  max-width: 150px;
+  flex-direction: column;
+`
+
+const CryptoCurrencyIconTooltip = ({ name }: { name: string }) => (
+  <TooltipWrapper>
+    <Text color={rgba(colors.white, 0.5)}>
+      <Trans i18nKey={'tokensList.tooltip'} />
+    </Text>
+    <Text>{name}</Text>
+  </TooltipWrapper>
+)
 
 class ParentCryptoCurrencyIcon extends PureComponent<Props> {
   render() {
-    const { currency, parentCurrency, borderColor } = this.props
-    const double = !!parentCurrency
+    const { currency, parent, borderColor } = this.props
+    const double = parent && parent.currency
 
-    return (
+    const content = (
       <ParentCryptoCurrencyIconWrapper borderColor={borderColor}>
-        {parentCurrency && <CryptoCurrencyIcon currency={parentCurrency} size={double ? 16 : 20} />}
+        {double && parent && (
+          <CryptoCurrencyIcon currency={parent.currency} size={double ? 16 : 20} />
+        )}
         <CryptoCurrencyIcon currency={currency} size={double ? 16 : 20} />
       </ParentCryptoCurrencyIconWrapper>
     )
+
+    if (double && parent) {
+      return (
+        <Tooltip render={() => <CryptoCurrencyIconTooltip name={parent.name} />}>{content}</Tooltip>
+      )
+    }
+
+    return content
   }
 }
 

--- a/src/components/TopBar/Breadcrumb/AccountCrumb.js
+++ b/src/components/TopBar/Breadcrumb/AccountCrumb.js
@@ -11,6 +11,7 @@ import { connect } from 'react-redux'
 import type { TokenAccount, Account } from '@ledgerhq/live-common/lib/types'
 import { push } from 'react-router-redux'
 
+import Text from 'components/base/Text'
 import { accountsSelector } from '../../../reducers/accounts'
 import CryptoCurrencyIcon from '../../CryptoCurrencyIcon'
 import DropDown from '../../base/DropDown'
@@ -32,8 +33,6 @@ type Props = {
 }
 
 const Item = styled.div`
-  font-family: 'Open Sans';
-  font-size: 13px;
   align-items: center;
   display: flex;
   flex-direction: row;
@@ -42,6 +41,10 @@ const Item = styled.div`
   color: ${p => (p.isActive ? p.theme.colors.dark : p.theme.colors.smoke)};
   > :first-child {
     margin-right: 10px;
+  }
+
+  > ${Text} {
+    flex: 1;
   }
 
   &:hover {
@@ -89,7 +92,8 @@ const AngleDown = styled.div`
 
 const Check = styled.div`
   color: ${p => p.theme.colors.wallet};
-  flex: 1;
+  align-items: center;
+  display: flex;
   text-align: right;
   margin-left: 20px;
 `
@@ -112,7 +116,9 @@ class AccountCrumb extends PureComponent<Props> {
           size={16}
           currency={parentId ? item.account.token : item.account.currency}
         />
-        {parentId ? item.account.token.name : item.account.name}
+        <Text ff={`Open Sans|${isActive ? 'SemiBold' : 'Regular'}`} fontSize={4}>
+          {parentId ? item.account.token.name : item.account.name}
+        </Text>
         {isActive && (
           <Check>
             <IconCheck size={14} />

--- a/src/components/base/DropDown/index.js
+++ b/src/components/base/DropDown/index.js
@@ -33,7 +33,7 @@ export const DropDownItem = styled(Box).attrs({
   ff: p => (p.isActive ? 'Open Sans|SemiBold' : 'Open Sans'),
   fontSize: 4,
   px: 3,
-  color: p => (p.isHighlighted || p.isActive ? 'dark' : 'warnGrey'),
+  color: p => (p.isHighlighted || p.isActive ? 'dark' : 'smoke'),
   bg: p => (p.isActive ? 'lightGrey' : ''),
 })`
   height: 40px;

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -224,7 +224,8 @@
     "placeholder": "To add tokens, simply send them to your Ethereum address.",
     "link": "Learn more",
     "seeTokens": "See tokens ({{tokenCount}})",
-    "hideTokens": "Hide tokens ({{tokenCount}})"
+    "hideTokens": "Hide tokens ({{tokenCount}})",
+    "tooltip": "Token from"
   },
   "addAccounts": {
     "title": "Add accounts",

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -222,7 +222,9 @@
     "title": "Tokens",
     "cta": "Receive token",
     "placeholder": "To add tokens, simply send them to your Ethereum address.",
-    "link": "Learn more"
+    "link": "Learn more",
+    "seeTokens": "See tokens ({{tokenCount}})",
+    "hideTokens": "Hide tokens ({{tokenCount}})"
   },
   "addAccounts": {
     "title": "Add accounts",


### PR DESCRIPTION
### Things done

- [x] Made the breadcrumbs follow design
- [x] Fixed styles for the range selector
- [x] Modified the expand/collapse behaviour of token rows for a full row cta
- [x] Asset distribution amount color change

- [x] Add tooltip for Grid Mode  Token Account cards to show the parent account name


![image](https://user-images.githubusercontent.com/4631227/60273847-4c8a8000-98f7-11e9-84b3-b38ceefc9fa7.png)
![image](https://user-images.githubusercontent.com/4631227/60273855-4eecda00-98f7-11e9-8a2f-ba112ac39a68.png)
![image](https://user-images.githubusercontent.com/4631227/60273861-514f3400-98f7-11e9-93c2-8ef41caee68b.png)

### Type

UI Polish
