### PR TITLE
LL-1769: Uniform icons on desktop/mobile

### DIFF
--- a/src/components/MainSideBar/index.js
+++ b/src/components/MainSideBar/index.js
@@ -22,7 +22,7 @@ import Space from 'components/base/Space'
 import UpdateDot from 'components/Updater/UpdateDot'
 import IconManager from 'icons/Manager'
 import IconWallet from 'icons/Wallet'
-import IconPieChart from 'icons/PieChart'
+import IconPortfolio from 'icons/Portfolio'
 import IconReceive from 'icons/Receive'
 import IconSend from 'icons/Send'
 import IconExchange from 'icons/Exchange'
@@ -129,7 +129,7 @@ class MainSideBar extends PureComponent<Props> {
         <SideBarList title={t('sidebar.menu')}>
           <SideBarListItem
             label={t('dashboard.title')}
-            icon={IconPieChart}
+            icon={IconPortfolio}
             iconActiveColor="wallet"
             onClick={this.handleClickDashboard}
             isActive={pathname === '/'}

--- a/src/icons/Portfolio.js
+++ b/src/icons/Portfolio.js
@@ -1,0 +1,17 @@
+// @flow
+
+import React from 'react'
+
+const path = (
+  <path
+    fill="currentColor"
+    fillRule="nonzero"
+    d="M.75 0c.41 0 .75.34.75.75v11c0 .69.56 1.25 1.25 1.25h11a.75.75 0 1 1 0 1.5h-11A2.75 2.75 0 0 1 0 11.75v-11C0 .34.34 0 .75 0zm13.3 2.06c.38.17.55.61.39 1l-2.22 5.02a.75.75 0 0 1-.82.43L6.37 7.6 4.4 11.12a.75.75 0 0 1-1.3-.74L5.32 6.4a.75.75 0 0 1 .8-.37l4.96.91 1.98-4.48a.75.75 0 0 1 1-.39z"
+  />
+)
+
+export default ({ size, ...p }: { size: number }) => (
+  <svg viewBox="0 0 15 15" height={size} width={size} {...p}>
+    {path}
+  </svg>
+)


### PR DESCRIPTION
> :information_source: Related PR: https://github.com/LedgerHQ/ledger-live-mobile/pull/1007

Make icons uniform between desktop and mobile.

![https://uplr.it/088f9.png](https://uplr.it/088f9.png)

### :ok_hand: Type
UI polish

### :mag: Context
LL-1769

### :clipboard: Parts of the app affected / Test plan
Sidebar