### PR TITLE
LL-1764: export from Account page

### DIFF
--- a/src/components/AccountPage/AccountHeaderActions.js
+++ b/src/components/AccountPage/AccountHeaderActions.js
@@ -31,13 +31,13 @@ const ButtonSettings = styled(Tabbable).attrs({
 })`
   width: 34px;
   height: 34px;
-  border:1px solid ${p => p.theme.colors.grey};
-  border-radius:4px;
+  border: 1px solid ${p => p.theme.colors.grey};
+  border-radius: 4px;
   &:hover {
     color: ${p => (p.disabled ? '' : p.theme.colors.dark)};
     background: ${p => (p.disabled ? '' : rgba(p.theme.colors.fog, 0.2))};
-    border-color:${p => p.theme.colors.dark};
-  
+    border-color: ${p => p.theme.colors.dark};
+  }
 
   &:active {
     background: ${p => (p.disabled ? '' : rgba(p.theme.colors.fog, 0.3))};

--- a/src/components/AccountsPage/AccountsHeader.js
+++ b/src/components/AccountsPage/AccountsHeader.js
@@ -1,14 +1,17 @@
 // @flow
 
 import React, { PureComponent } from 'react'
-import Box from 'components/base/Box'
 import { compose } from 'redux'
 import { T, translate } from 'react-i18next'
 import { connect } from 'react-redux'
+
 import IconPlus from 'icons/Plus'
+import Box from 'components/base/Box'
 import Button from 'components/base/Button'
 import { openModal } from 'reducers/modals'
-import { MODAL_ADD_ACCOUNTS } from '../../config/constants'
+import { MODAL_ADD_ACCOUNTS } from 'config/constants'
+
+import OptionsButton from './OptionsButton'
 
 type Props = {
   t: T,
@@ -31,13 +34,14 @@ class AccountsHeader extends PureComponent<Props> {
         <Box grow ff="Museo Sans|Regular" fontSize={7} color="dark">
           {t('accounts.title')}
         </Box>
-        <Box>
+        <Box horizontal flow={2} alignItems="center" justifyContent="flex-end">
           <Button small primary onClick={this.handleAddAccountModal}>
             <Box horizontal flow={1} alignItems="center">
               <IconPlus size={12} />
               <Box>{t('addAccounts.cta.add')}</Box>
             </Box>
           </Button>
+          <OptionsButton />
         </Box>
       </Box>
     )

--- a/src/components/AccountsPage/OptionsButton.js
+++ b/src/components/AccountsPage/OptionsButton.js
@@ -1,0 +1,174 @@
+// @flow
+
+import React, { PureComponent } from 'react'
+import { compose } from 'redux'
+import { connect } from 'react-redux'
+import { createStructuredSelector } from 'reselect'
+import styled from 'styled-components'
+import { T, translate } from 'react-i18next'
+
+import Box from 'components/base/Box'
+import Button from 'components/base/Button'
+import Switch from 'components/base/Switch'
+import Tooltip from 'components/base/Tooltip'
+import DropDown, { DropDownItem } from 'components/base/DropDown'
+import ExportAccountsModal from 'components/SettingsPage/ExportAccountsModal'
+import Track from 'analytics/Track'
+
+import { setHideEmptyTokenAccounts } from 'actions/settings'
+import { hideEmptyTokenAccountsSelector } from 'reducers/settings'
+import { openModal } from 'reducers/modals'
+
+import { MODAL_EXPORT_OPERATIONS } from 'config/constants'
+
+import IconDots from 'icons/Dots'
+import IconDownloadCloud from 'icons/DownloadCloud'
+import IconSend from 'icons/Send'
+
+const Separator = styled.div`
+  background-color: ${p => p.theme.colors.lightFog};
+  height: 1px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+`
+
+const Item = styled(DropDownItem)`
+  width: 230px;
+  cursor: pointer;
+  white-space: pre-wrap;
+  background-color: ${p => !p.disableHover && p.isHighlighted && p.theme.colors.lightGrey};
+`
+
+type StateProps = {|
+  hideEmptyTokenAccounts: boolean,
+|}
+
+type DispatchProps = {|
+  setHideEmptyTokenAccounts: boolean => any,
+  openModal: (string, any) => any,
+|}
+
+type OwnProps = {|
+  t: T,
+|}
+
+type Props = {|
+  ...OwnProps,
+  ...DispatchProps,
+  ...StateProps,
+|}
+
+type State = {|
+  isModalOpened: boolean,
+|}
+
+const mapDispatchToProps: DispatchProps = {
+  setHideEmptyTokenAccounts,
+  openModal,
+}
+
+const mapStateToProps: StateProps = createStructuredSelector({
+  hideEmptyTokenAccounts: hideEmptyTokenAccountsSelector,
+})
+
+class OptionsButton extends PureComponent<Props, State> {
+  state = {
+    isModalOpened: false,
+  }
+
+  items = [
+    {
+      key: 'exportOperations',
+      label: this.props.t('accounts.optionsMenu.exportOperations'),
+      icon: <IconDownloadCloud size={12} />,
+      onClick: () => this.props.openModal(MODAL_EXPORT_OPERATIONS),
+    },
+    {
+      key: 'exportAccounts',
+      label: this.props.t('accounts.optionsMenu.exportToMobile'),
+      icon: <IconSend size={12} />,
+      onClick: () => this.setState({ isModalOpened: true }),
+    },
+    {
+      key: 'sep1',
+      type: 'separator',
+      label: '',
+    },
+    {
+      key: 'hideEmpty',
+      label: this.props.t('settings.accounts.hideEmptyTokens.title'),
+      onClick: (e: MouseEvent) => {
+        e.preventDefault()
+        this.props.setHideEmptyTokenAccounts(!this.props.hideEmptyTokenAccounts)
+      },
+    },
+  ]
+
+  renderItem = ({ item, isHighlighted }) => {
+    if (item.type === 'separator') {
+      return <Separator />
+    }
+
+    return (
+      <Item
+        horizontal
+        alignItems="center"
+        justifyContent="flex-start"
+        isHighlighted={isHighlighted}
+        flow={2}
+        onClick={item.onClick}
+        disableHover={item.key === 'hideEmpty'}
+      >
+        {item.key === 'hideEmpty' ? (
+          <Box mr={4}>
+            <Track
+              onUpdate
+              event={
+                this.props.hideEmptyTokenAccounts
+                  ? 'hideEmptyTokenAccountsEnabled'
+                  : 'hideEmptyTokenAccountsDisabled'
+              }
+            />
+            <Switch
+              isChecked={this.props.hideEmptyTokenAccounts}
+              onChange={this.props.setHideEmptyTokenAccounts}
+            />
+          </Box>
+        ) : item.icon ? (
+          <Box mr={4}>{item.icon}</Box>
+        ) : null}
+        {item.label}
+      </Item>
+    )
+  }
+
+  render() {
+    const { isModalOpened } = this.state
+
+    return (
+      <>
+        <DropDown horizontal offsetTop={2} items={this.items} renderItem={this.renderItem}>
+          <Tooltip render={() => this.props.t('accounts.optionsMenu.title')}>
+            <Button small outlineGrey flow={1} style={{ width: 34, padding: 0 }}>
+              <Box horizontal flow={1} alignItems="center" justifyContent="center">
+                <IconDots size={14} />
+              </Box>
+            </Button>
+          </Tooltip>
+        </DropDown>
+        <ExportAccountsModal
+          isOpen={isModalOpened}
+          onClose={() => this.setState({ isModalOpened: false })}
+        />
+      </>
+    )
+  }
+}
+
+export default compose(
+  translate(),
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+)(OptionsButton)

--- a/src/components/SettingsPage/ExportAccountsModal.js
+++ b/src/components/SettingsPage/ExportAccountsModal.js
@@ -1,0 +1,136 @@
+// @flow
+
+import React from 'react'
+import styled from 'styled-components'
+
+import type { T } from 'types/common'
+import { Trans, translate } from 'react-i18next'
+
+import Modal from 'components/base/Modal'
+import ModalBody from 'components/base/Modal/ModalBody'
+import Box from 'components/base/Box'
+import Button from 'components/base/Button'
+import QRCodeExporter from 'components/QRCodeExporter'
+import { BulletRow } from 'components/Onboarding/helperComponents'
+import Text from 'components/base/Text'
+
+type OwnProps = {|
+  isOpen: boolean,
+  onClose: () => void,
+|}
+
+type Props = {|
+  t: T,
+  ...OwnProps,
+|}
+
+const BulletRowIcon = styled(Box).attrs({
+  ff: 'Rubik|Regular',
+  fontSize: 10,
+  textAlign: 'center',
+  color: 'wallet',
+  pl: 2,
+})`
+  background-color: rgba(100, 144, 241, 0.1);
+  border-radius: 12px;
+  display: inline-flex;
+  height: 18px;
+  width: 18px;
+  padding: 0px;
+  padding-top: 2px;
+`
+
+const ExportAccountsModal = ({ isOpen, onClose, t }: Props) => (
+  <Modal
+    isOpened={isOpen}
+    onClose={onClose}
+    render={({ onClose }: any) => {
+      const stepsImportMobile = [
+        {
+          key: 'step1',
+          icon: <BulletRowIcon>{'1'}</BulletRowIcon>,
+          desc: (
+            <Box style={{ display: 'block' }}>
+              <Trans i18nKey="settings.export.modal.step1">
+                {'Tap the'}
+                <Text ff="Open Sans|SemiBold" color="dark">
+                  {'+'}
+                </Text>
+                {'button in'}
+                <Text ff="Open Sans|SemiBold" color="dark">
+                  {'Accounts'}
+                </Text>
+              </Trans>
+            </Box>
+          ),
+        },
+        {
+          key: 'step2',
+          icon: <BulletRowIcon>{'2'}</BulletRowIcon>,
+          desc: (
+            <Box style={{ display: 'block' }}>
+              <Trans i18nKey="settings.export.modal.step2">
+                {'Tap'}
+                <Text ff="Open Sans|SemiBold" color="dark">
+                  {'Import desktop accounts'}
+                </Text>
+              </Trans>
+            </Box>
+          ),
+        },
+        {
+          key: 'step3',
+          icon: <BulletRowIcon>{'3'}</BulletRowIcon>,
+          desc: (
+            <Box style={{ display: 'block' }}>
+              <Trans i18nKey="settings.export.modal.step3">
+                {'Scan the'}
+                <Text ff="Open Sans|SemiBold" color="dark">
+                  {'LiveQR Code'}
+                </Text>
+                {'until the loader hits 100%'}
+              </Trans>
+            </Box>
+          ),
+        },
+      ]
+
+      return (
+        <ModalBody
+          onClose={onClose}
+          title={t('settings.export.modal.title')}
+          render={() => (
+            <Box justify="center" align="center">
+              <Box flow={2}>
+                <QRCodeExporter size={330} />
+              </Box>
+              <Box shrink style={{ width: 330, fontSize: 13, marginTop: 20 }}>
+                <Text ff="Open Sans|SemiBold" color="dark">
+                  {t('settings.export.modal.listTitle')}
+                </Text>
+              </Box>
+              <Box style={{ width: 330 }}>
+                {stepsImportMobile.map(step => (
+                  <BulletRow key={step.key} step={step} />
+                ))}
+              </Box>
+            </Box>
+          )}
+          renderFooter={() => (
+            <Box>
+              <Button small onClick={onClose} primary>
+                {t('settings.export.modal.button')}
+              </Button>
+            </Box>
+          )}
+        />
+      )
+    }}
+  />
+)
+
+// prettier-ignore
+export default React.memo<OwnProps>(
+  translate()(ExportAccountsModal),
+  (prev, next) => prev.isOpen === next.isOpen
+)

--- a/src/components/SettingsPage/sections/Accounts/Export.js
+++ b/src/components/SettingsPage/sections/Accounts/Export.js
@@ -1,40 +1,18 @@
 // @flow
 
 import React, { PureComponent } from 'react'
-import { Trans, translate } from 'react-i18next'
+import { translate } from 'react-i18next'
 
 import type { T } from 'types/common'
 
-import styled from 'styled-components'
 import { SettingsSectionHeader as Header } from '../../SettingsSection'
 import { EXPERIMENTAL_WS_EXPORT } from '../../../../config/constants'
 import IconShare from '../../../../icons/Share'
 import Button from '../../../base/Button'
-import Modal from '../../../base/Modal'
-import ModalBody from '../../../base/Modal/ModalBody'
-import Box from '../../../base/Box'
-import QRCodeExporter from '../../../QRCodeExporter'
-import { BulletRow } from '../../../Onboarding/helperComponents'
-import Text from '../../../base/Text'
 import SocketExport from '../../SocketExport'
 import ExportOperationsBtn from '../../../ExportOperationsBtn'
 import DownloadCloud from '../../../../icons/DownloadCloud'
-
-const BulletRowIcon = styled(Box).attrs({
-  ff: 'Rubik|Regular',
-  fontSize: 10,
-  textAlign: 'center',
-  color: 'wallet',
-  pl: 2,
-})`
-  background-color: rgba(100, 144, 241, 0.1);
-  border-radius: 12px;
-  display: inline-flex;
-  height: 18px;
-  width: 18px;
-  padding: 0px;
-  padding-top: 2px;
-`
+import ExportAccountsModal from '../../ExportAccountsModal'
 
 type Props = {
   t: T,
@@ -55,90 +33,6 @@ class SectionExport extends PureComponent<Props, State> {
 
   onModalClose = () => {
     this.setState({ isModalOpened: false })
-  }
-
-  renderModal = ({ onClose }: any) => {
-    const { t } = this.props
-    const stepsImportMobile = [
-      {
-        key: 'step1',
-        icon: <BulletRowIcon>{'1'}</BulletRowIcon>,
-        desc: (
-          <Box style={{ display: 'block' }}>
-            <Trans i18nKey="settings.export.modal.step1">
-              {'Tap the'}
-              <Text ff="Open Sans|SemiBold" color="dark">
-                {'+'}
-              </Text>
-              {'button in'}
-              <Text ff="Open Sans|SemiBold" color="dark">
-                {'Accounts'}
-              </Text>
-            </Trans>
-          </Box>
-        ),
-      },
-      {
-        key: 'step2',
-        icon: <BulletRowIcon>{'2'}</BulletRowIcon>,
-        desc: (
-          <Box style={{ display: 'block' }}>
-            <Trans i18nKey="settings.export.modal.step2">
-              {'Tap'}
-              <Text ff="Open Sans|SemiBold" color="dark">
-                {'Import desktop accounts'}
-              </Text>
-            </Trans>
-          </Box>
-        ),
-      },
-      {
-        key: 'step3',
-        icon: <BulletRowIcon>{'3'}</BulletRowIcon>,
-        desc: (
-          <Box style={{ display: 'block' }}>
-            <Trans i18nKey="settings.export.modal.step3">
-              {'Scan the'}
-              <Text ff="Open Sans|SemiBold" color="dark">
-                {'LiveQR Code'}
-              </Text>
-              {'until the loader hits 100%'}
-            </Trans>
-          </Box>
-        ),
-      },
-    ]
-
-    return (
-      <ModalBody
-        onClose={onClose}
-        title={t('settings.export.modal.title')}
-        render={() => (
-          <Box justify="center" align="center">
-            <Box flow={2}>
-              <QRCodeExporter size={330} />
-            </Box>
-            <Box shrink style={{ width: 330, fontSize: 13, marginTop: 20 }}>
-              <Text ff="Open Sans|SemiBold" color="dark">
-                {t('settings.export.modal.listTitle')}
-              </Text>
-            </Box>
-            <Box style={{ width: 330 }}>
-              {stepsImportMobile.map(step => (
-                <BulletRow key={step.key} step={step} />
-              ))}
-            </Box>
-          </Box>
-        )}
-        renderFooter={() => (
-          <Box>
-            <Button small onClick={onClose} primary>
-              {t('settings.export.modal.button')}
-            </Button>
-          </Box>
-        )}
-      />
-    )
   }
 
   render() {
@@ -172,7 +66,7 @@ class SectionExport extends PureComponent<Props, State> {
             renderRight={<SocketExport />}
           />
         )}
-        <Modal isOpened={isModalOpened} onClose={this.onModalClose} render={this.renderModal} />
+        <ExportAccountsModal isOpen={isModalOpened} onClose={this.onModalClose} />
       </>
     )
   }

--- a/src/components/base/Button/index.js
+++ b/src/components/base/Button/index.js
@@ -115,6 +115,7 @@ const buttonStyles: { [_: string]: Style } = {
       background: transparent;
       border: 1px solid ${p.theme.colors.grey};
       color: ${p.theme.colors.grey};
+      box-shadow: ${p.isFocused ? focusedShadowStyle : ''}
     `,
     active: p => `
       color: ${darken(p.theme.colors.grey, 0.1)};

--- a/src/icons/Dots.js
+++ b/src/icons/Dots.js
@@ -1,0 +1,21 @@
+// @flow
+
+import React from 'react'
+
+const path = (
+  <path
+    d="M9 3a1 1 0 110-2 1 1 0 010 2zm7 0a1 1 0 110-2 1 1 0 010 2zM2 3a1 1 0 110-2 1 1 0 010 2z"
+    stroke="currentColor"
+    strokeWidth="2"
+    fill="currentColor"
+    fillRule="evenodd"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  />
+)
+
+export default ({ size, ...p }: { size: number }) => (
+  <svg viewBox="0 0 18 4" height={size} width={size} {...p}>
+    {path}
+  </svg>
+)

--- a/src/icons/DownloadCloud.js
+++ b/src/icons/DownloadCloud.js
@@ -6,7 +6,7 @@ const path = (
   <g
     fill="none"
     fillRule="evenodd"
-    stroke="#6490F1"
+    stroke="currentColor"
     strokeLinecap="round"
     strokeLinejoin="round"
     strokeWidth={1.5}
@@ -16,8 +16,8 @@ const path = (
   </g>
 )
 
-export default ({ width = 18, height = 15, ...p }: { width?: number, height?: number }) => (
-  <svg viewBox="0 0 18 15" height={height} width={width} {...p}>
+export default ({ size, ...p }: { size: number }) => (
+  <svg viewBox="0 0 18 15" height={size} width={size} {...p}>
     {path}
   </svg>
 )

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -146,6 +146,11 @@
       "month": "Month",
       "year": "Year"
     },
+    "optionsMenu": {
+      "title": "Options",
+      "exportOperations": "Export operation history",
+      "exportToMobile": "Export to mobile"
+    },
     "contextMenu": {
       "star": "Star",
       "receive": "Receive",


### PR DESCRIPTION
This PR allows exporting from the Accounts page. It also allows toggling "hide empty token accounts" directly from there.

### :camera_flash: Screenshot
![https://uplr.it/8febe.png](https://uplr.it/8febe.png)

### :ok_hand: Type
Feature

### :mag: Context
LL-1764

### :clipboard: Parts of the app affected / Test plan
* Account page
* Settings -> Export accounts