### PR TITLE
LL-1471 Add accounts tokens 

### DIFF
--- a/src/components/AccountPage/TokensList.js
+++ b/src/components/AccountPage/TokensList.js
@@ -62,7 +62,7 @@ const mapDispatchToProps = {
 
 // Fixme Temporarily hiding the receive token button
 const ReceiveButton = (props: { onClick: () => void }) => (
-  <Button hidden small primary onClick={props.onClick}>
+  <Button small primary onClick={props.onClick}>
     <Box horizontal flow={1} alignItems="center">
       <IconPlus size={12} />
       <Box>

--- a/src/components/EnsureDeviceApp.js
+++ b/src/components/EnsureDeviceApp.js
@@ -37,6 +37,7 @@ class EnsureDeviceApp extends Component<{
   device: ?Device,
   account?: ?Account,
   currency?: ?CryptoCurrency,
+  isToken?: boolean,
 }> {
   connectInteractionHandler = () =>
     createCancelablePolling(() => {
@@ -63,13 +64,13 @@ class EnsureDeviceApp extends Component<{
     })
 
   renderOpenAppTitle = () => {
-    const { account, currency } = this.props
+    const { account, currency, isToken } = this.props
     const cur = account ? account.currency : currency
     invariant(cur, 'No currency given')
     return (
       <Trans i18nKey="deviceConnect.step2" parent="div">
         {'Open the '}
-        <Bold>{cur.managerAppName}</Bold>
+        <Bold>{cur.managerAppName + (isToken ? '*' : '')}</Bold>
         {' app on your device'}
       </Trans>
     )

--- a/src/components/ParentCryptoCurrencyIcon.js
+++ b/src/components/ParentCryptoCurrencyIcon.js
@@ -42,12 +42,11 @@ class ParentCryptoCurrencyIcon extends PureComponent<Props> {
   render() {
     const { currency, parent, borderColor } = this.props
     const double = parent && parent.currency
+    const parentCurrency = currency.type === 'TokenCurrency' ? currency.parentCurrency : null
 
     const content = (
       <ParentCryptoCurrencyIconWrapper borderColor={borderColor}>
-        {double && parent && (
-          <CryptoCurrencyIcon currency={parent.currency} size={double ? 16 : 20} />
-        )}
+        {parentCurrency && <CryptoCurrencyIcon currency={parentCurrency} size={double ? 16 : 20} />}
         <CryptoCurrencyIcon currency={currency} size={double ? 16 : 20} />
       </ParentCryptoCurrencyIconWrapper>
     )

--- a/src/components/base/AccountsList/index.js
+++ b/src/components/base/AccountsList/index.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from 'react'
 import { translate } from 'react-i18next'
-import type { Account } from '@ledgerhq/live-common/lib/types'
+import type { Account, CryptoCurrency, TokenCurrency } from '@ledgerhq/live-common/lib/types'
 
 import Box from 'components/base/Box'
 import FakeLink from 'components/base/FakeLink'
@@ -14,6 +14,7 @@ import AccountRow from './AccountRow'
 class AccountsList extends Component<
   {
     accounts: Account[],
+    currency: CryptoCurrency | TokenCurrency,
     checkedIds?: string[],
     editedNames: { [accountId: string]: string },
     setAccountName?: (Account, string) => void,
@@ -51,6 +52,7 @@ class AccountsList extends Component<
   render() {
     const {
       accounts,
+      currency,
       checkedIds,
       onToggleAccount,
       editedNames,
@@ -107,6 +109,7 @@ class AccountsList extends Component<
               <AccountRow
                 key={account.id}
                 account={account}
+                currency={currency}
                 autoFocusInput={i === 0 && autoFocusFirstInput}
                 isDisabled={!onToggleAccount || !checkedIds}
                 isChecked={!checkedIds || checkedIds.find(id => id === account.id) !== undefined}

--- a/src/components/base/CurrencyBadge.js
+++ b/src/components/base/CurrencyBadge.js
@@ -3,10 +3,11 @@
 import React from 'react'
 import styled from 'styled-components'
 import { getCryptoCurrencyIcon } from '@ledgerhq/live-common/lib/react'
-import type { CryptoCurrency } from '@ledgerhq/live-common/lib/types'
+import type { CryptoCurrency, TokenCurrency } from '@ledgerhq/live-common/lib/types'
 import { rgba } from 'styles/helpers'
 import IconCheck from 'icons/Check'
 import Box from 'components/base/Box'
+import ParentCryptoCurrencyIcon from 'components/ParentCryptoCurrencyIcon'
 
 import Spinner from './Spinner'
 
@@ -46,11 +47,14 @@ export function CurrencyCircleIcon({
   showCheckmark,
   ...props
 }: {
-  currency: CryptoCurrency,
+  currency: CryptoCurrency | TokenCurrency,
   size: number,
   showSpinner?: boolean,
   showCheckmark?: boolean,
 }) {
+  if (currency.type === 'TokenCurrency') {
+    return <ParentCryptoCurrencyIcon currency={currency} size={size} />
+  }
   const Icon = getCryptoCurrencyIcon(currency)
   return (
     <CryptoIconWrapper
@@ -70,7 +74,7 @@ export function CurrencyCircleIcon({
   )
 }
 
-function CurrencyBadge({ currency, ...props }: { currency: CryptoCurrency }) {
+function CurrencyBadge({ currency, ...props }: { currency: CryptoCurrency | TokenCurrency }) {
   return (
     <Box horizontal flow={3} {...props}>
       <CurrencyCircleIcon size={40} currency={currency} />

--- a/src/components/base/Label.js
+++ b/src/components/base/Label.js
@@ -10,6 +10,7 @@ export default styled.label.attrs({
   align: 'center',
   display: 'block',
 })`
+  margin-top: ${p => (p.mt ? `${p.mt}px` : 'auto')};
   ${alignItems};
   ${color};
   ${fontSize};

--- a/src/components/modals/AddAccounts/index.js
+++ b/src/components/modals/AddAccounts/index.js
@@ -5,7 +5,7 @@ import { compose } from 'redux'
 import { connect } from 'react-redux'
 import { Trans, translate } from 'react-i18next'
 import { createStructuredSelector } from 'reselect'
-import type { CryptoCurrency, Account } from '@ledgerhq/live-common/lib/types'
+import type { CryptoCurrency, TokenCurrency, Account } from '@ledgerhq/live-common/lib/types'
 import { addAccounts } from '@ledgerhq/live-common/lib/account'
 import Track from 'analytics/Track'
 import { MODAL_ADD_ACCOUNTS } from 'config/constants'
@@ -93,7 +93,7 @@ type State = {
 
 export type StepProps = DefaultStepProps & {
   t: T,
-  currency: ?CryptoCurrency,
+  currency: ?CryptoCurrency | ?TokenCurrency,
   device: ?Device,
   isAppOpened: boolean,
   scannedAccounts: Account[],

--- a/src/components/modals/AddAccounts/steps/01-step-choose-currency.js
+++ b/src/components/modals/AddAccounts/steps/01-step-choose-currency.js
@@ -25,17 +25,11 @@ const TokenTipsContainer = styled(Box)`
   padding: 16px;
 `
 
-const TokenTips = React.memo(() => (
+const TokenTips = React.memo(({ currency }: *) => (
   <TokenTipsContainer mt={4} horizontal alignItems="center">
     <InfoCircle size={16} color={colors.wallet} />
     <Text style={{ flex: 1, marginLeft: 20 }} ff="Open Sans|Regular" fontSize={4}>
-      <Trans i18nKey="to.do">
-        {'To add this ERC20 token, you need to '}
-        <Text ff="Open Sans|SemiBold">{'add an Ethereum account'}</Text>
-        {' then open it and click on the "'}
-        <Text ff="Open Sans|SemiBold">{'Add token'}</Text>
-        {'" button'}
-      </Trans>
+      <Trans i18nKey="addAccounts.tokensTip" values={{ currency: currency.parentCurrency.name }} />
     </Text>
   </TokenTipsContainer>
 ))
@@ -50,7 +44,7 @@ function StepChooseCurrency({ currency, setCurrency }: StepProps) {
     <Fragment>
       {currency ? <CurrencyDownStatusAlert currency={currency} /> : null}
       <SelectCurrency currencies={currencies} autoFocus onChange={setCurrency} value={currency} />
-      {currency && currency.type === 'TokenCurrency' ? <TokenTips /> : null}
+      {currency && currency.type === 'TokenCurrency' ? <TokenTips currency={currency} /> : null}
     </Fragment>
   )
 }

--- a/src/components/modals/AddAccounts/steps/01-step-choose-currency.js
+++ b/src/components/modals/AddAccounts/steps/01-step-choose-currency.js
@@ -1,20 +1,56 @@
 // @flow
 
-import React, { Fragment } from 'react'
+import React, { Fragment, useMemo } from 'react'
+import styled from 'styled-components'
+import { Trans } from 'react-i18next'
+import { listSupportedCurrencies, listTokens } from '@ledgerhq/live-common/lib/currencies'
 
+import { colors } from 'styles/theme'
+import { useWithTokens } from 'helpers/experimental'
 import TrackPage from 'analytics/TrackPage'
 import SelectCurrency from 'components/SelectCurrency'
+import InfoCircle from 'icons/InfoCircle'
 import Button from 'components/base/Button'
+import Box from 'components/base/Box'
+import Text from 'components/base/Text'
 import CurrencyDownStatusAlert from 'components/CurrencyDownStatusAlert'
 import CurrencyBadge from 'components/base/CurrencyBadge'
 
 import type { StepProps } from '../index'
 
+const TokenTipsContainer = styled(Box)`
+  background: ${colors.pillActiveBackground};
+  color: ${colors.wallet};
+  font-weight: 400;
+  padding: 16px;
+`
+
+const TokenTips = React.memo(() => (
+  <TokenTipsContainer mt={4} horizontal alignItems="center">
+    <InfoCircle size={16} color={colors.wallet} />
+    <Text style={{ flex: 1, marginLeft: 20 }} ff="Open Sans|Regular" fontSize={4}>
+      <Trans i18nKey="to.do">
+        {'To add this ERC20 token, you need to '}
+        <Text ff="Open Sans|SemiBold">{'add an Ethereum account'}</Text>
+        {' then open it and click on the "'}
+        <Text ff="Open Sans|SemiBold">{'Add token'}</Text>
+        {'" button'}
+      </Trans>
+    </Text>
+  </TokenTipsContainer>
+))
+
 function StepChooseCurrency({ currency, setCurrency }: StepProps) {
+  const withTokens = useWithTokens()
+  const currencies = useMemo(
+    () => listSupportedCurrencies().concat(withTokens ? listTokens() : []),
+    [withTokens],
+  )
   return (
     <Fragment>
       {currency ? <CurrencyDownStatusAlert currency={currency} /> : null}
-      <SelectCurrency autoFocus onChange={setCurrency} value={currency} />
+      <SelectCurrency currencies={currencies} autoFocus onChange={setCurrency} value={currency} />
+      {currency && currency.type === 'TokenCurrency' ? <TokenTips /> : null}
     </Fragment>
   )
 }
@@ -24,7 +60,11 @@ export function StepChooseCurrencyFooter({ transitionTo, currency, t }: StepProp
     <Fragment>
       <TrackPage category="AddAccounts" name="Step1" />
       {currency && <CurrencyBadge mr="auto" currency={currency} />}
-      <Button primary disabled={!currency} onClick={() => transitionTo('connectDevice')}>
+      <Button
+        primary
+        disabled={!currency || currency.type === 'TokenCurrency'}
+        onClick={() => transitionTo('connectDevice')}
+      >
         {t('common.continue')}
       </Button>
     </Fragment>

--- a/src/components/modals/AddAccounts/steps/02-step-connect-device.js
+++ b/src/components/modals/AddAccounts/steps/02-step-connect-device.js
@@ -7,6 +7,7 @@ import { Trans } from 'react-i18next'
 import TrackPage from 'analytics/TrackPage'
 import Button from 'components/base/Button'
 import Box from 'components/base/Box'
+import ParentCryptoCurrencyIcon from 'components/ParentCryptoCurrencyIcon'
 import ConnectDevice from 'components/modals/StepConnectDevice'
 import { CurrencyCircleIcon } from 'components/base/CurrencyBadge'
 
@@ -21,8 +22,19 @@ function StepConnectDevice({ t, currency, device, setAppOpened }: StepProps) {
     <Fragment>
       <TrackPage category="AddAccounts" name="Step2" />
       <Box align="center" mb={6}>
-        <CurrencyCircleIcon mb={3} size={40} currency={currency} />
-        <Box ff="Open Sans" fontSize={4} color="dark" textAlign="center" style={{ width: 370 }}>
+        {currency.type === 'TokenCurrency' ? (
+          <ParentCryptoCurrencyIcon currency={currency} size={40} />
+        ) : (
+          <CurrencyCircleIcon size={40} currency={currency} />
+        )}
+        <Box
+          mt={3}
+          ff="Open Sans"
+          fontSize={4}
+          color="dark"
+          textAlign="center"
+          style={{ width: 370 }}
+        >
           <Trans i18nKey="addAccounts.connectDevice.desc" parent="div">
             {`Follow the steps below to add `}
             <strong style={{ fontWeight: 'bold' }}>{currencyName}</strong>
@@ -33,7 +45,7 @@ function StepConnectDevice({ t, currency, device, setAppOpened }: StepProps) {
       <ConnectDevice
         t={t}
         deviceSelected={device}
-        currency={currency}
+        currency={currency.type === 'TokenCurrency' ? currency.parentCurrency : currency}
         onStatusChange={(deviceStatus, appStatus) => {
           if (appStatus === 'success') {
             setAppOpened(true)

--- a/src/components/modals/Receive/steps/01-step-account.js
+++ b/src/components/modals/Receive/steps/01-step-account.js
@@ -53,17 +53,12 @@ const TokenSelection = ({
 }) => {
   const tokens = useMemo(() => listTokensForCryptoCurrency(currency), [currency])
   return (
-    <Box mt={30}>
-      <Label>
-        <Trans
-          i18nKey="receive.steps.chooseAccount.token"
-          values={{
-            currencyName: currency.name,
-          }}
-        />
+    <>
+      <Label mt={30}>
+        <Trans i18nKey="receive.steps.chooseAccount.token" />
       </Label>
       <SelectCurrency onChange={onChangeToken} currencies={tokens} value={token} />
-    </Box>
+    </>
   )
 }
 

--- a/src/components/modals/Receive/steps/01-step-account.js
+++ b/src/components/modals/Receive/steps/01-step-account.js
@@ -62,7 +62,7 @@ const TokenSelection = ({
           }}
         />
       </Label>
-      <SelectCurrency onChange={onChangeToken} currencies={tokens} value={token || tokens[0]} />
+      <SelectCurrency onChange={onChangeToken} currencies={tokens} value={token} />
     </Box>
   )
 }
@@ -96,9 +96,13 @@ export default function StepAccount({
   )
 }
 
-export function StepAccountFooter({ transitionTo, account }: StepProps) {
+export function StepAccountFooter({ transitionTo, receiveTokenMode, token, account }: StepProps) {
   return (
-    <Button disabled={!account} primary onClick={() => transitionTo('device')}>
+    <Button
+      disabled={!account || (receiveTokenMode && !token)}
+      primary
+      onClick={() => transitionTo('device')}
+    >
       <Trans i18nKey="common.continue" />
     </Button>
   )

--- a/src/components/modals/Receive/steps/02-step-connect-device.js
+++ b/src/components/modals/Receive/steps/02-step-connect-device.js
@@ -3,6 +3,10 @@
 import React, { Fragment } from 'react'
 import { Trans } from 'react-i18next'
 import { getMainAccount } from '@ledgerhq/live-common/lib/account/helpers'
+import type { TokenCurrency } from '@ledgerhq/live-common/lib/types'
+import { colors } from 'styles/theme'
+import InfoCircle from 'icons/InfoCircle'
+import Text from 'components/base/Text'
 import Box from 'components/base/Box'
 import Button from 'components/base/Button'
 import EnsureDeviceApp from 'components/EnsureDeviceApp'
@@ -11,20 +15,42 @@ import TrackPage from 'analytics/TrackPage'
 
 import type { StepProps } from '../index'
 
+export const TokenTips: React$ComponentType<{ token: TokenCurrency }> = React.memo(({ token }) => (
+  <Box mt={4} horizontal alignItems="center">
+    <InfoCircle size={12} color={colors.graphite} />
+    <Text style={{ flex: 1, marginLeft: 10 }} ff="Open Sans|Regular" color="graphite" fontSize={3}>
+      <Trans i18nKey="to.do">
+        {'*'}
+        <Text color="dark" ff="Open Sans|SemiBold">
+          {token.name}
+        </Text>
+        {' is a token on '}
+        <Text color="dark" ff="Open Sans|SemiBold">
+          {token.parentCurrency.name}
+        </Text>
+      </Trans>
+    </Text>
+  </Box>
+))
+
 export default function StepConnectDevice({
   account,
   parentAccount,
+  token,
   onChangeAppOpened,
 }: StepProps) {
   const mainAccount = account ? getMainAccount(account, parentAccount) : null
+  const tokenCur = (account && account.type === 'TokenAccount' && account.token) || token
   return (
     <Fragment>
       {mainAccount ? <CurrencyDownStatusAlert currency={mainAccount.currency} /> : null}
       <EnsureDeviceApp
         account={mainAccount}
+        isToken={!!tokenCur}
         waitBeforeSuccess={200}
         onSuccess={() => onChangeAppOpened(true)}
       />
+      {!tokenCur ? null : <TokenTips token={tokenCur} />}
     </Fragment>
   )
 }

--- a/src/components/modals/Receive/steps/02-step-connect-device.js
+++ b/src/components/modals/Receive/steps/02-step-connect-device.js
@@ -4,8 +4,6 @@ import React, { Fragment } from 'react'
 import { Trans } from 'react-i18next'
 import { getMainAccount } from '@ledgerhq/live-common/lib/account/helpers'
 import type { TokenCurrency } from '@ledgerhq/live-common/lib/types'
-import { colors } from 'styles/theme'
-import InfoCircle from 'icons/InfoCircle'
 import Text from 'components/base/Text'
 import Box from 'components/base/Box'
 import Button from 'components/base/Button'
@@ -17,18 +15,11 @@ import type { StepProps } from '../index'
 
 export const TokenTips: React$ComponentType<{ token: TokenCurrency }> = React.memo(({ token }) => (
   <Box mt={4} horizontal alignItems="center">
-    <InfoCircle size={12} color={colors.graphite} />
     <Text style={{ flex: 1, marginLeft: 10 }} ff="Open Sans|Regular" color="graphite" fontSize={3}>
-      <Trans i18nKey="to.do">
-        {'*'}
-        <Text color="dark" ff="Open Sans|SemiBold">
-          {token.name}
-        </Text>
-        {' is a token on '}
-        <Text color="dark" ff="Open Sans|SemiBold">
-          {token.parentCurrency.name}
-        </Text>
-      </Trans>
+      <Trans
+        i18nKey="receive.steps.connectDevice.tokensTip"
+        values={{ currency: token.parentCurrency.name }}
+      />
     </Text>
   </Box>
 ))

--- a/src/components/modals/Send/steps/02-step-connect-device.js
+++ b/src/components/modals/Send/steps/02-step-connect-device.js
@@ -7,20 +7,24 @@ import Button from 'components/base/Button'
 import EnsureDeviceApp from 'components/EnsureDeviceApp'
 
 import type { StepProps } from '../index'
+import { TokenTips } from '../../Receive/steps/02-step-connect-device'
 
 export default function StepConnectDevice({
   account,
   parentAccount,
   onChangeAppOpened,
 }: StepProps<*>) {
+  const token = account && account.type === 'TokenAccount' && account.token
   return (
     <Fragment>
       <TrackPage category="Send Flow" name="Step 2" />
       <EnsureDeviceApp
         account={account ? getMainAccount(account, parentAccount) : null}
+        isToken={!!token}
         waitBeforeSuccess={200}
         onSuccess={() => onChangeAppOpened(true)}
       />
+      {!token ? null : <TokenTips token={token} />}
     </Fragment>
   )
 }

--- a/src/helpers/experimental.js
+++ b/src/helpers/experimental.js
@@ -2,6 +2,7 @@
 import { ipcRenderer } from 'electron'
 import { setEnvUnsafe, isEnvDefault, changes, getAllEnvs } from '@ledgerhq/live-common/lib/env'
 import type { EnvName } from '@ledgerhq/live-common/lib/env'
+import useEnv from 'hooks/useEnv'
 
 export type FeatureCommon = {
   name: EnvName,
@@ -140,3 +141,9 @@ changes.subscribe(({ name, value }) => {
     setLocalStorageEnv(name, value)
   }
 })
+
+export const useWithTokens = () => {
+  const experimentalExplorers = !!useEnv('EXPERIMENTAL_EXPLORERS')
+  const experimentalLibcore = !!useEnv('EXPERIMENTAL_LIBCORE')
+  return experimentalExplorers && experimentalLibcore
+}

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -270,6 +270,7 @@
     "connectDevice": {
       "desc": "Follow the steps below to add <1><0>{{currencyName}}</0></1> accounts"
     },
+    "tokensTip":"To add this {{tokenType}} token, please add an {{currency}} account and send tokens to it",
     "accountToImportSubtitle_plural": "Add existing accounts",
     "selectAll": "Select all ({{count}})",
     "unselectAll": "Deselect all ({{count}})",
@@ -409,12 +410,13 @@
       "chooseAccount": {
         "title": "Account",
         "label": "Account to credit",
-        "parentAccount": "1. Choose {{currencyName}} Account",
-        "token": "2. Choose {{currencyName}} Token"
+        "parentAccount": "1. Select {{currencyName}} account",
+        "token": "2. Select a token"
       },
       "connectDevice": {
         "title": "Device",
-        "withoutDevice": "Don't have your device?"
+        "withoutDevice": "Don't have your device?",
+        "tokensTip":"* Token reception is made through the {{currency}} address"
       },
       "confirmAddress": {
         "title": "Verification",

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -227,7 +227,7 @@
   },
   "tokensList": {
     "title": "Tokens",
-    "cta": "Receive token",
+    "cta": "Add token",
     "placeholder": "To add tokens, simply send them to your Ethereum address.",
     "link": "Learn more",
     "seeTokens": "See tokens ({{tokenCount}})",


### PR DESCRIPTION
This is an up to date version of the work done by @gre simply rebased to latest develop and updated some wording and minor styles. There are still a few issues though here that need to be addressed (or not). We refer to the address (on the receive flow) as both `ethereum` address and `{tokenName} address`, maybe this should be consistent.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/projects/LL/issues/LL-1471

### Parts of the app affected / Test plan

Receive flow, add account flow from an eth account with tokens.

-----

Closes https://github.com/LedgerHQ/ledger-live-desktop/pull/2169 