### PR TITLE
LL-1820: Show token account count in Add accounts flow

### DIFF
--- a/src/components/CryptoCurrencyIcon.js
+++ b/src/components/CryptoCurrencyIcon.js
@@ -14,11 +14,11 @@ type Props = {
 }
 
 // NB this is to avoid seeing the parent icon through
-const TokenIconWrapper = styled.div`
+export const TokenIconWrapper = styled.div`
   border-radius: 4px;
 `
-const TokenIcon = styled.div`
-  font-size: ${p => p.size / 2}px;
+export const TokenIcon = styled.div`
+  font-size: ${p => p.fontSize ? p.fontSize : p.size / 2}px;
   font-family: 'Open Sans';
   font-weight: bold;
   color: ${p => p.color};

--- a/src/components/CryptoCurrencyIconWithCount.js
+++ b/src/components/CryptoCurrencyIconWithCount.js
@@ -22,8 +22,7 @@ const Wrapper = styled.div`
   ${p =>
     p.doubleIcon
       ? `
-  margin-left: -6px;
-  margin-right: -6px;
+  margin-right: -12px;
 
   > :nth-child(1) {
     clip-path: polygon(0% 0%, 100% 0%, 100% 50%, 81% 50%, 68% 54%, 58% 63%, 52% 74%, 50% 86%, 50% 100%, 0% 100%);

--- a/src/components/CryptoCurrencyIconWithCount.js
+++ b/src/components/CryptoCurrencyIconWithCount.js
@@ -1,0 +1,81 @@
+// @flow
+import React, { PureComponent } from 'react'
+import styled from 'styled-components'
+import { Trans } from 'react-i18next'
+
+import type { Currency } from '@ledgerhq/live-common/lib/types'
+import { getCurrencyColor } from '@ledgerhq/live-common/lib/currencies'
+
+import { colors } from 'styles/theme'
+import Tooltip from 'components/base/Tooltip'
+import CryptoCurrencyIcon, { TokenIconWrapper, TokenIcon } from './CryptoCurrencyIcon'
+
+type Props = {
+  currency: Currency,
+  count: number,
+  withTooltip?: boolean,
+  bigger?: boolean,
+  inactive?: boolean,
+}
+
+const Wrapper = styled.div`
+  ${p =>
+    p.doubleIcon
+      ? `
+  margin-left: -6px;
+  margin-right: -6px;
+
+  > :nth-child(1) {
+    clip-path: polygon(0% 0%, 100% 0%, 100% 50%, 81% 50%, 68% 54%, 58% 63%, 52% 74%, 50% 86%, 50% 100%, 0% 100%);
+  }`
+      : `
+  display: flex;
+  align-items: center;`}
+
+  line-height: ${p => (p.bigger ? '18px' : '18px')};
+  font-size: ${p => (p.bigger ? '12px' : '12px')};
+
+  > :nth-child(2) {
+    margin-top: ${p => (p.bigger ? '-15px' : '-13px')};
+    margin-left: ${p => (p.bigger ? '10px' : '8px')};
+
+    border: 2px solid ${p => p.theme.colors.white};
+  }
+`
+
+export default class CryptoCurrencyIconWithCount extends PureComponent<Props> {
+  render() {
+    const { currency, bigger, withTooltip, inactive, count } = this.props
+    const color = inactive ? colors.grey : getCurrencyColor(currency)
+
+    const size = bigger ? 20 : 16
+    const fontSize = size / 2 + (count < 10 ? 2 : count >= 100 ? -2 : 0)
+
+    const content = (
+      <Wrapper doubleIcon={count > 0} bigger={bigger}>
+        <CryptoCurrencyIcon inactive={inactive} currency={currency} size={size} />
+        {count > 0 && (
+          <TokenIconWrapper>
+            <TokenIcon color={color} size={size} fontSize={fontSize}>
+              {`+${count}`}
+            </TokenIcon>
+          </TokenIconWrapper>
+        )}
+      </Wrapper>
+    )
+
+    if (withTooltip && count > 0) {
+      return (
+        <Tooltip
+          render={() => (
+            <Trans i18nKey={'tokensList.countTooltip'} count={count} values={{ count }} />
+          )}
+        >
+          {content}
+        </Tooltip>
+      )
+    }
+
+    return content
+  }
+}

--- a/src/components/ParentCryptoCurrencyIcon.js
+++ b/src/components/ParentCryptoCurrencyIcon.js
@@ -26,7 +26,7 @@ const ParentCryptoCurrencyIconWrapper = styled.div`
       : `
   display: flex;
   align-items: center;`}
