### PR TITLE
LL-1579 Change the show all/less button in asset distribution to match token rows

### DIFF
--- a/src/components/AssetDistribution/index.js
+++ b/src/components/AssetDistribution/index.js
@@ -7,7 +7,6 @@ import { Trans } from 'react-i18next'
 import { getAssetsDistribution } from '@ledgerhq/live-common/lib/portfolio'
 import type { AssetsDistribution } from '@ledgerhq/live-common/lib/types/portfolio'
 import styled from 'styled-components'
-import Button from 'components/base/Button'
 import Text from 'components/base/Text'
 import IconAngleDown from 'icons/AngleDown'
 import { calculateCountervalueSelector } from 'actions/general'
@@ -25,16 +24,23 @@ type State = {
   showAll: boolean,
 }
 
-const SeeAllButton = styled(Button)`
-  margin: 16px;
-  border-radius: 4px;
-  border: 1px solid ${p => p.theme.colors.fog};
-  cursor: pointer;
-  align-items: center;
+const SeeAllButton = styled.div`
+  margin-top: 15px;
   display: flex;
+  color: ${p => p.theme.colors.wallet};
+  align-items: center;
   justify-content: center;
-  > :first-child {
-    margin-right: 6px;
+  border-top: 1px solid ${p => p.theme.colors.lightFog};
+  height: 40px;
+  cursor: pointer;
+
+  &:hover ${Text} {
+    text-decoration: underline;
+  }
+
+  > :nth-child(2) {
+    margin-left: 8px;
+    transform: rotate(${p => (p.expanded ? '180deg' : '0deg')});
   }
 `
 
@@ -58,6 +64,9 @@ class AssetDistribution extends PureComponent<Props, State> {
   state = {
     showAll: false,
   }
+
+  toggleShowAll = () => this.setState(prevState => ({ showAll: !prevState.showAll }))
+
   render() {
     const { distribution } = this.props
     const {
@@ -84,12 +93,12 @@ class AssetDistribution extends PureComponent<Props, State> {
           {subList.map(item => (
             <Row key={item.currency.id} item={item} />
           ))}
-          {!showAll && subList.length < distribution.list.length && (
-            <SeeAllButton onClick={() => this.setState({ showAll: true })}>
-              <Text ff="Open Sans|SemiBold" color="grey" fontSize={3}>
-                <Trans i18nKey="distribution.seeAll" />
-              </Text>{' '}
-              <IconAngleDown size={12} />
+          {!almostAll && (
+            <SeeAllButton expanded={showAll} onClick={this.toggleShowAll}>
+              <Text color="wallet" ff="Open Sans|SemiBold" fontSize={4}>
+                <Trans i18nKey={showAll ? 'distribution.showLess' : 'distribution.showAll'} />
+              </Text>
+              <IconAngleDown size={16} />
             </SeeAllButton>
           )}
         </Card>

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -445,7 +445,8 @@
     "distribution": "Distribution",
     "amount": "Amount",
     "value": "Value",
-    "seeAll": "See all",
+    "showAll": "Show all",
+    "showLess": "Show less",
     "header": "Asset distribution ({{count}})"
   },
   "settings": {


### PR DESCRIPTION
<img width="1464" alt="Screenshot 2019-07-10 at 12 57 48" src="https://user-images.githubusercontent.com/4631227/60964009-89507100-a312-11e9-9def-3d8b181a72da.png">


<img width="1464" alt="Screenshot 2019-07-10 at 12 58 00" src="https://user-images.githubusercontent.com/4631227/60964008-89507100-a312-11e9-9841-d00d08c73a16.png">


<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1579

### Parts of the app affected / Test plan

Asset distribution block in portfolio.
