### PR TITLE
Enabling privacy mode where no account balances are shown.

### DIFF
--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -55,3 +55,6 @@ export const dismissBanner = (bannerKey: string) => ({
   type: 'SETTINGS_DISMISS_BANNER',
   payload: bannerKey,
 })
+
+export const toggleDiscreetMode = (discreetMode: ?boolean) =>
+  saveSettings({ discreetMode: !discreetMode })

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -16,6 +16,7 @@ import Default from 'components/layout/Default'
 import CounterValues from 'helpers/countervalues'
 import { BridgeSyncProvider } from 'bridge/BridgeSyncContext'
 import { UpdaterProvider } from 'components/Updater/UpdaterContext'
+import DiscreetModeWrapper from 'components/Discreet/DiscreetModeWrapper'
 import ContextMenuWrapper from './ContextMenu/ContextMenuWrapper'
 
 const App = ({
@@ -32,17 +33,19 @@ const App = ({
       <CounterValues.PollingProvider>
         <I18nextProvider i18n={i18n} initialLanguage={language}>
           <ThemeProvider theme={theme}>
-            <ThrowBlock>
-              <UpdaterProvider>
-                <ConnectedRouter history={history}>
-                  <Switch>
-                    <ContextMenuWrapper>
-                      <Route component={Default} />
-                    </ContextMenuWrapper>
-                  </Switch>
-                </ConnectedRouter>
-              </UpdaterProvider>
-            </ThrowBlock>
+            <DiscreetModeWrapper>
+              <ThrowBlock>
+                <UpdaterProvider>
+                  <ConnectedRouter history={history}>
+                    <Switch>
+                      <ContextMenuWrapper>
+                        <Route component={Default} />
+                      </ContextMenuWrapper>
+                    </Switch>
+                  </ConnectedRouter>
+                </UpdaterProvider>
+              </ThrowBlock>
+            </DiscreetModeWrapper>
           </ThemeProvider>
         </I18nextProvider>
       </CounterValues.PollingProvider>

--- a/src/components/Discreet/DiscreetModeWrapper.js
+++ b/src/components/Discreet/DiscreetModeWrapper.js
@@ -1,0 +1,35 @@
+// @flow
+import React, { PureComponent } from 'react'
+import { connect } from 'react-redux'
+import { discreetModeSelector } from 'reducers/settings'
+import { toggleDiscreetMode } from 'actions/settings'
+
+export const DiscreetModeContext: Object = React.createContext({})
+
+type Props = {
+  children?: React$Node,
+  discreetMode: boolean,
+  toggleDiscreetMode: Function,
+}
+
+const mapStateToProps = state => ({
+  discreetMode: discreetModeSelector(state),
+})
+
+const mapDispatchToProps = { toggleDiscreetMode }
+
+class DiscreetModeWrapper extends PureComponent<Props> {
+  render() {
+    const { discreetMode, toggleDiscreetMode, children } = this.props
+    return (
+      <DiscreetModeContext.Provider value={{ discreetMode, toggleDiscreetMode }}>
+        {children}
+      </DiscreetModeContext.Provider>
+    )
+  }
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(DiscreetModeWrapper)

--- a/src/components/Discreet/ToggleDiscreetModeButton.js
+++ b/src/components/Discreet/ToggleDiscreetModeButton.js
@@ -1,0 +1,27 @@
+import React, { PureComponent } from 'react'
+import styled from 'styled-components'
+import IconEye from 'icons/Eye'
+import IconEyeOff from 'icons/EyeOff'
+import { DiscreetModeContext } from './DiscreetModeWrapper'
+
+const ToggleDiscreetButton = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+class ToggleDiscreetModeButton extends PureComponent {
+  render() {
+    return (
+      <DiscreetModeContext.Consumer>
+        {({ toggleDiscreetMode, discreetMode }) => (
+          <ToggleDiscreetButton onClick={() => toggleDiscreetMode(discreetMode)}>
+            {discreetMode ? <IconEyeOff size={18} /> : <IconEye size={18} />}
+          </ToggleDiscreetButton>
+        )}
+      </DiscreetModeContext.Consumer>
+    )
+  }
+}
+
+export default ToggleDiscreetModeButton

--- a/src/components/TopBar/index.js
+++ b/src/components/TopBar/index.js
@@ -20,6 +20,7 @@ import IconSettings from 'icons/Settings'
 
 import Box from 'components/base/Box'
 import Tooltip from 'components/base/Tooltip'
+import ToggleDiscreetModeButton from 'components/Discreet/ToggleDiscreetModeButton'
 import CurrenciesStatusBanner from 'components/CurrenciesStatusBanner'
 
 import ActivityIndicator from './ActivityIndicator'
@@ -111,6 +112,14 @@ class TopBar extends PureComponent<Props> {
                   </Box>
                 </Fragment>
               )}
+              <Tooltip render={() => t('dashboard.toggleDiscreetMode')}>
+                <ItemContainer isInteractive>
+                  <ToggleDiscreetModeButton />
+                </ItemContainer>
+              </Tooltip>
+              <Box justifyContent="center">
+                <Bar />
+              </Box>
               <Tooltip render={() => t('settings.title')} data-e2e="setting_button">
                 <ItemContainer isInteractive onClick={this.navigateToSettings}>
                   <IconSettings size={16} />

--- a/src/components/base/Select/index.js
+++ b/src/components/base/Select/index.js
@@ -6,6 +6,7 @@ import AsyncReactSelect from 'react-select/lib/Async'
 import { translate } from 'react-i18next'
 import { FixedSizeList as List } from 'react-window'
 import styled from 'styled-components'
+import debounce from 'lodash/debounce'
 
 import createStyles from './createStyles'
 import createRenderers from './createRenderers'
@@ -91,13 +92,25 @@ class Select extends PureComponent<Props> {
       // $FlowFixMe
       this.timeout = requestAnimationFrame(() => this.ref.focus())
     }
+
+    window.addEventListener('resize', this.resizeHandler)
   }
 
   componentWillUnmount() {
     if (this.timeout) {
       cancelAnimationFrame(this.timeout)
     }
+
+    window.removeEventListener('resize', this.resizeHandler)
   }
+
+  resizeHandler = debounce(
+    () => {
+      this.ref && this.ref.blur()
+    },
+    200,
+    { leading: true },
+  )
 
   handleChange = (value, { action }) => {
     const { onChange } = this.props

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -59,6 +59,7 @@ export type SettingsState = {
   dismissedBanners: string[],
   accountsViewMode: 'card' | 'list',
   showAccountsHelperBanner: boolean,
+  discreetMode: boolean,
 }
 
 const defaultsForCurrency: Currency => CurrencySettings = crypto => {
@@ -89,6 +90,7 @@ const INITIAL_STATE: SettingsState = {
   dismissedBanners: [],
   accountsViewMode: 'card',
   showAccountsHelperBanner: true,
+  discreetMode: false,
 }
 
 const pairHash = (from, to) => `${from.ticker}_${to.ticker}`
@@ -235,6 +237,8 @@ export const accountsViewModeSelector = (state: State) => state.settings.account
 export const marketIndicatorSelector = (state: State) => state.settings.marketIndicator
 export const sentryLogsSelector = (state: State) => state.settings.sentryLogs
 export const autoLockTimeoutSelector = (state: State) => state.settings.autoLockTimeout
+export const discreetModeSelector = (state: State): boolean => state.settings.discreetMode
+
 export const shareAnalyticsSelector = (state: State) => state.settings.shareAnalytics
 export const selectedTimeRangeSelector = (state: State) => state.settings.selectedTimeRange
 export const hasCompletedOnboardingSelector = (state: State) =>

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -162,7 +162,8 @@
     "summary": "Here's the summary of your account",
     "summary_plural": "Here's the summary of your {{count}} accounts",
     "recentActivity": "Last operations",
-    "totalBalance": "Total balance"
+    "totalBalance": "Total balance",
+    "toggleDiscreetMode": "Toggle discreet mode"
   },
   "currentAddress": {
     "title": "Current address",


### PR DESCRIPTION
Enable/Disable a discreet mode where account balances are hidden/shown

![discreetmode1](https://user-images.githubusercontent.com/29690241/60540460-82709f80-9d0f-11e9-990a-ea49f3e58082.gif)



### Type

Feature

### Parts of the app affected / Test plan

Using context a component can access and toggle the discreet mode.

Send and receive modals are also affected by Discreet Mode:

![discreetmode3](https://user-images.githubusercontent.com/29690241/60547688-a5f01600-9d20-11e9-9a16-e966d708eff6.gif)

At this moment graph is unaffected by Discreet Mode:

![discreetmode2](https://user-images.githubusercontent.com/29690241/60547572-50b40480-9d20-11e9-9fa0-b3eeceed731f.gif)


Blurring might be a good alternative to using "*"



