### PR TITLE
LL-1699: Fix spacebar toggling accounts in add accounts

### DIFF
--- a/src/components/base/AccountsList/AccountRow.js
+++ b/src/components/base/AccountsList/AccountRow.js
@@ -31,6 +31,11 @@ export default class AccountRow extends PureComponent<Props> {
     e.stopPropagation()
   }
 
+  handleKeyPress = (e: SyntheticEvent<HTMLInputElement>) => {
+    // this fixes a bug with the event propagating to the Tabbable
+    e.stopPropagation()
+  }
+
   onToggleAccount = () => {
     const { onToggleAccount, account, isChecked } = this.props
     if (onToggleAccount) onToggleAccount(account, !isChecked)
@@ -87,6 +92,7 @@ export default class AccountRow extends PureComponent<Props> {
               onEnter={this.handlePreventSubmit}
               onFocus={this.onFocus}
               onBlur={this.onBlur}
+              onKeyPress={this.handleKeyPress}
               maxLength={MAX_ACCOUNT_NAME_SIZE}
               editInPlace
               autoFocus={autoFocusInput}


### PR DESCRIPTION
Fixes a bug where hitting space while editing the name would toggle the account selection.

![bug_space](https://user-images.githubusercontent.com/1671753/62219724-200ecb80-b3af-11e9-8395-e91f0c328226.gif)

### :ok_hand: Type

Bug fix

### :mag: Context

LL-1699

### :clipboard: Parts of the app affected / Test plan

Add accounts