### PR TITLE
LL-1594 Hide clock icon on failed transactions

### DIFF
--- a/src/components/OperationsList/ConfirmationCheck.js
+++ b/src/components/OperationsList/ConfirmationCheck.js
@@ -82,7 +82,7 @@ class ConfirmationCheck extends PureComponent<{
         {...props}
       >
         {type === 'IN' ? <IconReceive size={12} /> : <IconSend size={12} />}
-        {!isConfirmed && (
+        {!isConfirmed && !hasFailed && (
           <WrapperClock>
             <IconClock size={10} />
           </WrapperClock>


### PR DESCRIPTION
To make sure we are on the same page here @gre this will not show the confirmation clock on a failed transaction regardless of the confirmation status. So, if the circle is red, there's no clock.

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1594

### Parts of the app affected / Test plan

Operation list, failed transactions should show no confirmation status indicator
