### PR TITLE
LL-1819 Sort accounts by currency for migrations

### DIFF
--- a/src/components/modals/MigrateAccounts/index.js
+++ b/src/components/modals/MigrateAccounts/index.js
@@ -8,11 +8,9 @@ import { connect } from 'react-redux'
 import { translate } from 'react-i18next'
 import { compose } from 'redux'
 import { createStructuredSelector } from 'reselect'
-import { accountsSelector } from 'reducers/accounts'
-import groupBy from 'lodash/groupBy'
+import { migratableAccountsSelector, accountsSelector } from 'reducers/accounts'
 import logger from 'logger'
 import { getCryptoCurrencyById } from '@ledgerhq/live-common/lib/currencies'
-import { canBeMigrated } from '@ledgerhq/live-common/lib/account'
 import type { Account } from '@ledgerhq/live-common/lib/types/account'
 import type { CryptoCurrency } from '@ledgerhq/live-common/src/types'
 import type { Device } from 'types/common'
@@ -56,7 +54,8 @@ type ScanStatus = 'idle' | 'scanning' | 'error' | 'finished' | 'finished-empty'
 export type StepProps = DefaultStepProps & {
   starredAccountIds: string[],
   replaceStarAccountId: ({ oldId: string, newId: string }) => void,
-  migratableAccounts: { [key: string]: Account[] },
+  currencyIds: string[],
+  migratableAccounts: Account[],
   migratedAccounts: { [key: string]: Account[] },
   err: ?Error,
   accounts: Account[],
@@ -109,11 +108,10 @@ class MigrateAccounts extends PureComponent<*, State> {
     this.setState({ scanStatus, err })
   }
   getNextCurrency = () => {
-    const { migratableAccounts } = this.props
+    const { currencyIds } = this.props
     this.hideLoopNotice = false
     const { currency } = this.state
-    const ids = Object.keys(migratableAccounts)
-    const nextCurrencyId = ids[ids.indexOf(currency && currency.id) + 1]
+    const nextCurrencyId = currencyIds[currencyIds.indexOf(currency && currency.id) + 1]
     return (nextCurrencyId && getCryptoCurrencyById(nextCurrencyId)) || null
   }
   handleMoveToNextCurrency = (forceNull: boolean = false) => {
@@ -128,7 +126,7 @@ class MigrateAccounts extends PureComponent<*, State> {
     const {
       device,
       migratableAccounts,
-      totalMigratableAccounts,
+      currencyIds,
       accounts,
       starredAccountIds,
       replaceAccounts,
@@ -141,7 +139,7 @@ class MigrateAccounts extends PureComponent<*, State> {
       replaceAccounts,
       replaceStarAccountId,
       migratableAccounts,
-      totalMigratableAccounts,
+      currencyIds,
       accounts,
       device,
       currency,
@@ -185,9 +183,11 @@ const mapStateToProps = createStructuredSelector({
   device: getCurrentDevice,
   accounts: accountsSelector,
   starredAccountIds: starredAccountIdsSelector,
-  totalMigratableAccounts: state => accountsSelector(state).filter(canBeMigrated).length,
-  migratableAccounts: state =>
-    groupBy(accountsSelector(state).filter(canBeMigrated), 'currency.id'),
+  migratableAccounts: migratableAccountsSelector,
+  currencyIds: state =>
+    migratableAccountsSelector(state)
+      .reduce((c, a) => (c.includes(a.currency.id) ? c : [...c, a.currency.id]), [])
+      .sort(),
 })
 
 const mapDispatchToProps = {

--- a/src/components/modals/MigrateAccounts/steps/01-step-overview.js
+++ b/src/components/modals/MigrateAccounts/steps/01-step-overview.js
@@ -105,108 +105,104 @@ const TextWrap = styled(Box)`
   display: inline;
 `
 
-const StepOverview = ({ migratableAccounts, currency, totalMigratableAccounts }: StepProps) => {
-  const migratableCurrencyIds = Object.keys(migratableAccounts)
+const StepOverview = ({ migratableAccounts, currency, currencyIds }: StepProps) => (
+  <Box align="center">
+    <TrackPage category="MigrateAccounts" name="Step1" />
 
-  return (
-    <Box align="center">
-      <TrackPage category="MigrateAccounts" name="Step1" />
-
-      <Logo>
-        <LedgerLiveLogo
-          width="58px"
-          height="58px"
-          icon={<img src={i('ledgerlive-logo.svg')} alt="" width={35} height={35} />}
+    <Logo>
+      <LedgerLiveLogo
+        width="58px"
+        height="58px"
+        icon={<img src={i('ledgerlive-logo.svg')} alt="" width={35} height={35} />}
+      />
+    </Logo>
+    <Title>
+      <Text ff="Museo Sans|Regular" fontSize={6} color="dark">
+        <Trans
+          i18nKey={
+            !migratableAccounts.length
+              ? 'migrateAccounts.overview.done'
+              : 'migrateAccounts.overview.title'
+          }
         />
-      </Logo>
-      <Title>
-        <Text ff="Museo Sans|Regular" fontSize={6} color="dark">
-          <Trans
-            i18nKey={
-              !totalMigratableAccounts
-                ? 'migrateAccounts.overview.done'
-                : 'migrateAccounts.overview.title'
-            }
-          />
+      </Text>
+    </Title>
+    {migratableAccounts.length ? (
+      <>
+        <Text color="graphite" ff="Open Sans|Regular" fontSize={4}>
+          <Trans i18nKey="migrateAccounts.overview.description" />
         </Text>
-      </Title>
-      {totalMigratableAccounts ? (
-        <>
-          <Text color="graphite" ff="Open Sans|Regular" fontSize={4}>
-            <Trans i18nKey="migrateAccounts.overview.description" />
-          </Text>
 
-          {migratableAccounts && (
-            <Wrapper>
-              {!currency ? (
-                <NextDeviceWarning>
-                  <IconExclamationCircle size={16} />
-                  <TextWrap ff="Open Sans|Bold" fontSize={4}>
+        {migratableAccounts && (
+          <Wrapper>
+            {!currency ? (
+              <NextDeviceWarning>
+                <IconExclamationCircle size={16} />
+                <TextWrap ff="Open Sans|Bold" fontSize={4}>
+                  <Text>
+                    <Trans
+                      i18nKey="migrateAccounts.overview.pendingDevices"
+                      count={migratableAccounts.length}
+                      values={{ totalMigratableAccounts: migratableAccounts.length }}
+                    />
+                  </Text>
+                  <HelpLink onClick={() => openURL(urls.migrateAccounts)}>
                     <Text>
-                      <Trans
-                        i18nKey="migrateAccounts.overview.pendingDevices"
-                        count={totalMigratableAccounts}
-                        values={{ totalMigratableAccounts }}
-                      />
+                      <Trans i18nKey="common.needHelp" />
                     </Text>
-                    <HelpLink onClick={() => openURL(urls.migrateAccounts)}>
-                      <Text>
-                        <Trans i18nKey="common.needHelp" />
-                      </Text>
-                      <IconExternalLink size={14} />
-                    </HelpLink>
-                  </TextWrap>
-                </NextDeviceWarning>
-              ) : null}
-              {migratableCurrencyIds.map(currencyId => {
-                const accounts = migratableAccounts[currencyId]
-                return (
-                  <Currency key={currencyId}>
-                    <Text color="dark" ff="Open Sans|SemiBold" fontSize={4}>
-                      <Trans
-                        i18nKey="migrateAccounts.overview.currency"
-                        count={accounts.length}
-                        values={{
-                          currency: accounts[0].currency.name,
-                          accounts: accounts.length,
-                        }}
+                    <IconExternalLink size={14} />
+                  </HelpLink>
+                </TextWrap>
+              </NextDeviceWarning>
+            ) : null}
+            {currencyIds.map(currencyId => {
+              const accounts = migratableAccounts.filter(a => a.currency.id === currencyId)
+              return (
+                <Currency key={currencyId}>
+                  <Text color="dark" ff="Open Sans|SemiBold" fontSize={4}>
+                    <Trans
+                      i18nKey="migrateAccounts.overview.currency"
+                      count={accounts.length}
+                      values={{
+                        currency: accounts[0].currency.name,
+                        accounts: accounts.length,
+                      }}
+                    />
+                  </Text>
+                  <AccountsWrapper>
+                    {accounts.map(account => (
+                      <AccountRow
+                        isReadonly
+                        key={account.id}
+                        account={account}
+                        accountName={account.name}
                       />
-                    </Text>
-                    <AccountsWrapper>
-                      {accounts.map(account => (
-                        <AccountRow
-                          isReadonly
-                          key={account.id}
-                          account={account}
-                          accountName={account.name}
-                        />
-                      ))}
-                    </AccountsWrapper>
-                  </Currency>
-                )
-              })}
-            </Wrapper>
-          )}
-        </>
-      ) : null}
-    </Box>
-  )
-}
+                    ))}
+                  </AccountsWrapper>
+                </Currency>
+              )
+            })}
+          </Wrapper>
+        )}
+      </>
+    ) : null}
+  </Box>
+)
 
 export default StepOverview
 
 export const StepOverviewFooter = ({
   transitionTo,
   t,
+  currencyIds,
   migratableAccounts,
-  totalMigratableAccounts,
   currency,
   moveToNextCurrency,
   hideLoopNotice,
   onCloseModal,
 }: StepProps) => (
   <Fragment>
-    {!totalMigratableAccounts ? (
+    {!migratableAccounts.length ? (
       <FooterContent>
         <Button primary onClick={onCloseModal}>
           {t('common.done')}
@@ -237,7 +233,7 @@ export const StepOverviewFooter = ({
         </Box>
         <Box horizontal align="center" justify="flex-end" flow={2}>
           <Button
-            disabled={!Object.keys(migratableAccounts).length}
+            disabled={!currencyIds.length}
             primary
             onClick={async () => {
               transitionTo('device')

--- a/src/components/modals/MigrateAccounts/steps/03-step-currency.js
+++ b/src/components/modals/MigrateAccounts/steps/03-step-currency.js
@@ -189,11 +189,11 @@ class StepCurrency extends PureComponent<Props> {
 export const StepCurrencyFooter = ({
   transitionTo,
   scanStatus,
-  migratableAccounts,
+  currencyIds,
   moveToNextCurrency,
   getNextCurrency,
   currency,
-  totalMigratableAccounts,
+  migratableAccounts,
 }: StepProps) => {
   if (scanStatus === 'error') {
     return (
@@ -204,14 +204,14 @@ export const StepCurrencyFooter = ({
     )
   }
   if (!['finished', 'finished-empty'].includes(scanStatus) || !currency) return null
-  const lastCurrency = last(Object.keys(migratableAccounts))
+  const lastCurrency = last(currencyIds)
   const next = lastCurrency !== currency.id && currency.id < lastCurrency ? 'device' : 'overview'
   const nextCurrency = getNextCurrency()
   return (
     <Button
       primary
       onClick={() => {
-        if (!totalMigratableAccounts) {
+        if (!migratableAccounts.length) {
           transitionTo('overview')
         } else {
           moveToNextCurrency(next === 'overview')

--- a/src/components/modals/OperationDetails.js
+++ b/src/components/modals/OperationDetails.js
@@ -422,23 +422,22 @@ const OperationDetails = connect(
             <Box horizontal>
               <OpDetailsTitle>{t('operationDetails.to')}</OpDetailsTitle>
               {recipients.length > 1 ? (
-              <Link>
-                <FakeLink
-                  underline
-                  fontSize={3}
-                  ml={2}
-                  color="smoke"
-                  onClick={() => openURL(urls.multipleDestinationAddresses)}
-                  iconFirst
-                >
-                  <Box mr={1}>
-                    <IconExternalLink size={12} />
-                  </Box>
-                  {t('operationDetails.multipleAddresses')}
-                </FakeLink>
-              </Link>
-              )
-                : null}
+                <Link>
+                  <FakeLink
+                    underline
+                    fontSize={3}
+                    ml={2}
+                    color="smoke"
+                    onClick={() => openURL(urls.multipleDestinationAddresses)}
+                    iconFirst
+                  >
+                    <Box mr={1}>
+                      <IconExternalLink size={12} />
+                    </Box>
+                    {t('operationDetails.multipleAddresses')}
+                  </FakeLink>
+                </Link>
+              ) : null}
             </Box>
             <DataList lines={recipients} t={t} />
           </Box>

--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -113,6 +113,8 @@ export const accountSelector = createSelector(
   (accounts, accountId) => accounts.find(a => a.id === accountId),
 )
 
+export const migratableAccountsSelector = (s: *): Account[] => s.accounts.filter(canBeMigrated)
+
 export const starredAccountsSelector = createSelector(
   accountsSelector,
   starredAccountIdsSelector,


### PR DESCRIPTION
Ideally this should show no different behaviour from the current migration flow, but it should prevent the edgecase where we would be eternally looping a currency instead of iterating through them. For now, this is not an issue since we remove ETC but we should revisit it if we ever allow ETC migrations.

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1819

### Parts of the app affected / Test plan

Full migration flow
