### PR TITLE
Collapse on token sidebar list

### DIFF
--- a/src/components/AccountsPage/AccountRowItem/Header.js
+++ b/src/components/AccountsPage/AccountRowItem/Header.js
@@ -15,11 +15,11 @@ type Props = {
 }
 
 // NB Inside Head to not break alignment with parent row;
+// and this is in fact not seen, because we draw on top
+// from AccountRowItem/index.js TokenBarIndicator
 const NestedIndicator = styled.div`
-  border-left: 1px solid ${p => p.theme.colors.lightFog};
   height: 44px;
-  margin-left: 9px;
-  padding-left: 5px;
+  width:14px;
 `
 
 class Header extends PureComponent<Props> {

--- a/src/components/AccountsPage/AccountRowItem/index.js
+++ b/src/components/AccountsPage/AccountRowItem/index.js
@@ -58,6 +58,24 @@ const TokenContent = styled.div`
   margin-top: 20px;
 `
 
+const TokenContentWrapper = styled.div`
+  position: relative;
+`
+
+const TokenBarIndicator = styled.div`
+  width: 15px;
+  border-left: 1px solid ${p => p.theme.colors.lightFog};
+  z-index: 2;
+  margin-left: 9px;
+  padding-left: 5px;
+  position: absolute;
+  left: 0;
+  height: 100%;
+  &:hover {
+    border-color: ${p => p.theme.colors.grey};
+  }
+`
+
 const TokenShowMoreIndicator = styled.div`
   margin: 15px -20px -16px;
   display: flex;
@@ -185,20 +203,23 @@ class AccountRowItem extends PureComponent<Props, State> {
             </RowContent>
           </AccountContextMenu>
           {showTokensIndicator && expanded && (
-            <TokenContent>
-              {tokens &&
-                tokens.map((token, index) => (
-                  <TokenRow
-                    nested
-                    index={index}
-                    key={token.id}
-                    range={range}
-                    account={token}
-                    parentAccount={mainAccount}
-                    onClick={onClick}
-                  />
-                ))}
-            </TokenContent>
+            <TokenContentWrapper>
+              <TokenBarIndicator onClick={this.toggleAccordion} />
+              <TokenContent>
+                {tokens &&
+                  tokens.map((token, index) => (
+                    <TokenRow
+                      nested
+                      index={index}
+                      key={token.id}
+                      range={range}
+                      account={token}
+                      parentAccount={mainAccount}
+                      onClick={onClick}
+                    />
+                  ))}
+              </TokenContent>
+            </TokenContentWrapper>
           )}
           {showTokensIndicator && !disabled && tokens && (
             <TokenShowMoreIndicator expanded={expanded} onClick={this.toggleAccordion}>


### PR DESCRIPTION
![collapse](https://user-images.githubusercontent.com/4631227/62286909-0924b380-b459-11e9-93e3-8438c1e183cd.gif)

Hacky way (had to position the bad absolutely since otherways it wouldn't align with the parent one) to provide the user a subtle way to collapse the token list without scrolling to the bottom of the screen. While this is not an issue for users with a low number of tokens, it is an issue for us devs, and I'm sure for some power-users too. 🚗 

### Type

UX improvement

### Context

🤷‍♂ 

### Parts of the app affected / Test plan

Account list, account with token accounts, this enables collapsing the list by clicking on the side bar.
