### PR TITLE
LL-1747 Persist starred accounts when migrating them

### DIFF
--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -78,3 +78,8 @@ export const dragDropStarAction = (payload: {
   type: 'SETTINGS_DRAG_DROP_STAR',
   payload,
 })
+
+export const replaceStarAccountId = (payload: { oldId: string, newId: string }) => ({
+  type: 'SETTINGS_REPLACE_STAR_ID',
+  payload,
+})

--- a/src/components/GenuineCheck.js
+++ b/src/components/GenuineCheck.js
@@ -47,7 +47,7 @@ type Props = {
 type State = {
   autoRepair: boolean,
   isBootloader: boolean,
-  isRepairing: boolean
+  isRepairing: boolean,
 }
 
 const usbIcon = <IconUsb size={16} />
@@ -64,7 +64,7 @@ class GenuineCheck extends PureComponent<Props, State> {
   state = {
     isBootloader: false,
     autoRepair: false,
-    isRepairing: false
+    isRepairing: false,
   }
 
   componentWillUnmount() {
@@ -160,7 +160,7 @@ class GenuineCheck extends PureComponent<Props, State> {
 
   onDoneAutoRepair = () => this.setState({ autoRepair: false })
 
-  setRapairing = (status) => this.setState({ isRepairing: status })
+  setRapairing = status => this.setState({ isRepairing: status })
 
   renderRepair() {
     const { onSuccess, device, ...props } = this.props
@@ -235,20 +235,20 @@ class GenuineCheck extends PureComponent<Props, State> {
 
     return (
       <Fragment>
-          <DeviceInteraction
-            disabled={isRepairing}
-            key={device ? device.path : null}
-            {...props}
-            waitBeforeSuccess={500}
-            steps={steps}
-            onSuccess={onSuccess}
-            onFail={this.handleFail}
-            renderError={(error, retry) =>
-              device && isBootloader ? null : (
-                <ErrorDescContainer error={error} onRetry={retry} mt={4} />
-              )
-            }
-          />
+        <DeviceInteraction
+          disabled={isRepairing}
+          key={device ? device.path : null}
+          {...props}
+          waitBeforeSuccess={500}
+          steps={steps}
+          onSuccess={onSuccess}
+          onFail={this.handleFail}
+          renderError={(error, retry) =>
+            device && isBootloader ? null : (
+              <ErrorDescContainer error={error} onRetry={retry} mt={4} />
+            )
+          }
+        />
         {autoRepair ? <AutoRepair onDone={this.onDoneAutoRepair} /> : null}
         {this.renderRepair()}
       </Fragment>

--- a/src/components/SettingsPage/RepairDeviceButton.js
+++ b/src/components/SettingsPage/RepairDeviceButton.js
@@ -58,7 +58,7 @@ class RepairDeviceButton extends PureComponent<Props, State> {
     if (this.state.isLoading) return
     const { push, onRepair } = this.props
     if (onRepair) {
-      onRepair(true);
+      onRepair(true)
     }
     this.timeout = setTimeout(() => this.setState({ isLoading: true }), 500)
     this.sub = firmwareRepair.send({ version }).subscribe({
@@ -76,7 +76,7 @@ class RepairDeviceButton extends PureComponent<Props, State> {
           push('/manager')
         })
         if (onRepair) {
-          onRepair(false);
+          onRepair(false)
         }
       },
     })

--- a/src/components/modals/MigrateAccounts/index.js
+++ b/src/components/modals/MigrateAccounts/index.js
@@ -24,6 +24,8 @@ import StepCurrency, { StepCurrencyFooter } from './steps/03-step-currency'
 import { getCurrentDevice } from '../../../reducers/devices'
 import { replaceAccounts } from '../../../actions/accounts'
 import { closeModal } from '../../../reducers/modals'
+import { replaceStarAccountId } from '../../../actions/settings'
+import { starredAccountIdsSelector } from '../../../reducers/settings'
 
 const createSteps = () => {
   const onBack = ({ transitionTo }: StepProps) => {
@@ -52,6 +54,8 @@ const createSteps = () => {
 
 type ScanStatus = 'idle' | 'scanning' | 'error' | 'finished'
 export type StepProps = DefaultStepProps & {
+  starredAccountIds: string[],
+  replaceStarAccountId: ({ oldId: string, newId: string }) => void,
   migratableAccounts: { [key: string]: Account[] },
   migratedAccounts: { [key: string]: Account[] },
   err: ?Error,
@@ -126,12 +130,16 @@ class MigrateAccounts extends PureComponent<*, State> {
       migratableAccounts,
       totalMigratableAccounts,
       accounts,
+      starredAccountIds,
       replaceAccounts,
+      replaceStarAccountId,
     } = this.props
     const { stepId, isAppOpened, err, scanStatus, currency } = this.state
 
     const stepperProps = {
+      starredAccountIds,
       replaceAccounts,
+      replaceStarAccountId,
       migratableAccounts,
       totalMigratableAccounts,
       accounts,
@@ -176,6 +184,7 @@ class MigrateAccounts extends PureComponent<*, State> {
 const mapStateToProps = createStructuredSelector({
   device: getCurrentDevice,
   accounts: accountsSelector,
+  starredAccountIds: starredAccountIdsSelector,
   totalMigratableAccounts: state => accountsSelector(state).filter(canBeMigrated).length,
   migratableAccounts: state =>
     groupBy(accountsSelector(state).filter(canBeMigrated), 'currency.id'),
@@ -183,6 +192,7 @@ const mapStateToProps = createStructuredSelector({
 
 const mapDispatchToProps = {
   replaceAccounts,
+  replaceStarAccountId,
   closeModal,
 }
 export default compose(

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -152,6 +152,12 @@ const handlers: Object = {
       starredAccountIds: ids,
     }
   },
+  SETTINGS_REPLACE_STAR_ID: (state: SettingsState, { payload: { oldId, newId } }) => ({
+    ...state,
+    starredAccountIds: state.starredAccountIds.map(starredAccountId =>
+      starredAccountId === oldId ? newId : starredAccountId,
+    ),
+  }),
   // used to debug performance of redux updates
   DEBUG_TICK: state => ({ ...state }),
 }


### PR DESCRIPTION
This should allow to persist the starred account when we do the migration. Not the prettiest code but until we have a nicer solution this should be enough.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1747

### Parts of the app affected / Test plan
Make sure that migration with.without starred accounts is not broken now. According to my testing it's all good :trollface: 

---------

**Note** the extra non related changes are triggered by prettier. These have passed out ci so something is wrong on that end. Until we get that fixed.... things like this will happen.