### PR TITLE
LL-1533: See related transactions in ETH fee operations

### DIFF
--- a/src/components/OperationsList/DateCell.js
+++ b/src/components/OperationsList/DateCell.js
@@ -11,12 +11,14 @@ const Cell = styled(Box).attrs({
   px: 3,
   horizontal: false,
 })`
-  width: 120px;
+  width: ${p => (p.compact ? 90 : 120)}px;
 `
 
 type Props = {
   t: T,
   operation: Operation,
+  text?: string,
+  compact?: boolean,
 }
 
 class DateCell extends PureComponent<Props> {
@@ -25,11 +27,18 @@ class DateCell extends PureComponent<Props> {
   }
 
   render() {
-    const { t, operation } = this.props
+    const { t, operation, compact, text } = this.props
+    const ellipsis = {
+      display: 'block',
+      textOverflow: 'ellipsis',
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+    }
+
     return (
-      <Cell>
-        <Box ff="Open Sans|SemiBold" fontSize={3} color="smoke">
-          {t(`operation.type.${operation.type}`)}
+      <Cell compact={compact}>
+        <Box ff="Open Sans|SemiBold" fontSize={3} color="smoke" style={ellipsis}>
+          {text || t(`operation.type.${operation.type}`)}
         </Box>
         <OperationDate date={operation.date} />
       </Cell>

--- a/src/components/OperationsList/Operation.js
+++ b/src/components/OperationsList/Operation.js
@@ -41,6 +41,8 @@ type Props = {
   ) => void,
   t: T,
   withAccount: boolean,
+  compact?: boolean,
+  text?: string,
 }
 
 class OperationComponent extends PureComponent<Props> {
@@ -54,7 +56,7 @@ class OperationComponent extends PureComponent<Props> {
   }
 
   render() {
-    const { account, parentAccount, t, operation, withAccount } = this.props
+    const { account, parentAccount, t, operation, withAccount, compact, text } = this.props
     const isOptimistic = operation.blockHeight === null
     return (
       <OperationRow isOptimistic={isOptimistic} onClick={this.onOperationClick}>
@@ -64,7 +66,7 @@ class OperationComponent extends PureComponent<Props> {
           account={account}
           t={t}
         />
-        <DateCell operation={operation} t={t} />
+        <DateCell compact={compact} text={text} operation={operation} t={t} />
         {withAccount &&
           (account.type === 'Account' ? (
             <AccountCell accountName={account.name} currency={account.currency} />

--- a/src/components/base/LabelInfoTooltip/index.js
+++ b/src/components/base/LabelInfoTooltip/index.js
@@ -21,4 +21,4 @@ function LabelInfoTooltip(props: Props) {
   )
 }
 
-export default LabelInfoTooltip
+export default React.memo<Props>(LabelInfoTooltip, (prev, next) => prev.text === next.text)

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -292,7 +292,10 @@
     "identifier": "Transaction ID",
     "viewOperation": "View in explorer",
     "showMore": "Show {{recipients}} more",
-    "showLess": "Show less"
+    "showLess": "Show less",
+    "tokenOperations": "Token transactions",
+    "tokenTooltip": "This operation is related to the following token transactions",
+    "details": "{{ currency }} details"
   },
   "operationList": {
     "noMoreOperations": "That's all"


### PR DESCRIPTION
This PR adds related `subOperations` to the operation detail view. It helps users understand why some transactions they may not have made are there (e.g. in the case of ETH, when sending tokens, an ETH fee will apply which shows up as a separate transaction).

### :camera_flash: Screenshots

#### When looking at a "fee" transaction
![2019-07-19_191111](https://user-images.githubusercontent.com/1671753/61552813-1ef9a800-aa59-11e9-8f0e-7d7186f72559.png)

#### When looking at a regular transaction
![2019-07-19_191122](https://user-images.githubusercontent.com/1671753/61552812-1ef9a800-aa59-11e9-8adb-dd330f09b6a6.png)

### :ok_hand: Type

Feature / UX

### :mag: Context

LL-1533

### :clipboard: Parts of the app affected / Test plan

Operation details