### PR TITLE
LL-1743: Learn more when selecting ERC20 in add account

### DIFF
--- a/src/components/AccountsPage/AccountRowItem/Header.js
+++ b/src/components/AccountsPage/AccountRowItem/Header.js
@@ -19,7 +19,7 @@ type Props = {
 // from AccountRowItem/index.js TokenBarIndicator
 const NestedIndicator = styled.div`
   height: 44px;
-  width:14px;
+  width: 14px;
 `
 
 class Header extends PureComponent<Props> {

--- a/src/components/modals/AddAccounts/steps/01-step-choose-currency.js
+++ b/src/components/modals/AddAccounts/steps/01-step-choose-currency.js
@@ -8,9 +8,11 @@ import { listSupportedCurrencies, listTokens } from '@ledgerhq/live-common/lib/c
 import { colors } from 'styles/theme'
 import { useWithTokens } from 'helpers/experimental'
 import TrackPage from 'analytics/TrackPage'
+import { urls } from 'config/urls'
 import SelectCurrency from 'components/SelectCurrency'
 import InfoCircle from 'icons/InfoCircle'
 import Button from 'components/base/Button'
+import ExternalLinkButton from 'components/base/ExternalLinkButton'
 import Box from 'components/base/Box'
 import Text from 'components/base/Text'
 import CurrencyDownStatusAlert from 'components/CurrencyDownStatusAlert'
@@ -62,13 +64,18 @@ export function StepChooseCurrencyFooter({ transitionTo, currency, t }: StepProp
     <Fragment>
       <TrackPage category="AddAccounts" name="Step1" />
       {currency && <CurrencyBadge mr="auto" currency={currency} />}
-      <Button
-        primary
-        disabled={!currency || currency.type === 'TokenCurrency'}
-        onClick={() => transitionTo('connectDevice')}
-      >
-        {t('common.continue')}
-      </Button>
+      {currency && currency.type === 'TokenCurrency' ? (
+        <ExternalLinkButton
+          primary
+          event="More info on Manage ERC20 tokens"
+          url={urls.managerERC20}
+          label={t('common.learnMore')}
+        />
+      ) : (
+        <Button primary disabled={!currency} onClick={() => transitionTo('connectDevice')}>
+          {t('common.continue')}
+        </Button>
+      )}
     </Fragment>
   )
 }


### PR DESCRIPTION
This PR replaces the `Continue` button with a `Learn more` link in the add accounts flow.

### :camera_flash: Screenshot
![image](https://user-images.githubusercontent.com/1671753/62638268-5dd69b80-b93d-11e9-9d4b-1040823b71b4.png)

### :ok_hand: Type

User Experience

### :mag: Context

LL-1743

### :clipboard: Parts of the app affected / Test plan

Add accounts > Select an ERC20 token
Also check non-ERC20 is not effected by this change