### PR TITLE
LL-1481 Prevent backdrop click on import step of add account

### DIFF
--- a/src/components/modals/AddAccounts/index.js
+++ b/src/components/modals/AddAccounts/index.js
@@ -256,6 +256,7 @@ class AddAccounts extends PureComponent<Props, State> {
         refocusWhenChange={stepId}
         onHide={() => this.setState({ ...INITIAL_STATE })}
         onBeforeOpen={this.handleBeforeOpen}
+        preventBackdropClick={stepId === 'import'}
         render={({ onClose }) => (
           <Stepper
             key={reset} // THIS IS A HACK because stepper is not controllable. FIXME


### PR DESCRIPTION
Prevent backdrop click on the import step of the add account flow.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/63435518-53310180-c427-11e9-8ad0-0d46b75ba6c7.png)

### Type

UX Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1481

### Parts of the app affected / Test plan

Go through the add account flow and try to dismiss the modal in the import step, it should **not** allow dismissal.
