### PR TITLE
LL-1775 Remove Edit from context menu on tokens

### DIFF
--- a/src/components/AccountsPage/AccountGridItem/index.js
+++ b/src/components/AccountsPage/AccountGridItem/index.js
@@ -34,7 +34,7 @@ class AccountCard extends PureComponent<Props> {
     const { account, parentAccount, range, hidden, ...props } = this.props
 
     return (
-      <AccountContextMenu account={account}>
+      <AccountContextMenu account={account} parentAccount={parentAccount}>
         <Card
           {...props}
           style={{ display: hidden && 'none' }}

--- a/src/components/ContextMenu/AccountContextMenu.js
+++ b/src/components/ContextMenu/AccountContextMenu.js
@@ -27,7 +27,7 @@ const mapDispatchToProps = {
 class AccountContextMenu extends PureComponent<Props> {
   getContextMenuItems = () => {
     const { openModal, toggleStarAction, account } = this.props
-    return [
+    const items = [
       {
         label: 'accounts.contextMenu.send',
         Icon: IconSend,
@@ -38,17 +38,23 @@ class AccountContextMenu extends PureComponent<Props> {
         Icon: IconReceive,
         callback: () => openModal(MODAL_RECEIVE, { account }),
       },
-      {
+    ]
+
+    if (account.type === 'Account') {
+      items.push({
         label: 'accounts.contextMenu.edit',
         Icon: IconAccountSettings,
         callback: () => openModal(MODAL_SETTINGS_ACCOUNT, { account }),
-      },
-      {
-        label: 'accounts.contextMenu.star',
-        Icon: IconStar,
-        callback: () => toggleStarAction(account.id),
-      },
-    ]
+      })
+    }
+
+    items.push({
+      label: 'accounts.contextMenu.star',
+      Icon: IconStar,
+      callback: () => toggleStarAction(account.id),
+    })
+
+    return items
   }
 
   render() {

--- a/src/components/ContextMenu/AccountContextMenu.js
+++ b/src/components/ContextMenu/AccountContextMenu.js
@@ -2,12 +2,10 @@
 
 import React, { PureComponent } from 'react'
 import { openModal } from 'reducers/modals'
-import { toggleStarAction } from 'actions/settings'
 import type { Account } from '@ledgerhq/live-common/lib/types/account'
 import { connect } from 'react-redux'
 import IconReceive from 'icons/Receive'
 import IconSend from 'icons/Send'
-import IconStar from 'icons/Star'
 import IconAccountSettings from 'icons/AccountSettings'
 import ContextMenuItem from './ContextMenuItem'
 import { MODAL_RECEIVE, MODAL_SEND, MODAL_SETTINGS_ACCOUNT } from '../../config/constants'
@@ -15,18 +13,16 @@ import { MODAL_RECEIVE, MODAL_SEND, MODAL_SETTINGS_ACCOUNT } from '../../config/
 type Props = {
   account: Account,
   children: any,
-  toggleStarAction: Function,
   openModal: Function,
 }
 
 const mapDispatchToProps = {
   openModal,
-  toggleStarAction,
 }
 
 class AccountContextMenu extends PureComponent<Props> {
   getContextMenuItems = () => {
-    const { openModal, toggleStarAction, account } = this.props
+    const { openModal, account } = this.props
     const items = [
       {
         label: 'accounts.contextMenu.send',
@@ -47,12 +43,6 @@ class AccountContextMenu extends PureComponent<Props> {
         callback: () => openModal(MODAL_SETTINGS_ACCOUNT, { account }),
       })
     }
-
-    items.push({
-      label: 'accounts.contextMenu.star',
-      Icon: IconStar,
-      callback: () => toggleStarAction(account.id),
-    })
 
     return items
   }

--- a/src/components/ContextMenu/AccountContextMenu.js
+++ b/src/components/ContextMenu/AccountContextMenu.js
@@ -2,7 +2,7 @@
 
 import React, { PureComponent } from 'react'
 import { openModal } from 'reducers/modals'
-import type { Account } from '@ledgerhq/live-common/lib/types/account'
+import type { Account, TokenAccount } from '@ledgerhq/live-common/lib/types/account'
 import { connect } from 'react-redux'
 import IconReceive from 'icons/Receive'
 import IconSend from 'icons/Send'
@@ -11,7 +11,8 @@ import ContextMenuItem from './ContextMenuItem'
 import { MODAL_RECEIVE, MODAL_SEND, MODAL_SETTINGS_ACCOUNT } from '../../config/constants'
 
 type Props = {
-  account: Account,
+  account: TokenAccount | Account,
+  parentAccount: ?Account,
   children: any,
   openModal: Function,
 }
@@ -22,17 +23,17 @@ const mapDispatchToProps = {
 
 class AccountContextMenu extends PureComponent<Props> {
   getContextMenuItems = () => {
-    const { openModal, account } = this.props
+    const { openModal, account, parentAccount } = this.props
     const items = [
       {
         label: 'accounts.contextMenu.send',
         Icon: IconSend,
-        callback: () => openModal(MODAL_SEND, { account }),
+        callback: () => openModal(MODAL_SEND, { account, parentAccount }),
       },
       {
         label: 'accounts.contextMenu.receive',
         Icon: IconReceive,
-        callback: () => openModal(MODAL_RECEIVE, { account }),
+        callback: () => openModal(MODAL_RECEIVE, { account, parentAccount }),
       },
     ]
 

--- a/src/components/ContextMenu/ContextMenuWrapper.js
+++ b/src/components/ContextMenu/ContextMenuWrapper.js
@@ -48,24 +48,25 @@ const ContextMenuContainer = styled(Box)`
   width: 170px;
   border-radius: 4px;
   box-shadow: 0 4px 8px 0 #00000007;
-  border: 1px solid #d8d8d8;
+  border: 1px solid ${p => p.theme.colors.lightFog};
   background-color: white;
   padding: 10px;
 `
 
-const ContextMenuItemContainer = styled(Box)`
-  padding: 10px 10px;
+const ContextMenuItemContainer = styled(Box).attrs({
+  ff: 'Museo Sans',
+})`
+  padding: 8px 16px;
   text-align: center;
   flex-direction: row;
   align-items: left;
   border-radius: 4px;
-  color: ${p => p.theme.colors.smoke};
-  font-family: 'Open Sans', Arial;
-  font-size: 13px;
+  color: ${p => p.theme.colors.dark};
+  font-size: 12px;
+  font-weight: 500;
 
   &:hover {
     cursor: pointer;
-    color: ${p => p.theme.colors.dark};
     background: ${p => p.theme.colors.lightGrey};
   }
 `


### PR DESCRIPTION
On _Accounts_ page in grid mode, context (right click) menu was showing an _Edit Account_ entry, resulting in a crash when selected.

This PR remove the entry for token accounts.

<details>
<summary>Here lies an out of date screenshot ⚰️</summary>

<img width="295" alt="Screen Shot 2019-08-07 at 17 48 55" src="https://user-images.githubusercontent.com/13920153/62637705-5498ff00-b93c-11e9-9851-57f932df0ec3.png">

</details>

EDIT:
- Redundant star removed
- Pixel polish

<img width="288" alt="Screen Shot 2019-08-08 at 14 57 46" src="https://user-images.githubusercontent.com/13920153/62705317-72726c80-b9ed-11e9-8f3b-851151c1abfb.png">


### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1775


### Parts of the app affected 

Context menu on accounts cards

### Test plan

- Go to _Accounts_ page
- Set to grid mode
- Right click on a token account: _Edit account_ should not be present
- Right click on a regular account: _Edit account_ should be there

