### PR TITLE
LL-1759: Pixel push - margins edition™

### DIFF
--- a/src/components/AccountsPage/AccountsHeader.js
+++ b/src/components/AccountsPage/AccountsHeader.js
@@ -27,7 +27,7 @@ class AccountsHeader extends PureComponent<Props> {
   render() {
     const { t } = this.props
     return (
-      <Box horizontal pb={6}>
+      <Box horizontal style={{ paddingBottom: 32 }}>
         <Box grow ff="Museo Sans|Regular" fontSize={7} color="dark">
           {t('accounts.title')}
         </Box>

--- a/src/components/DashboardPage/BalanceSummary.js
+++ b/src/components/DashboardPage/BalanceSummary.js
@@ -47,7 +47,7 @@ class PortfolioBalanceSummary extends PureComponent<Props> {
   render() {
     const { portfolio, range, chartColor, chartId, Header } = this.props
     return (
-      <Card p={0} py={5}>
+      <Card p={0} py={5} style={{ marginTop: 32 }}>
         {Header ? (
           <Box px={6}>
             <Header portfolio={portfolio} />

--- a/src/components/DashboardPage/SummaryDesc.js
+++ b/src/components/DashboardPage/SummaryDesc.js
@@ -13,7 +13,7 @@ class SummaryDesc extends PureComponent<{
     const { totalAccounts, t } = this.props
     return (
       <Text
-        color="grey"
+        color="smoke"
         fontSize={5}
         ff="Museo Sans|Light"
         data-e2e="dashboard_accountsSummaryDesc"

--- a/src/components/DashboardPage/index.js
+++ b/src/components/DashboardPage/index.js
@@ -155,7 +155,6 @@ class DashboardPage extends PureComponent<Props> {
 }
 // This forces only one visible top banner at a time
 export const TopBannerContainer = styled.div`
-  margin-top: 8px;
   z-index: 19;
 
   & > *:not(:first-child) {

--- a/src/components/PartnersPage/index.js
+++ b/src/components/PartnersPage/index.js
@@ -21,7 +21,7 @@ class PartnersPage extends PureComponent<Props> {
         <Box ff="Museo Sans|Regular" fontSize={7} color="dark">
           {t('partners.title')}
         </Box>
-        <Box ff="Museo Sans|Light" fontSize={5} mb={5}>
+        <Box ff="Museo Sans|Light" fontSize={5} mb={5} color="smoke">
           {t('partners.desc')}
         </Box>
         <Box flow={3}>

--- a/src/components/TopBanner.js
+++ b/src/components/TopBanner.js
@@ -92,7 +92,7 @@ const Container = styled(Box).attrs({
   px: 3,
   bg: p => colors[p.status] || 'wallet',
   color: 'white',
-  mt: -20,
+  mt: -32,
   mb: 20,
   fontSize: 4,
   ff: 'Open Sans|SemiBold',

--- a/src/components/layout/Default.js
+++ b/src/components/layout/Default.js
@@ -47,7 +47,7 @@ const Main = styled(GrowScroll).attrs({
   px: 6,
 })`
   outline: none;
-  padding-top: ${p => p.theme.sizes.topBarHeight + p.theme.space[4]}px;
+  padding-top: ${p => p.theme.sizes.topBarHeight + p.theme.space[6]}px;
 `
 
 type Props = {


### PR DESCRIPTION
Fix some margins, with @dekkaki :tada: 

Some changes were a bit weird to make (everything is so interlocked it was hard to change one thing without everything else changing with it) so we made some quick hacks, but maybe we should rethink this?

### :camera_flash: Screenshots
![2019-08-09_172713](https://user-images.githubusercontent.com/1671753/62790312-25fd5e80-bacb-11e9-91ff-2bd6f901ea60.png)

### :ok_hand: Type
UI polish

### :mag: Context
LL-1759

### :clipboard: Parts of the app affected / Test plan
* Portfolio
  * Check banner case (i.e. migration)
* Accounts
  * Check with banner as well
* Buy crypto