### PR TITLE
Adds quotes to fix the whitespace that broke the stars

### DIFF
--- a/src/components/Stars/Star.js
+++ b/src/components/Stars/Star.js
@@ -33,7 +33,7 @@ const StarIcon = styled.div`
   & {
     height: 50px;
     width: 50px;
-    background-image: url(${p => i(p.yellow ? 'starAnim2.png' : 'starAnim.png')});
+    background-image: url("${p => i(p.yellow ? 'starAnim2.png' : 'starAnim.png')}");
     background-position: ${p => (p.filled ? 'right' : 'left')};
     background-repeat: no-repeat;
     background-size: 3000%;


### PR DESCRIPTION
In the dev build the stars were working because the path didn't contian any white spaces, I would assume that if your user or some folder did then it wouldn't hav worked either. It's a bummer though, stars shouldn't be taken away from us so easily 🌟 

### Type

Bug fix

### Parts of the app affected / Test plan

Must be tested in dist mode `yarn dist:dir` to see if it works.
