### PR TITLE
LL-1810: Add ERC20 add account empty state

### DIFF
--- a/src/components/AccountPage/EmptyStateAccount.js
+++ b/src/components/AccountPage/EmptyStateAccount.js
@@ -9,6 +9,7 @@ import { translate, Trans } from 'react-i18next'
 import { openModal } from 'reducers/modals'
 import type { T } from 'types/common'
 import type { Account, TokenAccount } from '@ledgerhq/live-common/lib/types'
+import { listTokenTypesForCryptoCurrency } from '@ledgerhq/live-common/lib/currencies'
 
 import { MODAL_RECEIVE } from 'config/constants'
 
@@ -34,6 +35,9 @@ class EmptyStateAccount extends PureComponent<Props, *> {
     const { t, account, parentAccount, openModal } = this.props
     const mainAccount = account.type === 'Account' ? account : parentAccount
     if (!mainAccount) return null
+
+    const hasTokens = Array.isArray(mainAccount.tokenAccounts)
+
     return (
       <Box mt={7} alignItems="center" selectable>
         <img
@@ -45,13 +49,34 @@ class EmptyStateAccount extends PureComponent<Props, *> {
         <Box mt={5} alignItems="center">
           <Title>{t('account.emptyState.title')}</Title>
           <Description mt={3} style={{ display: 'block' }}>
-            <Trans i18nKey="account.emptyState.desc">
-              {'Make sure the'}
-              <Text ff="Open Sans|SemiBold" color="dark">
-                {mainAccount.currency.managerAppName}
-              </Text>
-              {'app is installed to receive funds.'}
-            </Trans>
+            {hasTokens ? (
+              <Trans i18nKey="account.emptyState.descToken">
+                {'Make sure the'}
+                <Text ff="Open Sans|SemiBold" color="dark">
+                  {mainAccount.currency.managerAppName}
+                </Text>
+                {'app is installed and start receiving'}
+                <Text ff="Open Sans|SemiBold" color="dark">
+                  {mainAccount.currency.ticker}
+                </Text>
+                {'and'}
+                <Text ff="Open Sans|SemiBold" color="dark">
+                  {account &&
+                    account.currency &&
+                    // $FlowFixMe
+                    listTokenTypesForCryptoCurrency(account.currency).join(', ')}
+                  {'tokens'}
+                </Text>
+              </Trans>
+            ) : (
+              <Trans i18nKey="account.emptyState.desc">
+                {'Make sure the'}
+                <Text ff="Open Sans|SemiBold" color="dark">
+                  {mainAccount.currency.managerAppName}
+                </Text>
+                {'app is installed and start receiving'}
+              </Trans>
+            )}
           </Description>
           <Button
             mt={5}

--- a/src/components/CryptoCurrencyIcon.js
+++ b/src/components/CryptoCurrencyIcon.js
@@ -18,7 +18,7 @@ export const TokenIconWrapper = styled.div`
   border-radius: 4px;
 `
 export const TokenIcon = styled.div`
-  font-size: ${p => p.fontSize ? p.fontSize : p.size / 2}px;
+  font-size: ${p => (p.fontSize ? p.fontSize : p.size / 2)}px;
   font-family: 'Open Sans';
   font-weight: bold;
   color: ${p => p.color};

--- a/src/components/SettingsPage/sections/CryptoAssets/RateRow/index.js
+++ b/src/components/SettingsPage/sections/CryptoAssets/RateRow/index.js
@@ -65,7 +65,7 @@ const NoDataContainer = styled(Box)`
 
 const NoData = () => (
   <NoDataContainer ff="Open Sans|SemiBold" color="gray" fontSize={4}>
-    <Trans style={{whiteSpace: 'nowrap'}} i18nKey="settings.rates.noCounterValue" />
+    <Trans style={{ whiteSpace: 'nowrap' }} i18nKey="settings.rates.noCounterValue" />
   </NoDataContainer>
 )
 

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -118,6 +118,7 @@
     "emptyState": {
       "title": "No crypto assets yet?",
       "desc": "Make sure the <1><0>{{managerAppName}}</0></1> app is installed and start receiving",
+      "descToken": "Make sure the <1><0>{{managerAppName}}</0></1> app is installed and start receiving <3><0>{{ticker}}</0></3> and <5><0>{{tokenList}}</0> tokens</5>",
       "buttons": {
         "receiveFunds": "Receive"
       }


### PR DESCRIPTION
> :information_source: Mobile: https://github.com/LedgerHQ/ledger-live-mobile/pull/1017

This PR adds the empty state for the ERC20 empty account case.

### :camera_flash: Screenshot
![https://uplr.it/2121d.png](https://uplr.it/2121d.png)

### :ok_hand: Type
UX

### :mag: Context
LL-1810

### :clipboard: Parts of the app affected / Test plan
* Empty Ethereum account page
* Other empty accounts (non-tokens)