### PR TITLE
Fix not-centered boxes in account page

### DIFF
--- a/src/components/BalanceInfos.js
+++ b/src/components/BalanceInfos.js
@@ -40,7 +40,7 @@ type Props = {
 
 export function BalanceSincePercent(props: BalanceSinceProps) {
   const { t, totalBalance, valueChange, since, isAvailable, ...otherProps } = props
-  if (!valueChange.percentage) return <Box {...otherProps} />
+  if (!valueChange.percentage) return null;
   return (
     <Box {...otherProps}>
       <FormattedVal


### PR DESCRIPTION
The modules shown in the account pages were not centered if the percentage module was hidden.

Before | After
---------|------------
![2019-07-15_170447](https://user-images.githubusercontent.com/1671753/61227984-aa0b3300-a725-11e9-9d3d-bde2dc96e352.png) | ![2019-07-15_172418](https://user-images.githubusercontent.com/1671753/61227983-aa0b3300-a725-11e9-9ca5-0d237fd280c7.png)

### Type

UI polish

### Parts of the app affected / Test plan

Account page