-  
+
   line-height: ${p => (p.bigger ? '18px' : '18px')};
   font-size: ${p => (p.bigger ? '12px' : '12px')};
   > :nth-child(2) {

--- a/src/components/base/AccountsList/AccountRow.js
+++ b/src/components/base/AccountsList/AccountRow.js
@@ -13,6 +13,15 @@ import FormattedVal from 'components/base/FormattedVal'
 import Input from 'components/base/Input'
 import { MAX_ACCOUNT_NAME_SIZE } from 'config/constants'
 
+const InputWrapper = styled.div`
+  margin-left: 4px;
+
+  & > div > div {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+`
+
 type Props = {
   account: Account,
   isChecked?: boolean,
@@ -87,19 +96,21 @@ export default class AccountRow extends PureComponent<Props> {
         <CryptoCurrencyIconWithCount currency={account.currency} count={tokenCount} withTooltip />
         <Box shrink grow ff="Open Sans|SemiBold" color="dark" fontSize={4}>
           {onEditName ? (
-            <Input
-              style={this.overflowStyles}
-              value={accountName}
-              onChange={this.handleChangeName}
-              onClick={this.onClickInput}
-              onEnter={this.handlePreventSubmit}
-              onFocus={this.onFocus}
-              onBlur={this.onBlur}
-              onKeyPress={this.handleKeyPress}
-              maxLength={MAX_ACCOUNT_NAME_SIZE}
-              editInPlace
-              autoFocus={autoFocusInput}
-            />
+            <InputWrapper>
+              <Input
+                style={this.overflowStyles}
+                value={accountName}
+                onChange={this.handleChangeName}
+                onClick={this.onClickInput}
+                onEnter={this.handlePreventSubmit}
+                onFocus={this.onFocus}
+                onBlur={this.onBlur}
+                onKeyPress={this.handleKeyPress}
+                maxLength={MAX_ACCOUNT_NAME_SIZE}
+                editInPlace
+                autoFocus={autoFocusInput}
+              />
+            </InputWrapper>
           ) : (
             <div style={{ ...this.overflowStyles, paddingLeft: 15 }}>{accountName}</div>
           )}

--- a/src/components/base/AccountsList/AccountRow.js
+++ b/src/components/base/AccountsList/AccountRow.js
@@ -8,7 +8,7 @@ import { darken } from 'styles/helpers'
 
 import Box, { Tabbable } from 'components/base/Box'
 import CheckBox from 'components/base/CheckBox'
-import CryptoCurrencyIcon from 'components/CryptoCurrencyIcon'
+import CryptoCurrencyIconWithCount from 'components/CryptoCurrencyIconWithCount'
 import FormattedVal from 'components/base/FormattedVal'
 import Input from 'components/base/Input'
 import { MAX_ACCOUNT_NAME_SIZE } from 'config/constants'
@@ -76,12 +76,15 @@ export default class AccountRow extends PureComponent<Props> {
       autoFocusInput,
       hideAmount,
     } = this.props
+
+    const tokenCount = (account.tokenAccounts && account.tokenAccounts.length) || 0
+
     return (
       <AccountRowContainer
         isDisabled={isDisabled}
         onClick={isDisabled ? null : this.onToggleAccount}
       >
-        <CryptoCurrencyIcon currency={account.currency} size={16} />
+        <CryptoCurrencyIconWithCount currency={account.currency} count={tokenCount} withTooltip />
         <Box shrink grow ff="Open Sans|SemiBold" color="dark" fontSize={4}>
           {onEditName ? (
             <Input
@@ -98,7 +101,7 @@ export default class AccountRow extends PureComponent<Props> {
               autoFocus={autoFocusInput}
             />
           ) : (
-            <div style={this.overflowStyles}>{accountName}</div>
+            <div style={{ ...this.overflowStyles, paddingLeft: 15 }}>{accountName}</div>
           )}
         </Box>
         {!hideAmount ? (
@@ -111,11 +114,7 @@ export default class AccountRow extends PureComponent<Props> {
             color="grey"
           />
         ) : null}
-        {!isDisabled && !isReadonly ? (
-          <CheckBox disabled isChecked={isChecked || !!isDisabled} />
-        ) : (
-          !isReadonly && <div style={{ width: 20 }} />
-        )}
+        {!isDisabled && !isReadonly && <CheckBox disabled isChecked={isChecked || !!isDisabled} />}
       </AccountRowContainer>
     )
   }

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -250,7 +250,9 @@
     "link": "Learn more",
     "seeTokens": "See tokens ({{tokenCount}})",
     "hideTokens": "Hide tokens ({{tokenCount}})",
-    "tooltip": "Token from"
+    "tooltip": "Token from",
+    "countTooltip": "1 Token",
+    "countTooltip_plural": "{{count}} Tokens"
   },
   "migrateAccounts": {
     "overview": {


### PR DESCRIPTION
This PR adds account count in Add Accouts flow. It also does some minor UI polish to align stuff.

### :camera_flash: Screenshot
![https://uplr.it/80d8a.png](https://uplr.it/80d8a.png)

### :ok_hand: Type
UX

### :mag: Context
LL-1820

### :clipboard:  Parts of the app affected / Test plan
Add accounts with ERC20