### PR TITLE
Update libcore to 3.1.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@ledgerhq/hw-transport-http": "^4.66.0",
     "@ledgerhq/hw-transport-node-hid": "^4.66.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^4.66.0",
-    "@ledgerhq/ledger-core": "^3.0.0",
+    "@ledgerhq/ledger-core": "^3.1.0-beta.1",
     "@ledgerhq/live-common": "7.7.1",
     "@ledgerhq/logs": "^4.64.0",
     "animated": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1813,10 +1813,10 @@
     "@ledgerhq/errors" "^4.66.0"
     events "^3.0.0"
 
-"@ledgerhq/ledger-core@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-3.0.0.tgz#b5a0757f06573addaca9e78099ada6ee91106c9f"
-  integrity sha512-YdHLFkkBQZpwfHIe2mbVWv79PBw/qG5ugJfVMjAxd4E9jeBAoUipwF4lNqm0G+ugNtMkkEzonWOaOJQj0L+GAQ==
+"@ledgerhq/ledger-core@^3.1.0-beta.1":
+  version "3.1.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-3.1.0-beta.1.tgz#e49104907137a406c10560eca369394d59e925b2"
+  integrity sha512-5/S3uCoIO6hZ7CwuAfN71ZtA/Mk+006+4kv/9KMT4v0InngptYsByGyIYwBZmF8Tjai+Z24/DKY+AERfGTO/cw==
   dependencies:
     bindings "^1.3.0"
     nan "^2.6.2"


### PR DESCRIPTION
let's merge this soon so we can later have a live-common version that consume internal transactions.

NB: this PR should be considered to not change anything, there are new feature in libcore that are not used yet. Just test everything still works. especially with ETH / BTC