### PR TITLE
Fixes ellipsis on account selector

### DIFF
--- a/src/components/SelectAccount/index.js
+++ b/src/components/SelectAccount/index.js
@@ -8,7 +8,6 @@ import {
 import Box from 'components/base/Box'
 import FormattedVal from 'components/base/FormattedVal'
 import Select from 'components/base/Select'
-import Text from 'components/base/Text'
 import CryptoCurrencyIcon from 'components/CryptoCurrencyIcon'
 import React, { useCallback } from 'react'
 import { translate } from 'react-i18next'
@@ -18,6 +17,7 @@ import { accountsSelector } from 'reducers/accounts'
 import { createStructuredSelector } from 'reselect'
 import type { Account, TokenAccount } from '@ledgerhq/live-common/lib/types'
 import type { T } from 'types/common'
+import Ellipsis from '../base/Ellipsis'
 
 const mapStateToProps = createStructuredSelector({
   accounts: accountsSelector,
@@ -72,19 +72,13 @@ const AccountOption = React.memo(
     const unit = getAccountUnit(account)
     const name = account.type === 'Account' ? account.name : currency.name
 
-    // FIXME: we need a non-hacky way to handle text ellipsis
-    const nameOuterStyle = { width: 0 }
-    const nameInnerStyle = { overflow: 'hidden', textOverflow: 'ellipsis' }
-
     return (
       <Box grow horizontal alignItems="center" flow={2}>
         {!isValue && account.type === 'TokenAccount' ? tokenTick : null}
         <CryptoCurrencyIcon currency={currency} size={16} />
-        <Box grow style={nameOuterStyle} ff="Open Sans|SemiBold" color="dark" fontSize={4}>
-          <Text style={nameInnerStyle} ff="Open Sans|SemiBold" color="dark" fontSize={4}>
-            {name}
-          </Text>
-        </Box>
+        <Ellipsis ff="Open Sans|SemiBold" color="dark" fontSize={4}>
+          {name}
+        </Ellipsis>
         <Box>
           <FormattedVal color="grey" val={account.balance} unit={unit} showCode disableRounding />
         </Box>


### PR DESCRIPTION

<img width="518" alt="image" src="https://user-images.githubusercontent.com/4631227/60159087-b40ad780-97f2-11e9-8f23-efa0fd2a428e.png">

Since the current custom implementation of the `MenuList` for performance, uses `FixedSizeList` we can't got to two lines on selector rows (it reuses them). There is a `DynamicSizeList` that I later found out about so perhaps that's a good future task. For now, this fixes the ellipsis which wasn't working on the account selector.


### Type

UI Polish

### Context

There was a `//  FIXME` from @meriadec  so I fixed it.

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
