### PR TITLE
prevent publishing even when detected as CI

### DIFF
--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -25,7 +25,7 @@ fi
 yarn compile
 
 runJob \
-  "DEBUG=electron-builder electron-builder" \
+  "DEBUG=electron-builder electron-builder --publish never" \
   "building and packaging app..." \
   "app built and packaged successfully" \
   "failed to build app" \


### PR DESCRIPTION
Prevents Jenkins build from failing because electron-builder detects Jenkins as CI and will try to fetch draft release on github requiring a GH_TOKEN

### Type

Fix

### Context

LL-1047
Nightly builds

