### PR TITLE
Adds double icon to stars, reworked parentcryptocurrencyicon

### DIFF
--- a/src/components/AccountPage/AccountHeader.js
+++ b/src/components/AccountPage/AccountHeader.js
@@ -102,7 +102,7 @@ const AccountHeader: React$ComponentType<Props> = React.memo(
     return (
       <Box horizontal align="center" flow={2} grow>
         <Box>
-          <ParentCryptoCurrencyIcon currency={currency} borderColor="lightGrey" />
+          <ParentCryptoCurrencyIcon currency={currency} bigger />
         </Box>
         <Box grow>
           {contract && account.type === 'TokenAccount' ? (

--- a/src/components/AccountsPage/AccountGridItem/Header.js
+++ b/src/components/AccountsPage/AccountGridItem/Header.js
@@ -57,7 +57,7 @@ class Header extends PureComponent<{
     return (
       <Box flow={4}>
         <Box horizontal ff="Open Sans|SemiBold" flow={3} alignItems="center">
-          <ParentCryptoCurrencyIcon currency={currency} parent={parentAccount} />
+          <ParentCryptoCurrencyIcon currency={currency} withTooltip />
           <HeadText name={name} title={title} />
           <AccountSyncStatusIndicator
             accountId={(parentAccount && parentAccount.id) || account.id}

--- a/src/components/AccountsPage/AccountRowItem/Header.js
+++ b/src/components/AccountsPage/AccountRowItem/Header.js
@@ -19,7 +19,7 @@ type Props = {
 // from AccountRowItem/index.js TokenBarIndicator
 const NestedIndicator = styled.div`
   height: 44px;
-  width:14px;
+  width: 14px;
 `
 
 class Header extends PureComponent<Props> {

--- a/src/components/CryptoCurrencyIcon.js
+++ b/src/components/CryptoCurrencyIcon.js
@@ -16,7 +16,6 @@ type Props = {
 // NB this is to avoid seeing the parent icon through
 const TokenIconWrapper = styled.div`
   border-radius: 4px;
-  background: white;
 `
 const TokenIcon = styled.div`
   font-size: ${p => p.size / 2}px;

--- a/src/components/ParentCryptoCurrencyIcon.js
+++ b/src/components/ParentCryptoCurrencyIcon.js
@@ -1,8 +1,7 @@
 // @flow
 import React, { PureComponent } from 'react'
 import styled from 'styled-components'
-import get from 'lodash/get'
-import type { Currency, Account } from '@ledgerhq/live-common/lib/types'
+import type { Currency } from '@ledgerhq/live-common/lib/types'
 import Tooltip from 'components/base/Tooltip'
 import Text from 'components/base/Text'
 import { Trans } from 'react-i18next'
@@ -12,15 +11,28 @@ import { rgba } from '../styles/helpers'
 
 type Props = {
   currency: Currency,
-  parent?: ?Account,
-  borderColor?: string,
+  withTooltip: boolean,
+  bigger?: boolean,
+  inactive?: boolean,
 }
 
 const ParentCryptoCurrencyIconWrapper = styled.div`
+  ${p =>
+    p.doubleIcon
+      ? `
+  > :nth-child(1) {
+    clip-path: polygon(0% 0%, 100% 0%, 100% 50%, 81% 50%, 68% 54%, 58% 63%, 52% 74%, 50% 86%, 50% 100%, 0% 100%);
+  }`
+      : `
+  display: flex;
+  align-items: center;`}
+  
+  line-height: ${p => (p.bigger ? '18px' : '18px')};
+  font-size: ${p => (p.bigger ? '12px' : '12px')};
   > :nth-child(2) {
-    margin-top: -13px;
-    margin-left: 8px;
-    border: 2px solid ${p => get(p.theme.colors, p.borderColor || 'white')};
+    margin-top: ${p => (p.bigger ? '-15px' : '-13px')};
+    margin-left: ${p => (p.bigger ? '10px' : '8px')};
+    border: 2px solid transparent;
   }
 `
 const TooltipWrapper = styled.div`
@@ -40,18 +52,20 @@ const CryptoCurrencyIconTooltip = ({ name }: { name: string }) => (
 
 class ParentCryptoCurrencyIcon extends PureComponent<Props> {
   render() {
-    const { currency, parent, borderColor } = this.props
-    const double = parent && parent.currency
-    const parentCurrency = currency.type === 'TokenCurrency' ? currency.parentCurrency : null
+    const { currency, bigger, withTooltip, inactive } = this.props
+
+    const parent = currency.type === 'TokenCurrency' ? currency.parentCurrency : null
 
     const content = (
-      <ParentCryptoCurrencyIconWrapper borderColor={borderColor}>
-        {parentCurrency && <CryptoCurrencyIcon currency={parentCurrency} size={double ? 16 : 20} />}
-        <CryptoCurrencyIcon currency={currency} size={double ? 16 : 20} />
+      <ParentCryptoCurrencyIconWrapper doubleIcon={!!parent} bigger={bigger}>
+        {parent && (
+          <CryptoCurrencyIcon inactive={inactive} currency={parent} size={bigger ? 20 : 16} />
+        )}
+        <CryptoCurrencyIcon inactive={inactive} currency={currency} size={bigger ? 20 : 16} />
       </ParentCryptoCurrencyIconWrapper>
     )
 
-    if (double && parent) {
+    if (withTooltip && parent) {
       return (
         <Tooltip render={() => <CryptoCurrencyIconTooltip name={parent.name} />}>{content}</Tooltip>
       )

--- a/src/components/Stars/Item.js
+++ b/src/components/Stars/Item.js
@@ -9,10 +9,14 @@ import { getAccountCurrency } from '@ledgerhq/live-common/lib/account/helpers'
 import type { Account, TokenAccount } from '@ledgerhq/live-common/src/types'
 import Text from 'components/base/Text'
 import FormattedVal from 'components/base/FormattedVal'
-import CryptoCurrencyIcon from '../CryptoCurrencyIcon'
+import ParentCryptoCurrencyIcon from 'components/ParentCryptoCurrencyIcon'
 import Box from '../base/Box/Box'
 
 const AccountName = styled(Text)``
+const ParentCryptoCurrencyIconWrapper = styled.div`
+  width: 20px;
+`
+
 const ItemWrapper = styled.div`
   height: 60px;
   flex: 1;
@@ -72,11 +76,9 @@ const Item = ({
           onClick={onAccountClick}
         >
           <Box horizontal ff="Open Sans|SemiBold" flex={1} flow={3} alignItems="center">
-            <CryptoCurrencyIcon
-              inactive={!active}
-              currency={getAccountCurrency(account)}
-              size={16}
-            />
+            <ParentCryptoCurrencyIconWrapper>
+              <ParentCryptoCurrencyIcon inactive={!active} currency={getAccountCurrency(account)} />
+            </ParentCryptoCurrencyIconWrapper>
             <Box vertical flex={1}>
               <AccountName color="smoke">
                 {account.type === 'Account' ? account.name : account.token.name}
@@ -89,7 +91,6 @@ const Item = ({
                 unit={account.unit || account.token.units[0]}
                 showCode
                 val={account.balance}
-                disableRounding
               />
             </Box>
           </Box>

--- a/src/components/base/CurrencyBadge.js
+++ b/src/components/base/CurrencyBadge.js
@@ -53,7 +53,7 @@ export function CurrencyCircleIcon({
   showCheckmark?: boolean,
 }) {
   if (currency.type === 'TokenCurrency') {
-    return <ParentCryptoCurrencyIcon currency={currency} size={size} />
+    return <ParentCryptoCurrencyIcon currency={currency} bigger />
   }
   const Icon = getCryptoCurrencyIcon(currency)
   return (

--- a/src/components/modals/AddAccounts/steps/02-step-connect-device.js
+++ b/src/components/modals/AddAccounts/steps/02-step-connect-device.js
@@ -23,7 +23,7 @@ function StepConnectDevice({ t, currency, device, setAppOpened }: StepProps) {
       <TrackPage category="AddAccounts" name="Step2" />
       <Box align="center" mb={6}>
         {currency.type === 'TokenCurrency' ? (
-          <ParentCryptoCurrencyIcon currency={currency} size={40} />
+          <ParentCryptoCurrencyIcon currency={currency} bigger />
         ) : (
           <CurrencyCircleIcon size={40} currency={currency} />
         )}


### PR DESCRIPTION
Reworked the way `ParentCryptoCurrencyIcon` works to no longer maintain an arbitrary size but rather a smaller and a bigger one. There used to be an erroneus use of this with a size of 40 in the add account flow but that made no sense. 

In order to fix the white border glitch on the double icon component when the background is not white we are now clipping the svg icon of the parent account. This could potentially be done better but for now it works.

Basically passing a clip path polygon to the svg element. 

<img width="372" alt="image" src="https://user-images.githubusercontent.com/4631227/62776092-de1a0f80-baa9-11e9-81ae-8400bd3123ed.png">


<img width="528" alt="image" src="https://user-images.githubusercontent.com/4631227/62776179-1faaba80-baaa-11e9-982c-c35579c41ac6.png">

Allows us to have hover/active states changing the background of the parent element without showing off a non-matching border color.

<img width="414" alt="image" src="https://user-images.githubusercontent.com/4631227/62778137-df4e3b00-baaf-11e9-98db-267fcae7ba24.png">

### Type

UI Polish