### PR TITLE
LL-1705: Fix unable to de-select accounts regression

### DIFF
--- a/src/components/modals/AddAccounts/steps/03-step-import.js
+++ b/src/components/modals/AddAccounts/steps/03-step-import.js
@@ -85,11 +85,13 @@ const Desc = styled(Box).attrs({
 `
 
 const SectionAccounts = ({ defaultSelected, ...rest }: *) => {
+  // componentDidMount-like effect
   useEffect(() => {
     if (defaultSelected && rest.onSelectAll) {
       rest.onSelectAll(rest.accounts)
     }
-  })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
   return <AccountsList {...rest} />
 }
 


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/LedgerHQ/ledger-live-desktop/commit/897f7493bc939a30cb71c559981e392c24bd0675 that prevents the user to de-select accounts.

### :camera_flash: Screen capture

![addAccount_UnableToUncheckAccounts](https://user-images.githubusercontent.com/1671753/61704684-90c93e80-ad44-11e9-825b-ce8430a7296e.gif)

### :ok_hand: Type

Bug fix

### :mag: Context

LL-1705

### :clipboard: Parts of the app affected / Test plan

Add accounts