### PR TITLE
add contract address for token on account page

### DIFF
--- a/src/components/AccountPage/AccountHeader.js
+++ b/src/components/AccountPage/AccountHeader.js
@@ -1,14 +1,26 @@
 // @flow
 
-import React, { PureComponent } from 'react'
+import React, { useCallback } from 'react'
 import styled from 'styled-components'
+import { Trans } from 'react-i18next'
 
 import type { TokenAccount, Account } from '@ledgerhq/live-common/lib/types'
+import {
+  getDefaultExplorerView,
+  getAccountContractExplorer,
+} from '@ledgerhq/live-common/lib/explorers'
+import {
+  getAccountCurrency,
+  getMainAccount,
+  shortAddressPreview,
+} from '@ledgerhq/live-common/lib/account/helpers'
 
 import Box from 'components/base/Box'
 import Ellipsis from 'components/base/Ellipsis'
 import Text from 'components/base/Text'
-import { getAccountCurrency } from '@ledgerhq/live-common/lib/account/helpers'
+import ExternalLink from 'icons/ExternalLink'
+import { openURL } from 'helpers/linking'
+import { colors } from 'styles/theme'
 import ParentCryptoCurrencyIcon from '../ParentCryptoCurrencyIcon'
 
 const CurName = styled(Text).attrs({
@@ -17,6 +29,42 @@ const CurName = styled(Text).attrs({
 })`
   text-transform: uppercase;
   letter-spacing: 1px;
+`
+
+const CurNameToken = styled(Text).attrs({
+  ff: 'Museo Sans|Bold',
+  fontSize: 2,
+})``
+
+const CurNameTokenLink = styled(CurNameToken)`
+  margin-left: 5px;
+  padding: 2px 4px;
+  border-radius: ${p => p.theme.radii[1]}px;
+`
+
+const CurNameTokenIcon = styled(Text).attrs({
+  ff: 'Open Sans|SemiBold',
+  fontSize: 2,
+})`
+  color: ${colors.wallet};
+  display: none;
+  margin-left: 5px;
+  align-items: center;
+`
+
+const Wrapper = styled(Box)`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+
+  :hover ${CurNameTokenIcon} {
+    display: flex;
+  }
+
+  :hover ${CurNameTokenLink} {
+    color: ${colors.wallet};
+    background-color: ${colors.pillActiveBackground};
+  }
 `
 
 const AccountName = styled(Text).attrs({
@@ -29,26 +77,59 @@ const AccountName = styled(Text).attrs({
 
 type Props = {
   account: TokenAccount | Account,
+  parentAccount: ?Account,
 }
 
-class AccountHeader extends PureComponent<Props> {
-  render() {
-    const { account } = this.props
+const AccountHeader: React$ComponentType<Props> = React.memo(
+  ({ account, parentAccount }: Props) => {
     const currency = getAccountCurrency(account)
+    const mainAccount = getMainAccount(account, parentAccount)
+    const explorerView = getDefaultExplorerView(mainAccount.currency)
+
+    const getContract = () =>
+      account.type === 'TokenAccount' && parentAccount
+        ? getAccountContractExplorer(explorerView, account, parentAccount)
+        : null
+
+    const contract = getContract()
+
+    const openLink = useCallback(() => {
+      if (contract) {
+        openURL(contract)
+      }
+    }, [contract])
+
     return (
       <Box horizontal align="center" flow={2} grow>
         <Box>
           <ParentCryptoCurrencyIcon currency={currency} borderColor="lightGrey" />
         </Box>
         <Box grow>
-          <CurName>{account.type === 'Account' ? currency.name : 'token'}</CurName>
+          {contract && account.type === 'TokenAccount' ? (
+            <Box horizontal alignItems="center">
+              <CurNameToken>
+                <Trans i18nKey="account.contractAddress" />
+              </CurNameToken>
+              <Wrapper horizontal alignItems="center" onClick={openLink}>
+                <CurNameTokenLink>
+                  {shortAddressPreview(account.token.contractAddress)}
+                </CurNameTokenLink>
+                <CurNameTokenIcon>
+                  <ExternalLink size={12} style={{ marginRight: 5 }} />
+                  <Trans i18nKey="account.openInExplorer" />
+                </CurNameTokenIcon>
+              </Wrapper>
+            </Box>
+          ) : (
+            <CurName>{currency.name}</CurName>
+          )}
           <AccountName>
             <Ellipsis>{account.type === 'Account' ? account.name : currency.name}</Ellipsis>
           </AccountName>
         </Box>
       </Box>
     )
-  }
-}
+  },
+)
 
 export default AccountHeader

--- a/src/components/AccountPage/index.js
+++ b/src/components/AccountPage/index.js
@@ -105,7 +105,7 @@ class AccountPage extends PureComponent<Props> {
         <SyncOneAccountOnMount priority={10} accountId={mainAccount.id} />
 
         <Box horizontal mb={5} flow={4}>
-          <AccountHeader account={account} />
+          <AccountHeader account={account} parentAccount={parentAccount} />
           <AccountHeaderActions account={account} parentAccount={parentAccount} />
         </Box>
 

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -98,6 +98,8 @@
   },
   "account": {
     "lastOperations": "Last operations",
+    "contractAddress": "Contract:",
+    "openInExplorer": "Open in explorer",
     "emptyState": {
       "title": "No crypto assets yet?",
       "desc": "Make sure the <1><0>{{managerAppName}}</0></1> app is installed and start receiving",


### PR DESCRIPTION
Show the contract address on account page for token and link to explorer

### Type

Feat

### Context

LL-1578

### Parts of the app affected / Test plan

Account Detail Page

![image](https://user-images.githubusercontent.com/671786/60887248-28fafa00-a254-11e9-8e6d-5a8e097c35d9.png)

![image](https://user-images.githubusercontent.com/671786/60887228-1d0f3800-a254-11e9-8b3a-fdf0e2dd3157.png)
