### PR TITLE
LL-1713: Fix amount not updated when user enters recipient address after checking send max

### DIFF
--- a/src/components/modals/Send/fields/AmountField.js
+++ b/src/components/modals/Send/fields/AmountField.js
@@ -39,10 +39,10 @@ class AmountField extends Component<
   componentDidMount() {
     this.resync()
   }
-  componentDidUpdate(nextProps: *) {
+  componentDidUpdate(prevProps: *) {
     if (
-      nextProps.account !== this.props.account ||
-      nextProps.transaction !== this.props.transaction
+      prevProps.account !== this.props.account ||
+      prevProps.transaction !== this.props.transaction
     ) {
       this.resync()
     }
@@ -63,6 +63,7 @@ class AmountField extends Component<
       if (this.syncId !== syncId) return
       this.setState({ validTransactionError: null, maxAmount })
     } catch (validTransactionError) {
+      if (this.syncId !== syncId) return
       this.setState({ validTransactionError, maxAmount: null })
     }
   }


### PR DESCRIPTION
This PR fixes a bug where checking send max before entering the address would result in transaction amount 0. This was due to a race condition: the transaction gets updated twice: the first time (without a `gasLimit`) would throw on `checkValidTransaction` but it would get caught *after* the second (with `gasLimit`) one was validated :thinking: 

The fix was simply to check the sync ID before updating state on error :tada: 

### :ok_hand: Type

Bug fix

### :mag: Context

LL-1713

### :clipboard: Parts of the app affected / Test plan

Send max ERC20