### PR TITLE
adds fallback screen when looking for tokens in manager

### DIFF
--- a/src/components/ManagerPage/AppSearchBar.js
+++ b/src/components/ManagerPage/AppSearchBar.js
@@ -25,7 +25,7 @@ const CrossContainer = styled(Box).attrs({
 type Props = {
   searchKeys: string[],
   list: Array<ApplicationVersion>,
-  children: (list: Array<ApplicationVersion>) => React$Node,
+  children: (list: Array<ApplicationVersion>, query: string) => React$Node,
 }
 
 type State = {
@@ -91,7 +91,7 @@ class AppSearchBar extends PureComponent<Props, State> {
           }}
           value={query}
           items={list}
-          render={items => children(items)}
+          render={items => children(items, query)}
         />
       </Fragment>
     )

--- a/src/components/ManagerPage/AppsList.js
+++ b/src/components/ManagerPage/AppsList.js
@@ -44,6 +44,7 @@ import Trash from 'icons/Trash'
 import { FreezeDeviceChangeEvents } from './HookDeviceChange'
 import ManagerApp, { Container as FakeManagerAppContainer } from './ManagerApp'
 import AppSearchBar from './AppSearchBar'
+import NoItemPlaceholder from './NoItemPlaceholder'
 
 const List = styled(Box).attrs({
   horizontal: true,
@@ -117,6 +118,7 @@ type State = {
   filteredAppVersionsList: Array<ApplicationVersion>,
   appsLoaded: boolean,
   app: ?ApplicationVersion,
+  eth: ?ApplicationVersion,
   mode: Mode,
   progress: number,
 }
@@ -163,6 +165,7 @@ class AppsList extends PureComponent<Props, State> {
     filteredAppVersionsList: [],
     appsLoaded: false,
     app: null,
+    eth: null,
     mode: 'home',
     progress: 0,
   }
@@ -191,11 +194,14 @@ class AppsList extends PureComponent<Props, State> {
         () => currenciesByMarketcap(listCryptoCurrencies()),
       )
 
+      const eth = filteredAppVersionsList.find(c => c.name === 'Ethereum')
+
       if (!this._unmounted) {
         this.setState({
           status: 'idle',
           filteredAppVersionsList,
           appsLoaded: true,
+          eth,
         })
       }
     } catch (err) {
@@ -464,24 +470,28 @@ class AppsList extends PureComponent<Props, State> {
   }
 
   renderList() {
-    const { filteredAppVersionsList, appsLoaded } = this.state
+    const { filteredAppVersionsList, appsLoaded, status, eth } = this.state
     return (
       <Box>
         <AppSearchBar searchKeys={['currency.ticker']} list={filteredAppVersionsList}>
-          {items => (
-            <List>
-              {items.map(c => (
-                <ManagerApp
-                  key={`${c.name}_${c.version}`}
-                  name={c.name}
-                  version={`Version ${c.version}`}
-                  icon={ICONS_FALLBACK[c.icon] || c.icon}
-                  onInstall={canHandleInstall(c) ? this.handleInstallApp(c) : null}
-                  onUninstall={this.handleUninstallApp(c)}
-                />
-              ))}
-            </List>
-          )}
+          {(items, query) =>
+            items.length === 0 && status !== 'loading' ? (
+              <NoItemPlaceholder query={query} installApp={this.handleInstallApp} app={eth} />
+            ) : (
+              <List>
+                {items.map(c => (
+                  <ManagerApp
+                    key={`${c.name}_${c.version}`}
+                    name={c.name}
+                    version={`Version ${c.version}`}
+                    icon={ICONS_FALLBACK[c.icon] || c.icon}
+                    onInstall={canHandleInstall(c) ? this.handleInstallApp(c) : null}
+                    onUninstall={this.handleUninstallApp(c)}
+                  />
+                ))}
+              </List>
+            )
+          }
         </AppSearchBar>
         {this.renderModal()}
         {!appsLoaded && FAKE_LIST}

--- a/src/components/ManagerPage/NoItemPlaceholder.js
+++ b/src/components/ManagerPage/NoItemPlaceholder.js
@@ -1,0 +1,100 @@
+// @flow
+
+import React, { useMemo, useCallback } from 'react'
+import { connect } from 'react-redux'
+import { Trans } from 'react-i18next'
+import styled from 'styled-components'
+import { push } from 'react-router-redux'
+import { listTokens } from '@ledgerhq/live-common/lib/currencies'
+import type { ApplicationVersion } from '@ledgerhq/live-common/lib/types/manager'
+
+import Box from 'components/base/Box'
+import Text from 'components/base/Text'
+import Button from 'components/base/Button'
+
+const Title = styled(Box).attrs({
+  ff: 'Museo Sans|Regular',
+  fontSize: 5,
+})`
+  color: ${p => p.theme.colors.dark};
+`
+
+const Wrapper = styled(Box).attrs({
+  alignItems: 'center',
+  pt: 5,
+})``
+
+type Props = {
+  query: string,
+  app: ?ApplicationVersion,
+  installApp: ApplicationVersion => *,
+  push: typeof push,
+}
+const tokens = listTokens()
+
+const NoItemPlaceholder = ({ query, installApp, app, push }: Props) => {
+  const found = useMemo(
+    () =>
+      tokens.find(
+        token =>
+          token.name.toLocaleLowerCase().includes(query.toLowerCase()) ||
+          token.ticker.toLocaleLowerCase().includes(query.toLowerCase()),
+      ),
+    [query],
+  )
+
+  const install = useCallback(() => {
+    if (!app) return
+
+    installApp(app)()
+  }, [app, installApp])
+
+  return found ? (
+    <Wrapper>
+      <Title>
+        <Trans i18nKey="manager.apps.noAppNeededForToken" values={{ tokenName: found.name }} />
+      </Title>
+      <Box pt={2} style={{ maxWidth: 500 }} alignItems="center">
+        <Text ff="Open Sans|Regular" color="graphite" fontSize={4} style={{ lineHeight: 1.6 }}>
+          <Trans i18nKey="manager.apps.lookingForToken" values={{ tokenName: found.name }} />
+        </Text>
+        <Text
+          ff="Open Sans|Regular"
+          color="graphite"
+          fontSize={4}
+          textAlign="center"
+          style={{ lineHeight: 1.6 }}
+        >
+          <Trans i18nKey="manager.apps.tokenAppDisclaimer" values={{ tokenName: found.name }}>
+            {'placeholder'}
+            <Text ff="Open Sans|SemiBold" color="dark">
+              {'placeholder'}
+            </Text>
+            {'placeholder'}
+            <Text ff="Open Sans|SemiBold" color="dark">
+              {'placeholder'}
+            </Text>
+          </Trans>
+        </Text>
+      </Box>
+      <Box pt={5} horizontal>
+        <Button
+          outline
+          outlineColor="grey"
+          onClick={() => push('/accounts')}
+          style={{ marginRight: 32 }}
+        >
+          <Trans i18nKey="manager.goToAccounts" />
+        </Button>
+        <Button primary onClick={install}>
+          <Trans i18nKey="manager.intallEthApp" />
+        </Button>
+      </Box>
+    </Wrapper>
+  ) : null
+}
+
+export default connect(
+  null,
+  { push },
+)(NoItemPlaceholder)

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -365,6 +365,8 @@
   },
   "manager": {
     "yourDeviceIsGenuine": "Your device is genuine",
+    "goToAccounts": "Go to accounts",
+    "intallEthApp": "Install Ethereum app",
     "apps": {
       "install": "Install",
       "all": "App catalog",
@@ -379,7 +381,10 @@
       "help": "Check on your device to see which apps are already installed",
       "installed": "App installed",
       "uninstalled": "App uninstalled",
-      "addAccount": "Add {{name}} account"
+      "addAccount": "Add {{name}} account",
+      "noAppNeededForToken": "No specific app needed for {{tokenName}}",
+      "lookingForToken": "It seems that you’re looking for an app for {{tokenName}}",
+      "tokenAppDisclaimer": "{{tokenName}} is an <1>ERC20 and doesn’t need an app</1>. To receive ERC20s, simply send them to an <3>Ethereum address</3>"
     },
     "firmware": {
       "installed": "Firmware version {{version}}",


### PR DESCRIPTION
When searching for a Token app in manager, fallback to a screen that explains how to use ERC20 Tokens with Ledger Devices

### Type

Feat

### Context

LL-1834

### Parts of the app affected / Test plan

Manager, looking for the name of an ERC20 token

![image](https://user-images.githubusercontent.com/671786/64175472-a8273b80-ce5b-11e9-8b53-5a7c13368841.png)

