### PR TITLE
fixes wording on error when not enough space

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -971,7 +971,7 @@
     },
     "ManagerNotEnoughSpace": {
       "title": "Sorry, not enough storage left",
-      "description": "Uninstall some apps to make space. This will not affect your crypto assets."
+      "description": "Uninstall all apps to make space. This will not affect your crypto assets."
     },
     "ManagerUninstallBTCDep": {
       "title": "Sorry, this app is required",


### PR DESCRIPTION
During firmware update, if there is not enough space available on the device, fixes the wording from "uninstall some apps" to "uninstall all apps"

### Type

Improvement

### Context

LL-1647

### Parts of the app affected / Test plan

Firmware update