### PR TITLE
LL-1602 Add safety padding to distribution row

### DIFF
--- a/src/components/AssetDistribution/Row.js
+++ b/src/components/AssetDistribution/Row.js
@@ -70,6 +70,8 @@ const Amount = styled.div`
 `
 const Value = styled.div`
   width: 15%;
+  box-sizing: border-box;
+  padding-left: 8px;
   text-align: right;
 `
 


### PR DESCRIPTION
This adds the safety padding discussed in the sprint planning as a solution, we still have an ugly misaligned that is in fact caused by Rubik not being monospace **and** being aligned to the left. If we were using a monospace font it would align beautifully. 

![image](https://user-images.githubusercontent.com/4631227/60466404-d8800d00-9c53-11e9-8292-1efc35e570c8.png)


### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1602

### Parts of the app affected / Test plan

Asset distribution block with ETH as countervalue to force overflow on a small width window.
