### PR TITLE
LL-1725 Fix ellipsis on address in operations list

### DIFF
--- a/src/components/OperationsList/AddressCell.js
+++ b/src/components/OperationsList/AddressCell.js
@@ -10,29 +10,41 @@ const Address = ({ value }: { value: string }) => {
     return <Box />
   }
 
-  const addrSize = value.length / 2
+  const quarter = Math.round(value.length / 4)
 
   // FIXME why not using CSS for this? meaning we might be able to have a left & right which both take 50% & play with overflow & text-align
-  const left = value.slice(0, 10)
-  const right = value.slice(-addrSize)
-  const middle = value.slice(10, -addrSize)
+  const left = value.slice(0, quarter)
+  const middle = value.slice(quarter, -quarter)
+  const right = value.slice(-quarter)
 
   return (
     <Box horizontal color="smoke" ff="Open Sans" fontSize={3}>
-      <div>{left}</div>
-      <AddressEllipsis>{middle}</AddressEllipsis>
-      <div>{right}</div>
+      <Left>{left}</Left>
+      <Middle>{middle}</Middle>
+      <Right>{right}</Right>
     </Box>
   )
 }
 
-const AddressEllipsis = styled.div`
+const Left = styled.div`
+  overflow: hidden;
+  white-space: nowrap;
+`
+
+const Right = styled.div`
+  overflow: hidden;
+  white-space: nowrap;
+  direction: rtl;
+`
+
+const Middle = styled.div`
   display: block;
   flex-shrink: 1;
 
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 1em;
 `
 
 const Cell = styled(Box).attrs({


### PR DESCRIPTION
Embedding `OperationsList` in modals brought out that addresses where not correctly truncated, and are overflowing over their siblings.

This should fix that.

Before:
<img width="548" alt="Screen Shot 2019-08-02 at 18 49 14" src="https://user-images.githubusercontent.com/13920153/62386274-a0703080-b557-11e9-8137-463c10da824b.png">

After:
<img width="556" alt="Screen Shot 2019-08-02 at 18 50 13" src="https://user-images.githubusercontent.com/13920153/62386287-ab2ac580-b557-11e9-9716-ec8e8b6d9692.png">


### Type

Bugfix/UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1725

### Parts of the app affected

Operation lists, especially in modals, like for ERC-20 related operations from parent ETH account.
