### PR TITLE
Enforce cryptographic verification of updates

### DIFF
--- a/src/commands/autoUpdate.js
+++ b/src/commands/autoUpdate.js
@@ -30,7 +30,6 @@ const cmd: Command<Input, Result> = createCommand('main:autoUpdate', () =>
         sendStatus('check-success')
       } catch (err) {
         logger.critical(err)
-        // don't throw if the check fail for now. it's a blank bullet.
         if (UPDATE_CHECK_IGNORE) {
           sendStatus('check-success')
         } else {

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -93,7 +93,7 @@ export const EXPERIMENTAL_MARKET_INDICATOR_SETTINGS = boolFromEnv(
 
 // Auto update
 
-export const UPDATE_CHECK_IGNORE = boolFromEnv('UPDATE_CHECK_IGNORE', true)
+export const UPDATE_CHECK_IGNORE = boolFromEnv('UPDATE_CHECK_IGNORE', false)
 export const UPDATE_CHECK_FEED = stringFromEnv(
   'UPDATE_CHECK_FEED',
   'http://resources.live.ledger.app/public_resources/signatures',


### PR DESCRIPTION
Up until now updates where cryptographically verified, but purposefully didn't prevent installation in case of failure, and only raised an error to Sentry, for testing.
This change blocks installation if the downloaded file doesn't successfully pass the crypto check.

### Type

Security enhancement

### Context

#1862
#2030

### Parts of the app affected

Auto-update

### Test plan

- Decrement app version number
- Build with `yarn dist`
- Using `UPDATE_CHECK_FEED` constant, point to an invalid signature file or an invalid url, it should block the update and display an error on
  - [x] Linux
  - [x] Mac
  - [x] Windows
