### PR TITLE
LL-1778 Fix show release notes after update

### DIFF
--- a/src/components/IsNewVersion.js
+++ b/src/components/IsNewVersion.js
@@ -1,0 +1,47 @@
+// @flow
+
+import { PureComponent } from 'react'
+import { connect } from 'react-redux'
+import semver from 'semver'
+
+import type { State } from 'reducers'
+import { openModal } from 'reducers/modals'
+import { lastUsedVersionSelector } from 'reducers/settings'
+import { saveSettings } from 'actions/settings'
+import { MODAL_RELEASES_NOTES } from 'config/constants'
+
+type Props = {
+  openModal: Function,
+  saveSettings: Function,
+  lastUsedVersion: string,
+}
+
+const mapStateToProps = (state: State) => ({
+  lastUsedVersion: lastUsedVersionSelector(state),
+})
+
+const mapDispatchToProps = {
+  openModal,
+  saveSettings,
+}
+
+class IsNewVersion extends PureComponent<Props> {
+  componentDidMount() {
+    const { lastUsedVersion, saveSettings, openModal } = this.props
+    const currentVersion = __APP_VERSION__
+
+    if (semver.gt(currentVersion, lastUsedVersion)) {
+      openModal(MODAL_RELEASES_NOTES, currentVersion)
+      saveSettings({ lastUsedVersion: currentVersion })
+    }
+  }
+
+  render() {
+    return null
+  }
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(IsNewVersion)

--- a/src/components/layout/Default.js
+++ b/src/components/layout/Default.js
@@ -37,6 +37,7 @@ import TopBar from 'components/TopBar'
 import SyncBackground from 'components/SyncBackground'
 import DebugUpdater from 'components/Updater/DebugUpdater'
 import ListenDevices from 'components/ListenDevices'
+import IsNewVersion from 'components/IsNewVersion'
 
 import SyncContinuouslyPendingOperations from '../SyncContinouslyPendingOperations'
 import HSMStatusBanner from '../HSMStatusBanner'
@@ -105,6 +106,8 @@ class Default extends Component<Props> {
             {visibleModals.map(([name, ModalComponent]) => (
               <ModalComponent key={name} />
             ))}
+
+            <IsNewVersion />
 
             {process.env.DEBUG_UPDATE && <DebugUpdater />}
 

--- a/src/components/modals/ReleaseNotes/index.js
+++ b/src/components/modals/ReleaseNotes/index.js
@@ -1,56 +1,16 @@
 // @flow
 
-import React, { PureComponent } from 'react'
-import { connect } from 'react-redux'
-import semver from 'semver'
+import React from 'react'
 
-import type { State } from 'reducers'
-import { openModal } from 'reducers/modals'
-import { lastUsedVersionSelector } from 'reducers/settings'
-import { saveSettings } from 'actions/settings'
 import { MODAL_RELEASES_NOTES } from 'config/constants'
 import Modal from 'components/base/Modal'
 
 import ReleaseNotesBody from './ReleaseNotesBody'
 
-type Props = {
-  openModal: Function,
-  saveSettings: Function,
-  lastUsedVersion: string,
-}
-
-const mapStateToProps = (state: State) => ({
-  lastUsedVersion: lastUsedVersionSelector(state),
-})
-
-const mapDispatchToProps = {
-  openModal,
-  saveSettings,
-}
-
-class ReleaseNotesModal extends PureComponent<Props> {
-  componentDidMount() {
-    const { lastUsedVersion, saveSettings, openModal } = this.props
-    const currentVersion = __APP_VERSION__
-
-    if (semver.gt(currentVersion, lastUsedVersion)) {
-      openModal(MODAL_RELEASES_NOTES, currentVersion)
-      saveSettings({ lastUsedVersion: currentVersion })
-    }
-  }
-
-  render() {
-    return (
-      <Modal
-        name={MODAL_RELEASES_NOTES}
-        centered
-        render={({ data, onClose }) => <ReleaseNotesBody version={data} onClose={onClose} />}
-      />
-    )
-  }
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ReleaseNotesModal)
+export default () => (
+  <Modal
+    name={MODAL_RELEASES_NOTES}
+    centered
+    render={({ data, onClose }) => <ReleaseNotesBody version={data} onClose={onClose} />}
+  />
+)


### PR DESCRIPTION

### Type

Regression Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1778

### Parts of the app affected

Release notes

### Test plan

- Replace `lastUsedVersion` in `app.json` with a lower than current version (eg `1.0.0`)
- Launch the app
- The release notes modal should show up on launch and the `lastUsedVersion` should be updated in `app.json`