### PR TITLE
LL-1663: Fix account page balance evolution being hidden when no countervalues are available

### DIFF
--- a/src/components/AccountPage/AccountBalanceSummaryHeader.js
+++ b/src/components/AccountPage/AccountBalanceSummaryHeader.js
@@ -157,7 +157,7 @@ class AccountBalanceSummaryHeader extends PureComponent<Props> {
         </Box>
         <Box key={primaryKey} horizontal justifyContent="center" flow={7}>
           <BalanceSincePercent
-            isAvailable={isAvailable}
+            isAvailable
             t={t}
             alignItems="center"
             totalBalance={data[0].balance}
@@ -165,7 +165,7 @@ class AccountBalanceSummaryHeader extends PureComponent<Props> {
             since={selectedTimeRange}
           />
           <BalanceSinceDiff
-            isAvailable={isAvailable}
+            isAvailable
             t={t}
             unit={data[0].unit}
             alignItems="center"


### PR DESCRIPTION
Before | After
--------|----------
![2019-07-15_170431](https://user-images.githubusercontent.com/1671753/61226575-f3a64e80-a722-11e9-90c5-c3a72a4f9eef.png) | ![2019-07-15_170447](https://user-images.githubusercontent.com/1671753/61226574-f30db800-a722-11e9-99ff-477e0b9dbbf6.png)

### Type

Bug fix

### Context

LL-1663

### Parts of the app affected / Test plan

Account balance