### PR TITLE
LL-1564: Fix graph date display

### DIFF
--- a/src/components/base/Chart/helpers.js
+++ b/src/components/base/Chart/helpers.js
@@ -5,7 +5,10 @@ export function enrichData(data) {
     ...d,
     ref: d,
     index: i,
-    parsedDate: d.date,
+    // normalize all dates to start of day for graph display to prevent d3 from
+    // rounding up
+    // see https://github.com/LedgerHQ/ledger-live-desktop/issues/2266
+    parsedDate: new Date(d.date).setHours(0, 0, 0, 0),
   }))
 }
 


### PR DESCRIPTION
This PR is an attempt to fix the display of graph dates. The issue is that most dates we have end on 23:59:59 and for some inexplicable reason d3 seems to round up when sending data to `tickFormat`...

![2019-08-21_150430](https://user-images.githubusercontent.com/1671753/63434529-94281680-c425-11e9-958f-601fc364b704.png)

### :ok_hand: Type
Bug fix

### :mag: Context
Fixes #2266
LL-1564

### :clipboard: Parts of the app affected / Test plan
All graphs with a visible tick scale:
* Portfolio
* Account page
