### PR TITLE
Marouane can see the difference between FFFFFF and FEFEFE

### DIFF
--- a/src/components/Stars/Star.js
+++ b/src/components/Stars/Star.js
@@ -16,7 +16,7 @@ const ButtonWrapper = styled.div`
   border-radius: 4px;
   padding: 8px;
   text-align: center;
-  background: ${p => (p.filled ? p.theme.colors.starYellow : p.theme.colors.white)};
+  background: ${p => (p.filled ? p.theme.colors.starYellow : 'transparent')};
   &:hover {
     background: ${p => (p.filled ? p.theme.colors.starYellow : rgba(p.theme.colors.fog, 0.2))};
     border-color: ${p => (p.filled ? p.theme.colors.starYellow : p.theme.colors.dark)};


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/62550970-6c548280-b86b-11e9-830d-938b13f3401c.png)

The backround of this star shouldnt be white, it should be transparent and let the light gray from behind through. @dekkaki noticed this, I looked at it for days without noticing anything.

### Type

UI Polish