### PR TITLE
LL-1815: Allow collapsing the sidebar

### DIFF
--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -38,6 +38,7 @@ export const setHideEmptyTokenAccounts = (hideEmptyTokenAccounts: boolean) => as
     dispatch(saveSettings({ hideEmptyTokenAccounts }))
   }
 }
+export const setSidebarCollapsed = (sidebarCollapsed: boolean) => saveSettings({ sidebarCollapsed })
 
 type FetchSettings = (*) => (Dispatch<*>) => void
 export const fetchSettings: FetchSettings = (settings: *) => dispatch => {

--- a/src/components/Stars/Item.js
+++ b/src/components/Stars/Item.js
@@ -12,9 +12,15 @@ import FormattedVal from 'components/base/FormattedVal'
 import ParentCryptoCurrencyIcon from 'components/ParentCryptoCurrencyIcon'
 import Box from '../base/Box/Box'
 
-const AccountName = styled(Text)``
+const AccountName = styled(Text)`
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+`
 const ParentCryptoCurrencyIconWrapper = styled.div`
   width: 20px;
+  margin-left: ${p => (p.collapsed && p.isToken ? '-6px' : '')};
+  transition: margin 0.5s;
 `
 
 const ItemWrapper = styled.div`
@@ -36,7 +42,8 @@ const ItemWrapper = styled.div`
     z-index: 1;
     border-color: ${p.active ? p.theme.colors.lightFog : p.theme.colors.sliderGrey};
     box-shadow: 0 12px 17px 0 rgba(0, 0, 0, 0.1);
-  `
+    width: ${p.collapsed ? '200px' : ''} !important;
+        `
       : ''}
 `
 
@@ -49,11 +56,13 @@ const Item = ({
   index,
   push,
   pathname,
+  collapsed,
 }: {
   account: Account | TokenAccount,
   index: number,
   push: Function,
   pathname: string,
+  collapsed?: boolean,
 }) => {
   const active = pathname.endsWith(account.id)
 
@@ -71,12 +80,16 @@ const Item = ({
           {...provided.draggableProps}
           {...provided.dragHandleProps}
           isDragging={snapshot.isDragging}
+          collapsed={collapsed}
           innerRef={provided.innerRef}
           active={active}
           onClick={onAccountClick}
         >
           <Box horizontal ff="Open Sans|SemiBold" flex={1} flow={3} alignItems="center">
-            <ParentCryptoCurrencyIconWrapper>
+            <ParentCryptoCurrencyIconWrapper
+              collapsed={collapsed}
+              isToken={account.type === 'TokenAccount'}
+            >
               <ParentCryptoCurrencyIcon inactive={!active} currency={getAccountCurrency(account)} />
             </ParentCryptoCurrencyIconWrapper>
             <Box vertical flex={1}>

--- a/src/components/Stars/index.js
+++ b/src/components/Stars/index.js
@@ -2,13 +2,16 @@
 
 import React, { PureComponent } from 'react'
 import { Trans } from 'react-i18next'
-import type { Account, TokenAccount } from '@ledgerhq/live-common/src/types'
 import { DragDropContext, Droppable } from 'react-beautiful-dnd'
 import styled from 'styled-components'
-import Text from 'components/base/Text'
 import { connect } from 'react-redux'
 import { createStructuredSelector } from 'reselect'
 import { push } from 'react-router-redux'
+import type { Account, TokenAccount } from '@ledgerhq/live-common/src/types'
+
+import SideBarTooltip from 'components/base/SideBar/SideBarTooltip'
+import { Hide } from 'components/MainSideBar'
+import Text from 'components/base/Text'
 import { dragDropStarAction } from '../../actions/settings'
 import { starredAccountsSelector } from '../../reducers/accounts'
 import { i } from '../../helpers/staticPath'
@@ -43,6 +46,7 @@ class Stars extends PureComponent<{
   pathname: string,
   starredAccounts: (Account | TokenAccount)[],
   dragDropStarAction: (*) => any,
+  collapsed: boolean,
 }> {
   onDragEnd = ({ source, destination }) => {
     const { dragDropStarAction, starredAccounts } = this.props
@@ -52,14 +56,25 @@ class Stars extends PureComponent<{
   }
 
   render() {
-    const { starredAccounts, pathname } = this.props
+    const { starredAccounts, pathname, collapsed } = this.props
     return starredAccounts && starredAccounts.length ? (
       <DragDropContext onDragEnd={this.onDragEnd}>
         <Droppable droppableId="list" direction="vertical">
           {provided => (
             <Container key={pathname} innerRef={provided.innerRef}>
               {starredAccounts.map((account: Account | TokenAccount, i) => (
-                <Item index={i} key={account.id} account={account} pathname={pathname} />
+                <SideBarTooltip
+                  text={account.type === 'Account' ? account.name : account.token.name}
+                  enabled={collapsed}
+                >
+                  <Item
+                    index={i}
+                    key={account.id}
+                    account={account}
+                    pathname={pathname}
+                    collapsed={collapsed}
+                  />
+                </SideBarTooltip>
               ))}
               {provided.placeholder}
             </Container>
@@ -67,18 +82,20 @@ class Stars extends PureComponent<{
         </Droppable>
       </DragDropContext>
     ) : (
-      <Placeholder>
-        <img alt="stars placeholder" src={i('starsPlaceholder.png')} width="95" height="53" />
-        <Text ff="Open Sans|SemiBold" color="grey" fontSize={3}>
-          <Trans i18nKey={'stars.placeholder'}>
-            {'Accounts that you star on the'}
-            <Text ff="Open Sans|SemiBold" color="dark">
-              {'Accounts'}
-            </Text>
-            {' page will now appear here!.'}
-          </Trans>
-        </Text>
-      </Placeholder>
+      <Hide visible={!collapsed}>
+        <Placeholder>
+          <img alt="stars placeholder" src={i('starsPlaceholder.png')} width="95" height="53" />
+          <Text ff="Open Sans|SemiBold" color="grey" fontSize={3}>
+            <Trans i18nKey={'stars.placeholder'}>
+              {'Accounts that you star on the'}
+              <Text ff="Open Sans|SemiBold" color="dark">
+                {'Accounts'}
+              </Text>
+              {' page will now appear here!.'}
+            </Trans>
+          </Text>
+        </Placeholder>
+      </Hide>
     )
   }
 }

--- a/src/components/base/Chart/helpers.js
+++ b/src/components/base/Chart/helpers.js
@@ -1,3 +1,4 @@
+import debounce from 'lodash/debounce'
 import c from 'color'
 
 export function enrichData(data) {
@@ -40,10 +41,14 @@ export function generateMargins(hideAxis) {
 }
 
 export function observeResize(node, cb) {
-  const onResize = () => {
-    const { width } = node.getBoundingClientRect()
-    cb(width)
-  }
+  const onResize = debounce(
+    () => {
+      const { width } = node.getBoundingClientRect()
+      cb(width)
+    },
+    100,
+    { maxWait: 1000 },
+  )
 
   const ro = new ResizeObserver(onResize)
   ro.observe(node)

--- a/src/components/base/SideBar/SideBarList.js
+++ b/src/components/base/SideBar/SideBarList.js
@@ -13,17 +13,18 @@ type Props = {
   scroll?: boolean,
   titleRight?: any,
   emptyState?: any,
+  collapsed?: boolean,
 }
 
 class SideBarList extends Component<Props> {
   render() {
-    const { children, title, scroll, titleRight, emptyState, ...props } = this.props
+    const { children, title, scroll, titleRight, emptyState, collapsed, ...props } = this.props
     const ListWrapper = scroll ? GrowScroll : Box
     return (
       <Fragment>
         {!!title && (
           <Fragment>
-            <SideBarListTitle>
+            <SideBarListTitle collapsed={collapsed}>
               {title}
               {!!titleRight && <Box ml="auto">{titleRight}</Box>}
             </SideBarListTitle>
@@ -55,6 +56,12 @@ const SideBarListTitle = styled(Box).attrs({
   cursor: default;
   letter-spacing: 2px;
   text-transform: uppercase;
+
+  // allow collapsing
+  opacity: ${p => (p.collapsed ? 0 : 1)};
+  transition: opacity 0.15s;
+  overflow: hidden;
+  white-space: nowrap;
 `
 
 export default SideBarList

