### PR TITLE
No star left behind 🌟

### DIFF
--- a/src/helpers/staticPath.js
+++ b/src/helpers/staticPath.js
@@ -1,4 +1,5 @@
 // @flow
+import pathModule from 'path'
 
 const { NODE_ENV, STORYBOOK_ENV } = process.env
 
@@ -9,13 +10,20 @@ const staticPath =
   __DEV__ && !STORYBOOK_ENV && NODE_ENV !== 'test'
     ? __static
     : isRunningInAsar
-    ? __dirname.replace(/app\.asar$/, 'static')
+    ? pathModule.join(pathModule.dirname(__dirname), 'static')
     : !STORYBOOK_ENV
-    ? `${__dirname}/../../static`
+    ? pathModule.join(__dirname, '/../../static')
     : 'static'
 
-export function getPath(path: string): string {
-  return isRunningInAsar ? `${staticPath}/${path}` : `/${path}`
+export function unixify(path: string): string {
+  return process.platform === 'win32' ? path.replace(/\\/g, '/') : path
+}
+
+export function getPath(path: string, posix?: boolean): string {
+  const fullPath = isRunningInAsar
+    ? pathModule.join(staticPath, path)
+    : pathModule.normalize(`/${path}`)
+  return posix ? unixify(fullPath) : fullPath
 }
 
 /**
@@ -23,6 +31,6 @@ export function getPath(path: string): string {
  *
  * note: `i` for `image` (using `img` was confusing when using with <img /> tag)
  */
-export const i = (path: string): string => getPath(`images/${path}`)
+export const i = (path: string): string => getPath(`images/${path}`, true)
 
 export default staticPath


### PR DESCRIPTION
Everybody should be able to see the stars, even through windows.
No star will be left behind.
Not on our watch.

### Details

Stars were missing from the UI on Windows because of:
- The way we computed the static asset path: we were doing naive string concatenation with the assumption of a POSIX path format, so we ended with a mix of `/` and `\` on win32.
This PR brings some normalization via Node's `path` module.
- We handed a _path_ where an _URL_ was expected: `\` are invalid in URLs, win32 or not. A flag has been added to optionally convert them to `/`.

### Type

Bug Fix
Code Quality Improvement

### Context

#2225 
#2241 
https://ledgerhq.atlassian.net/browse/LL-1483

### Parts of the app affected / Test plan

Stars 🤩
Other images, like confettis
