### PR TITLE
Fix the repair process for FW 1.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ xliffs/
 /build/linux/arch/*.tar.xz
 
 /test-e2e/sync/data/actual_app.json
+
+.yalc
+yalc.lock

--- a/src/components/base/Modal/RepairModal.js
+++ b/src/components/base/Modal/RepairModal.js
@@ -4,6 +4,7 @@ import React, { PureComponent } from 'react'
 import { translate } from 'react-i18next'
 import styled from 'styled-components'
 import { repairChoices } from '@ledgerhq/live-common/lib/hw/firmwareUpdate-repair'
+import { MCUNotGenuineToDashboard } from '@ledgerhq/errors'
 import type { T } from 'types/common'
 import TrackPage from 'analytics/TrackPage'
 import IconCheck from 'icons/Check'
@@ -108,8 +109,8 @@ const ErrorStep = ({ error }: { error: Error }) => (
       </Box>
       <Box
         color="graphite"
-        mt={4}
-        fontSize={6}
+        mt={3}
+        fontSize={4}
         ff="Open Sans"
         textAlign="center"
         style={{ maxWidth: 350 }}
@@ -170,6 +171,8 @@ class RepairModal extends PureComponent<Props, *> {
     } = this.props
     const { selectedOption } = this.state
     const onClose = !cancellable && isLoading ? undefined : onReject
+    const disableRepair =
+      isLoading || !selectedOption || (error && error instanceof MCUNotGenuineToDashboard)
 
     return (
       <Modal
@@ -219,7 +222,7 @@ class RepairModal extends PureComponent<Props, *> {
                   primary={!isDanger}
                   danger={isDanger}
                   isLoading={isLoading}
-                  disabled={isLoading || !selectedOption}
+                  disabled={disableRepair}
                 >
                   {t('settings.repairDevice.button')}
                 </Button>

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -1184,6 +1184,10 @@
     "UnknownMCU": {
       "title": "Unknown MCU version",
       "description": "Please contact Ledger Support"
+    },
+    "MCUNotGenuineToDashboard": {
+      "title": "Access dashboard to update",
+      "description": "Please restart the device without pressing any button. Then press both buttons on the device three times to access the dashboard. Finally open the Manager to update the firmware."
     }
   }
 }


### PR DESCRIPTION
When user's device is in FW 1.3.1 and sees `MCU Not Genuine`, the repair process should not continue and we should explain to the user that he needs to return to dashboard to complete the firmware update process.

Also fix the font size for errors in repair process

### Type

Fix/Improvement

### Context

LL-1613 (but not exclusively)

### Parts of the app affected / Test plan

Repair Modal

![image](https://user-images.githubusercontent.com/671786/63436633-50cfa700-c429-11e9-99a8-7540b312b89d.png)


// How To Test

@Arnaud97234 you will need a Nano S in 1.3.1 that has a `MCU Not Genuine` state. I have one lying around if you need to.

PS: The *issue*  with this fix is that if some user start their 1.4.1 in bootloader mode by themselves, (but don't have the MCU not genuine message), from what I understand, they will trigger the same error as displayed above (although they SHOULD NOT enter bootloader mode to try and repair their device if everything is fine with it)