--- a/src/components/base/SideBar/SideBarListItem.js
+++ b/src/components/base/SideBar/SideBarListItem.js
@@ -4,6 +4,7 @@ import React, { PureComponent } from 'react'
 import styled from 'styled-components'
 
 import Box, { Tabbable } from 'components/base/Box'
+import SideBarTooltip from './SideBarTooltip'
 
 export type Props = {
   label: string | (Props => React$Node),
@@ -15,6 +16,7 @@ export type Props = {
   isActive?: boolean,
   onClick?: void => void,
   isActive?: boolean,
+  showTooltip?: boolean,
 }
 
 class SideBarListItem extends PureComponent<Props> {
@@ -28,27 +30,34 @@ class SideBarListItem extends PureComponent<Props> {
       onClick,
       isActive,
       disabled,
+      showTooltip,
     } = this.props
+
+    const renderedLabel =
+      typeof label === 'function' ? (
+        label(this.props)
+      ) : (
+        <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {label}
+        </span>
+      )
+
     return (
-      <Container
-        isActive={!disabled && isActive}
-        iconActiveColor={iconActiveColor}
-        onClick={disabled ? undefined : onClick}
-        disabled={disabled}
-      >
-        {!!Icon && <Icon size={16} />}
-        <Box grow shrink>
-          {typeof label === 'function' ? (
-            label(this.props)
-          ) : (
-            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {label}
-            </span>
-          )}
-          {!!desc && desc(this.props)}
-        </Box>
-        {NotifComponent && <NotifComponent />}
-      </Container>
+      <SideBarTooltip text={renderedLabel} enabled={!!showTooltip}>
+        <Container
+          isActive={!disabled && isActive}
+          iconActiveColor={iconActiveColor}
+          onClick={disabled ? undefined : onClick}
+          disabled={disabled}
+        >
+          {!!Icon && <Icon size={16} />}
+          <Box grow shrink>
+            {renderedLabel}
+            {!!desc && desc(this.props)}
+          </Box>
+          {NotifComponent && <NotifComponent />}
+        </Container>
+      </SideBarTooltip>
     )
   }
 }

