### PR TITLE
LL-1702 + LL-1791: Rates settings

### DIFF
--- a/src/components/AccountPage/AccountBalanceSummaryHeader.js
+++ b/src/components/AccountPage/AccountBalanceSummaryHeader.js
@@ -128,7 +128,7 @@ class AccountBalanceSummaryHeader extends PureComponent<Props> {
             unit={data[0].unit}
           >
             <Wrapper>
-              <div style={{ width: 'auto', marginRight: 8 }}>
+              <div style={{ width: 'auto', marginRight: 20 }}>
                 <FormattedVal
                   key={secondaryKey}
                   animateTicker

--- a/src/components/Price.js
+++ b/src/components/Price.js
@@ -74,8 +74,7 @@ const Price = ({
 
   return (
     <PriceWrapper color={color} fontSize={fontSize}>
-      <IconActivity size={12} style={{ color: activityColor }} />
-      {' '}
+      <IconActivity size={12} style={{ color: activityColor, marginRight: 4 }} />
       {!withEquality ? null : (
         <>
           <CurrencyUnitValue value={value} unit={effectiveUnit} showCode />

--- a/src/components/SelectExchange.js
+++ b/src/components/SelectExchange.js
@@ -42,7 +42,7 @@ class SelectExchange extends Component<
   },
 > {
   state = {
-    prevFromTo: '', // eslint-disable-line
+    prevFromTo: '',
     exchanges: null,
     error: null,
     isLoading: false,
@@ -101,7 +101,8 @@ class SelectExchange extends Component<
     const options = exchanges ? exchanges.map(e => ({ value: e.id, label: e.name, ...e })) : []
     const value = options.find(e => e.id === exchangeId)
 
-    return error ? (
+    // $FlowFixMe
+    return error && error.status !== 400 ? (
       <Box
         style={{ wordWrap: 'break-word', width: 250 }}
         color="alertRed"

--- a/src/components/SettingsPage/SettingsSection.js
+++ b/src/components/SettingsPage/SettingsSection.js
@@ -49,14 +49,18 @@ export function SettingsSectionHeader({
   desc,
   icon,
   renderRight,
+  onClick,
+  style,
 }: {
   title: string,
   desc: string,
   icon: any,
   renderRight?: any,
+  onClick?: () => void,
+  style?: any,
 }) {
   return (
-    <SettingsSectionHeaderContainer tabIndex={-1}>
+    <SettingsSectionHeaderContainer tabIndex={-1} onClick={onClick} style={style}>
       <RoundIconContainer mr={3}>{icon}</RoundIconContainer>
       <Box grow flex={1} mr={3}>
         <Box ff="Museo Sans|Regular" color="dark" data-e2e="settingsGeneral_title">

--- a/src/components/SettingsPage/sections/CryptoAssets/Currencies.js
+++ b/src/components/SettingsPage/sections/CryptoAssets/Currencies.js
@@ -62,10 +62,12 @@ class Currencies extends PureComponent<Props, State> {
           title={t('settings.tabs.currencies')}
           desc={t('settings.currencies.desc')}
           renderRight={
-            <Show visible={sectionVisible} onClick={this.toggleCurrencySection}>
+            <Show visible={sectionVisible}>
               <IconAngleDown size={24} />
             </Show>
           }
+          onClick={this.toggleCurrencySection}
+          style={{ cursor: 'pointer' }}
         />
         {sectionVisible && (
           <Body>

--- a/src/components/SettingsPage/sections/CryptoAssets/RateRow/index.js
+++ b/src/components/SettingsPage/sections/CryptoAssets/RateRow/index.js
@@ -39,6 +39,9 @@ export const RateRowWrapper = styled.div`
 
   > * {
     flex: 1;
+    &:nth-child(1) {
+      flex: 0.75;
+    }
     &:nth-child(2) {
       width: 300px;
     }
@@ -81,7 +84,6 @@ class RateRow extends PureComponent<Props> {
           <Ellipsis>
             <Price
               withEquality
-              withActivityColor="wallet"
               from={from}
               to={to}
               color="graphite"


### PR DESCRIPTION
* Make `Rates` setting section clickable everywhere
* Reduce size for `Rate` in rates table
* Change icon color in rates table
* Minor change to margin in `Price` component
* Hide 400 errors in settings UI

## :camera_flash: Screenshots
![2019-08-09_162050](https://user-images.githubusercontent.com/1671753/62785905-d5cdce80-bac1-11e9-8068-7c816f1bb577.png)
![2019-08-09_162004](https://user-images.githubusercontent.com/1671753/62785906-d5cdce80-bac1-11e9-8360-1dc99443c3e2.png)


## :ok_hand: Type
UI polish

### :mag: Context
LL-1702

### :clipboard: Parts of the app affected / Test plan
Settings > Crypto assets