### PR TITLE
LL-1739 "Do it later" button in migration modal

### DIFF
--- a/src/components/modals/MigrateAccounts/steps/01-step-overview.js
+++ b/src/components/modals/MigrateAccounts/steps/01-step-overview.js
@@ -63,18 +63,12 @@ const HelpLink = styled.span.attrs({
     color: ${p => rgba(p.theme.colors.wallet, 0.9)};
   }
 `
-const FooterContent = styled.div`
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  align-items: flex-end;
-
-  > ${Text} {
-    margin-top: 21px;
-    &:hover {
-      text-decoration: underline;
-    }
-  }
+const FooterContent = styled(Box).attrs({
+  flow: 2,
+  horizontal: true,
+  align: 'center',
+})`
+  justify: flex-end;
 `
 
 const Exclamation = styled.div`
@@ -220,6 +214,7 @@ export const StepOverviewFooter = ({
       </FooterContent>
     ) : !currency && !hideLoopNotice ? (
       <FooterContent>
+        <Button onClick={onCloseModal}>{t('migrateAccounts.overview.doItLaterBtn')}</Button>
         <Button
           primary
           onClick={() => {

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -249,7 +249,8 @@
       "currency_plural": "{{count}} {{currency}} accounts need to be updated:",
       "footer": "You need your Ledger Device to complete the update",
       "pendingDevices": "1 account could not be updated. Please connect the device associated to the account below",
-      "pendingDevices_plural": "{{totalMigratableAccounts}} accounts could not be updated. Please connect the device associated to the account below"
+      "pendingDevices_plural": "{{totalMigratableAccounts}} accounts could not be updated. Please connect the device associated to the account below",
+      "doItLaterBtn": "Do it later"
     },
     "connectDevice": {
       "title": "{{currencyName}} update",


### PR DESCRIPTION
When the user finishes the update of accounts from one device, and has other accounts from another device or with a passphrase, add a "Do it later" button in addition to the CTA.

<img width="539" alt="Screen Shot 2019-07-31 at 16 11 34" src="https://user-images.githubusercontent.com/13920153/62220584-8e07c280-b3b0-11e9-9688-00cb89df3e88.png">

### Type

UX Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1739

### Parts of the app affected

Migration modal
