### PR TITLE
Fixes gas limit issues

### DIFF
--- a/src/families/AdvancedOptionsField/EthereumKind.js
+++ b/src/families/AdvancedOptionsField/EthereumKind.js
@@ -7,7 +7,6 @@ import { getAccountBridge } from 'bridge'
 import Box from 'components/base/Box'
 import Input from 'components/base/Input'
 import Label from 'components/base/Label'
-import Spoiler from 'components/base/Spoiler'
 
 type Props = {
   onChange: (*) => void,
@@ -17,18 +16,13 @@ type Props = {
 }
 
 class AdvancedOptions extends PureComponent<Props, *> {
-  state = {
-    loading: false,
-  }
+  state = { isValid: false }
 
   componentDidMount() {
     this.resync()
   }
 
   componentDidUpdate(nextProps: Props) {
-    if (nextProps.account.id !== this.props.account.id) {
-      this.lastRecipient = '' // changing account need resync of gas limit for token accounts
-    }
     if (nextProps.transaction !== this.props.transaction) {
       this.resync()
     }
@@ -39,33 +33,23 @@ class AdvancedOptions extends PureComponent<Props, *> {
     this.isUnmounted = true
   }
 
-  lastRecipient = ''
   isUnmounted = false
   syncId = 0
   async resync() {
+    const syncId = ++this.syncId
     const { account, transaction } = this.props
     const bridge = getAccountBridge(account)
-    const syncId = ++this.syncId
     const recipient = bridge.getTransactionRecipient(account, transaction)
-    if (recipient === this.lastRecipient) return
-    this.lastRecipient = recipient
     const isValid = await bridge
       .checkValidRecipient(account, recipient)
       .then(() => true, () => false)
     if (syncId !== this.syncId) return
     if (this.isUnmounted) return
+    this.setState(s => (s.isValid !== isValid ? { isValid } : null))
     if (isValid) {
-      try {
-        this.setState({ loading: true })
-        const t = await bridge.prepareTransaction(account, transaction)
-        if (syncId !== this.syncId) return
-        if (t !== transaction) this.props.onChange(t)
-      } finally {
-        if (!this.isUnmounted) this.setState({ loading: false })
-      }
+      const t = await bridge.prepareTransaction(account, transaction)
       if (syncId !== this.syncId) return
-      if (this.isUnmounted) return
-      this.lastRecipient = recipient
+      if (t !== transaction) this.props.onChange(t)
     }
   }
 
@@ -81,22 +65,24 @@ class AdvancedOptions extends PureComponent<Props, *> {
 
   render() {
     const { account, transaction, t } = this.props
-    const { loading } = this.state
+    const { isValid } = this.state
     const bridge = getAccountBridge(account)
     const gasLimit = bridge.getTransactionExtra(account, transaction, 'gasLimit')
     return (
-      <Spoiler title={t('send.steps.amount.advancedOptions')}>
-        <Box horizontal align="center" flow={5}>
-          <Box style={{ width: 200 }}>
-            <Label>
-              <span>{t('send.steps.amount.ethereumGasLimit')}</span>
-            </Label>
-          </Box>
-          <Box grow>
-            <Input value={gasLimit.toString()} onChange={this.onChange} loading={loading} />
-          </Box>
+      <Box horizontal align="center" flow={5}>
+        <Box style={{ width: 200 }}>
+          <Label>
+            <span>{t('send.steps.amount.ethereumGasLimit')}</span>
+          </Label>
         </Box>
-      </Spoiler>
+        <Box grow>
+          <Input
+            value={gasLimit ? gasLimit.toString() : ''}
+            onChange={this.onChange}
+            loading={isValid && !gasLimit}
+          />
+        </Box>
+      </Box>
     )
   }
 }


### PR DESCRIPTION
- gas limit field is clearly visible so you can see when it's loading
- Continue is blocked until gas limit is loaded
- you can still edit the field manually
- if calc fails (e.g. no network) it fallbacks to 21000
- ~~a gas limit of 0 is invalid and blocks Continue~~ => WILL BE FIXED LATER

We will need to backport this in live-common for mobile implementation.

![gl](https://user-images.githubusercontent.com/211411/60264148-c9f7c580-98e2-11e9-9f36-cd98fe26404c.gif)


### Type

bug fix

### Context

LL-1599

### Technical notes

gasLimit becomes an optional field. that helps tracking if it was settled or not. either network settles by calculation or the user does it. it get set back to undefined if it needs recalculation. a cache has also been introduced for performance (now it's a backend perf problematic).