--- a/src/components/base/SideBar/SideBarTooltip.js
+++ b/src/components/base/SideBar/SideBarTooltip.js
@@ -1,0 +1,31 @@
+// @flow
+
+import React from 'react'
+
+import Tooltip from 'components/base/Tooltip'
+
+type Props = {
+  children: React$Node,
+  enabled: boolean,
+  text: React$Node,
+}
+
+const tippyOptions = {
+  placement: 'right',
+  boundary: 'window',
+  popperOptions: {
+    modifiers: {
+      preventOverflow: {
+        enabled: false,
+      },
+    },
+  },
+}
+
+const SideBarTooltip = ({ children, text, enabled }: Props) => (
+  <Tooltip options={tippyOptions} render={() => text} enabled={enabled}>
+    {children}
+  </Tooltip>
+)
+
+export default React.memo<Props>(SideBarTooltip)

--- a/src/components/base/Tooltip/index.js
+++ b/src/components/base/Tooltip/index.js
@@ -22,7 +22,7 @@ export const TooltipContainer = ({
   style,
   tooltipBg,
 }: {
-  children: any,
+  children: React$Node,
   innerRef?: Function,
   style?: Object,
   tooltipBg?: string,
@@ -51,40 +51,83 @@ TooltipContainer.defaultProps = {
 
 type Props = {
   offset?: Array<number>,
-  children: any,
+  children: React$Node,
+  enabled?: boolean,
   render: Function,
   tooltipBg?: string,
+  options?: { [string]: any },
+}
+
+export const replaceTippyArrow = (_tippy: any, tooltipBg?: string) => {
+  _tippy.popper.querySelector('.tippy-roundarrow').innerHTML = `
+    <svg viewBox="0 0 24 8">
+      <path${
+        tooltipBg ? ` fill="${colors[tooltipBg]}"` : ''
+      } d="M5 8l5.5-5.6c.8-.8 2-.8 2.8 0L19 8" />
+    </svg>`
+}
+
+export const defaultTippyOptions = {
+  arrowType: 'round',
+  animateFill: false,
+  animation: 'shift-toward',
+  arrow: true,
+  offset: 0,
+  performance: true,
 }
 
 class Tooltip extends PureComponent<Props> {
   static defaultProps = {
     offset: [0, 0],
+    enabled: true,
   }
 
   componentDidMount() {
-    const { offset, tooltipBg } = this.props
+    const { offset, tooltipBg, enabled, options } = this.props
 
     if (this._node && this._template) {
       tippy(this._node, {
-        arrowType: 'round',
-        animateFill: false,
-        animation: 'shift-toward',
-        arrow: true,
+        ...defaultTippyOptions,
         html: this._template,
         offset: offset ? offset.map(v => space[v]).join(',') : 0,
-        performance: true,
+        ...options,
       })
 
+      const _tippy = this._node && this._node._tippy
+
+      // make flow happy
+      if (!_tippy) return
+
       // Override default arrow ¯\_(ツ)_/¯
-      if (this._node && this._node._tippy) {
-        this._node._tippy.popper.querySelector('.tippy-roundarrow').innerHTML = `
-          <svg viewBox="0 0 24 8">
-            <path${
-              tooltipBg ? ` fill="${colors[tooltipBg]}"` : ''
-            } d="M5 8l5.5-5.6c.8-.8 2-.8 2.8 0L19 8" />
-          </svg>`
+      replaceTippyArrow(_tippy, tooltipBg)
+
+      // disable tooltip if needed
+      if (!enabled) {
+        _tippy.disable()
       }
     }
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    const _tippy = this._node && this._node._tippy
+
+    if (!_tippy) return
+
+    // handle dynamically updating enabled state
+    if (prevProps.enabled && !this.props.enabled) {
+      _tippy.disable()
+      _tippy.hide()
+    } else if (!prevProps.enabled && this.props.enabled) {
+      _tippy.enable()
+    }
+  }
+
+  componentWillUnmount() {
+    const _tippy = this._node && this._node._tippy
+
+    if (!_tippy) return
+
+    _tippy.destroy()
   }
 
   _node = undefined

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -62,6 +62,7 @@ export type SettingsState = {
   accountsViewMode: 'card' | 'list',
   showAccountsHelperBanner: boolean,
   hideEmptyTokenAccounts: boolean,
+  sidebarCollapsed: boolean,
 }
 
 const defaultsForCurrency: Currency => CurrencySettings = crypto => {
@@ -94,6 +95,7 @@ const INITIAL_STATE: SettingsState = {
   accountsViewMode: 'list',
   showAccountsHelperBanner: true,
   hideEmptyTokenAccounts: getEnv('HIDE_EMPTY_TOKEN_ACCOUNTS'),
+  sidebarCollapsed: false,
 }
 
 const pairHash = (from, to) => `${from.ticker}_${to.ticker}`
@@ -256,6 +258,7 @@ export const confirmationsNbForCurrencySelector = (
   return defs.confirmationsNb ? defs.confirmationsNb.def : 0
 }
 
+export const sidebarCollapsedSelector = (state: State) => state.settings.sidebarCollapsed
 export const accountsViewModeSelector = (state: State) => state.settings.accountsViewMode
 export const marketIndicatorSelector = (state: State) => state.settings.marketIndicator
 export const sentryLogsSelector = (state: State) => state.settings.sentryLogs


### PR DESCRIPTION
This PR allows collapsing the sidebar for :sparkles: improved :sparkles: user experience :sparkles: 

* Collapse the sidebar
* State is persisted across user sessions
* Tooltips to know what icons mean when collapsed
* Drag/drop for stars still works

### :camera_flash: Video demo
[![Demo](https://user-images.githubusercontent.com/1671753/63522631-0cabd780-c4f9-11e9-8ed5-03ebc0cfa412.gif)](https://www.youtube.com/watch?v=MVw93BjNidY)

https://www.youtube.com/watch?v=MVw93BjNidY

### :ok_hand: Type
Feature

### :mag: Context
LL-1815

### :clipboard: Parts of the app affected / Test plan
* Sidebar
* Don't forget to check persistence

### :bug: Remaining issues
* :question: There seems to be a tooltip issue when dragging star accounts. Open to suggestions... maybe remove the tooltips on starred accounts?
* :rocket: Performance could be improved (especially noticeable when lots of accounts on grid mode)