### PR TITLE
LL-1553: Guide users to account creation after installing an app

### DIFF
--- a/src/components/modals/AddAccounts/index.js
+++ b/src/components/modals/AddAccounts/index.js
@@ -195,6 +195,18 @@ class AddAccounts extends PureComponent<Props, State> {
 
   handleSetAppOpened = (isAppOpened: boolean) => this.setState({ isAppOpened })
 
+  handleBeforeOpen = ({ data }) => {
+    const { currency } = this.state
+
+    if (!currency) {
+      if (data && data.currency) {
+        this.setState({
+          currency: data.currency,
+        })
+      }
+    }
+  }
+
   onGoStep1 = () => {
     this.setState(({ reset }) => ({ ...INITIAL_STATE, reset: reset + 1 }))
   }
@@ -243,6 +255,7 @@ class AddAccounts extends PureComponent<Props, State> {
         name={MODAL_ADD_ACCOUNTS}
         refocusWhenChange={stepId}
         onHide={() => this.setState({ ...INITIAL_STATE })}
+        onBeforeOpen={this.handleBeforeOpen}
         render={({ onClose }) => (
           <Stepper
             key={reset} // THIS IS A HACK because stepper is not controllable. FIXME

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -307,11 +307,13 @@
       "installSuccess": "{{app}} was successfully installed",
       "unsupportedSuccess": "Learn how to use {{app}}",
       "uninstallSuccess": "{{app}} uninstalled",
-      "supportedCurrency": "{{app}} is now installed on your {{device}}. Add an account so you can send and receive funds",
+      "supportedCurrency": "{{app}} is now installed on your {{device}}.",
+      "supportedCurrencyNeedAccount": "{{app}} is now installed on your {{device}}. You need to add a {{currency}} account in order to receive and manage assets.",
       "unsupportedCurrency": "{{app}} support is not integrated in Ledger Live. Click the button to learn how to use it.",
       "help": "Check on your device to see which apps are already installed",
       "installed": "App installed",
-      "uninstalled": "App uninstalled"
+      "uninstalled": "App uninstalled",
+      "addAccount": "Add {{name}} account"
     },
     "firmware": {
       "installed": "Firmware version {{version}}",


### PR DESCRIPTION
This PR aims at guiding users after installing an app to the account creation screen if they have no accounts already added to Ledger Live.

### :camera_flash: Screenshots

#### Install without having matching accounts
> Call to action is set a primary focus

![2019-07-18_173915](https://user-images.githubusercontent.com/1671753/61472268-64987100-a984-11e9-86c1-ecbb3217f74f.png)

#### Install with accounts already added
> Call to action is set as secondary focus

![2019-07-18_173533](https://user-images.githubusercontent.com/1671753/61472271-64987100-a984-11e9-9d33-f4b8c8078e8c.png)

#### When clicking "Add _$currency_ account"
> Note that the currency is pre-selected

![2019-07-18_173537](https://user-images.githubusercontent.com/1671753/61472269-64987100-a984-11e9-9a04-74a399b6c9c4.png)


### :ok_hand: Type

Feature / UX

### :mag: Context

LL-1553

### :clipboard: Parts of the app affected / Test plan

Manager, Accounts