### PR TITLE
LL-1656: Fix margin on token account rows

### DIFF
--- a/src/components/AccountsPage/AccountRowItem/index.js
+++ b/src/components/AccountsPage/AccountRowItem/index.js
@@ -39,7 +39,7 @@ const Row = styled(Box)`
   flex: 1;
   font-weight: 600;
   justify-content: flex-start;
-  margin-bottom: ${p => (p.tokens && !p.expanded ? 18 : 9)}px;
+  margin-bottom: 9px;
   padding: 16px 20px;
   position: relative;
   :hover {


### PR DESCRIPTION
Fixes account row margin which was too large

Before | After
---------|---------------
![2019-07-15_143436](https://user-images.githubusercontent.com/1671753/61216470-b7b4be80-a70d-11e9-8395-cc82d70f6f17.png) | ![2019-07-15_143346](https://user-images.githubusercontent.com/1671753/61216471-b7b4be80-a70d-11e9-9657-3b64f4aac0bf.png)

### Type

UI polish

### Context

LL-1656

### Parts of the app affected / Test plan

Accounts list