### PR TITLE
LL-1837 Fix select component regression

### DIFF
--- a/src/components/base/Select/index.js
+++ b/src/components/base/Select/index.js
@@ -56,7 +56,9 @@ class MenuList extends PureComponent<*, *> {
 
   static getDerivedStateFromProps({ children }, state) {
     if (children !== state.children) {
-      const currentIndex = Math.max(children.findIndex(({ props: { isFocused } }) => isFocused), 0)
+      const currentIndex = Array.isArray(children)
+        ? Math.max(children.findIndex(({ props: { isFocused } }) => isFocused), 0)
+        : 0
 
       return {
         children,


### PR DESCRIPTION
Our select componenet was broken since the introduction of the keyboard based highlight since when there are no children, the "children" prop is still set, to an empty component object from react-select, then we try to find in it and well, it's not an array, so we crash.

Funny thing is non of us found this out in a full week of working on desktop, which means we are doing pretty much always the same and not covering cases like this one, honestly it's a bit scary 😅 

### Type

Regression fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1837

### Parts of the app affected / Test plan

All selectors should be affected really, add account, select account, rate provider, language selector, etc
