### PR TITLE
LL-1554 Limit the Send/Receive redirect to /manager

### DIFF
--- a/src/components/MainSideBar/index.js
+++ b/src/components/MainSideBar/index.js
@@ -121,17 +121,20 @@ class MainSideBar extends PureComponent<Props> {
 
   handleClickDashboard = () => this.push('/')
   handleOpenSendModal = () => {
-    this.push('/')
+    this.maybeRedirectToAccounts()
     this.props.openModal(MODAL_SEND)
   }
   handleOpenReceiveModal = () => {
-    this.push('/')
+    this.maybeRedirectToAccounts()
     this.props.openModal(MODAL_RECEIVE)
   }
   handleClickManager = () => this.push('/manager')
   handleClickAccounts = () => this.push('/accounts')
   handleClickExchange = () => this.push('/partners')
   handleClickDev = () => this.push('/dev')
+  maybeRedirectToAccounts = () => {
+    this.props.location.pathname === '/manager' && this.push('/accounts')
+  }
 
   render() {
     const { t, noAccounts, location, developerMode } = this.props


### PR DESCRIPTION

![maybe redirect](https://user-images.githubusercontent.com/4631227/60468140-fbf98680-9c58-11e9-949b-cd11d8c51c52.gif)
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Feature
### Context
https://ledgerhq.atlassian.net/browse/LL-1554
<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan
Redirects upon opening the modal for send/receive should now only happen when the current screen is the Manager and instead of redirecting to the portfolio, it now redirects to Accounts.
<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
