### PR TITLE
order crypto by market cap in add account select

### DIFF
--- a/src/components/ManagerPage/index.js
+++ b/src/components/ManagerPage/index.js
@@ -2,11 +2,12 @@
 
 import React, { PureComponent, Fragment } from 'react'
 import invariant from 'invariant'
+import type { DeviceInfo } from '@ledgerhq/live-common/lib/types/manager'
+import { getFullListSortedCryptoCurrencies } from 'helpers/countervalues'
+import { getEnv } from '@ledgerhq/live-common/lib/env'
 import { openURL } from 'helpers/linking'
 import { urls } from 'config/urls'
 import type { Device } from 'types/common'
-import type { DeviceInfo } from '@ledgerhq/live-common/lib/types/manager'
-import { getFullListSortedCryptoCurrencies } from 'helpers/countervalues'
 
 import Dashboard from './Dashboard'
 import ManagerGenuineCheck from './ManagerGenuineCheck'
@@ -30,7 +31,7 @@ class ManagerPage extends PureComponent<Props, State> {
   state = INITIAL_STATE
 
   componentDidMount() {
-    getFullListSortedCryptoCurrencies() // start fetching the crypto currencies ordering
+    getFullListSortedCryptoCurrencies(getEnv('MANAGER_DEV_MODE')) // start fetching the crypto currencies ordering
   }
 
   // prettier-ignore

--- a/src/helpers/countervalues.js
+++ b/src/helpers/countervalues.js
@@ -1,19 +1,20 @@
 // @flow
 
 import { createSelector } from 'reselect'
-import { LEDGER_COUNTERVALUES_API } from 'config/constants'
 import createCounterValues from '@ledgerhq/live-common/lib/countervalues'
+import type { CryptoCurrency } from '@ledgerhq/live-common/lib/types'
+import { makeLRUCache } from '@ledgerhq/live-common/lib/cache'
+import uniq from 'lodash/uniq'
+import { LEDGER_COUNTERVALUES_API } from 'config/constants'
+import { listCryptoCurrencies } from 'config/cryptocurrencies'
 import { setExchangePairsAction } from 'actions/settings'
 import { currenciesSelector } from 'reducers/accounts'
-import uniq from 'lodash/uniq'
 import {
   counterValueCurrencySelector,
   exchangeSettingsForPairSelector,
   intermediaryCurrency,
 } from 'reducers/settings'
 import logger from 'logger'
-import { listCryptoCurrencies } from '@ledgerhq/live-common/lib/currencies'
-import type { CryptoCurrency } from '@ledgerhq/live-common/lib/types'
 import network from '../api/network'
 
 export const pairsSelector = createSelector(
@@ -77,29 +78,37 @@ const CounterValues = createCounterValues({
 })
 
 let sortCache
-export const getFullListSortedCryptoCurrencies: () => Promise<CryptoCurrency[]> = () => {
-  if (!sortCache) {
-    sortCache = CounterValues.fetchTickersByMarketcap().then(
-      tickers => {
-        const list = listCryptoCurrencies().slice(0)
-        const prependList = []
-        tickers.forEach(ticker => {
-          const item = list.find(c => c.ticker === ticker)
-          if (item) {
-            list.splice(list.indexOf(item), 1)
-            prependList.push(item)
-          }
-        })
-        return prependList.concat(list)
-      },
-      () => {
-        sortCache = null // reset the cache for the next time it comes here to "try again"
-        return listCryptoCurrencies() // fallback on default sort
-      },
-    )
-  }
+export const getFullListSortedCryptoCurrencies: (
+  withDevCrypto?: boolean,
+  onlyTerminated?: boolean,
+  onlySupported?: boolean,
+) => Promise<CryptoCurrency[]> = makeLRUCache(
+  (withDevCrypto = false, onlyTerminated = false, onlySupported = false) => {
+    if (!sortCache) {
+      sortCache = CounterValues.fetchTickersByMarketcap().then(
+        tickers => {
+          const list = listCryptoCurrencies(withDevCrypto, onlyTerminated, onlySupported).slice(0)
+          const prependList = []
+          tickers.forEach(ticker => {
+            const item = list.find(c => c.ticker === ticker)
+            if (item) {
+              list.splice(list.indexOf(item), 1)
+              prependList.push(item)
+            }
+          })
+          return prependList.concat(list)
+        },
+        () => {
+          sortCache = null // reset the cache for the next time it comes here to "try again"
+          return listCryptoCurrencies() // fallback on default sort
+        },
+      )
+    }
 
-  return sortCache
-}
+    return sortCache
+  },
+  (withDevCrypto, onlyTerminated, onlySupported) =>
+    `${withDevCrypto ? '1' : '0'}_${onlyTerminated ? '1' : '0'}_${onlySupported ? '1' : '0'}`,
+)
 
 export default CounterValues

--- a/src/hooks/useCryptoCurrencies.js
+++ b/src/hooks/useCryptoCurrencies.js
@@ -1,6 +1,8 @@
 // @flow
 import type { CryptoCurrency } from '@ledgerhq/live-common/lib/types'
+import { useState, useEffect } from 'react'
 
+import { getFullListSortedCryptoCurrencies } from 'helpers/countervalues'
 import { listCryptoCurrencies } from 'config/cryptocurrencies'
 import useEnv from 'hooks/useEnv'
 
@@ -12,7 +14,14 @@ const useCryptocurrencies = ({
   onlySupported?: boolean,
 }): CryptoCurrency[] => {
   const devMode = useEnv('MANAGER_DEV_MODE')
-  const cryptos = listCryptoCurrencies(devMode, onlyTerminated, onlySupported)
+  const [cryptos, setCryptos] = useState(() =>
+    listCryptoCurrencies(devMode, onlyTerminated, onlySupported),
+  )
+
+  useEffect(() => {
+    getFullListSortedCryptoCurrencies(devMode, onlyTerminated, onlySupported).then(setCryptos)
+  }, [onlyTerminated, onlySupported, devMode])
+
   return cryptos
 }
 


### PR DESCRIPTION
Make sure the cryptoassets are ordered by market cap in manager and add account's select

### Type

Bug Fix

### Context

LL-1584

### Parts of the app affected / Test plan

![image](https://user-images.githubusercontent.com/671786/60276602-3af7a700-98fc-11e9-8245-547556e451fd.png)

![image](https://user-images.githubusercontent.com/671786/60276662-5662b200-98fc-11e9-95f7-8f7f62f7ed2b.png)



