### PR TITLE
LL-1560 Stop overriding font styling for inputs

### DIFF
--- a/src/components/base/Input/index.js
+++ b/src/components/base/Input/index.js
@@ -64,6 +64,7 @@ const Base = styled.input.attrs({
   fontSize: 4,
 })`
   font-family: 'Open Sans';
+  font-weight: 600;
   ${fontFamily};
   ${fontSize};
   border: 0;

--- a/src/components/base/Input/index.js
+++ b/src/components/base/Input/index.js
@@ -61,7 +61,6 @@ const WarningDisplay = styled(ErrorDisplay)`
 `
 
 const Base = styled.input.attrs({
-  ff: p => (p.ff || p.small ? 'Open Sans' : 'Open Sans|SemiBold'),
   fontSize: 4,
 })`
   ${fontFamily};

--- a/src/components/base/Input/index.js
+++ b/src/components/base/Input/index.js
@@ -63,6 +63,7 @@ const WarningDisplay = styled(ErrorDisplay)`
 const Base = styled.input.attrs({
   fontSize: 4,
 })`
+  font-family: 'Open Sans';
   ${fontFamily};
   ${fontSize};
   border: 0;

--- a/src/families/AdvancedOptionsField/EthereumKind.js
+++ b/src/families/AdvancedOptionsField/EthereumKind.js
@@ -77,6 +77,7 @@ class AdvancedOptions extends PureComponent<Props, *> {
         </Box>
         <Box grow>
           <Input
+            ff="Rubik"
             value={gasLimit ? gasLimit.toString() : ''}
             onChange={this.onChange}
             loading={isValid && !gasLimit}

--- a/src/families/AdvancedOptionsField/RippleKind.js
+++ b/src/families/AdvancedOptionsField/RippleKind.js
@@ -43,7 +43,7 @@ class RippleKind extends Component<Props> {
           <Label>
             <span>{t('send.steps.amount.rippleTag')}</span>
           </Label>
-          <Input value={String(tag || '')} onChange={this.onChange} />
+          <Input ff="Rubik" value={String(tag || '')} onChange={this.onChange} />
         </Box>
       </Box>
     )


### PR DESCRIPTION
There was an global override for inputs receiving the `ff` attribute, meaning all the amount inputs that were supposed to get the Rubik's font were getting Open Sans. This was frustrating design.

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1560

### Parts of the app affected / Test plan

Inputs, numeral inputs should have Rubiks.
