### PR TITLE
LL-1740 Hide starred empty token accounts

### DIFF
--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -5,7 +5,6 @@ import type { SettingsState as Settings } from 'reducers/settings'
 import type { PortfolioRange } from '@ledgerhq/live-common/lib/types/portfolio'
 import type { Currency } from '@ledgerhq/live-common/lib/types'
 import { setEnvOnAllThreads } from 'helpers/env'
-import type { Account } from '@ledgerhq/live-common/lib/types/account'
 
 export type SaveSettings = ($Shape<Settings>) => { type: string, payload: $Shape<Settings> }
 
@@ -70,11 +69,7 @@ export const toggleStarAction = (accountId: string) => ({
   accountId,
 })
 
-export const dragDropStarAction = (payload: {
-  from: number,
-  to: number,
-  starredAccounts: Account[],
-}) => ({
+export const dragDropStarAction = (payload: { from: string, to: string }) => ({
   type: 'SETTINGS_DRAG_DROP_STAR',
   payload,
 })

--- a/src/components/Stars/index.js
+++ b/src/components/Stars/index.js
@@ -10,7 +10,7 @@ import { connect } from 'react-redux'
 import { createStructuredSelector } from 'reselect'
 import { push } from 'react-router-redux'
 import { dragDropStarAction } from '../../actions/settings'
-import { starredAccountsSelector } from '../../reducers/accounts'
+import { starredAccountsEnforceHideEmptyTokenSelector } from '../../reducers/accounts'
 import { i } from '../../helpers/staticPath'
 import Item from './Item'
 
@@ -31,7 +31,7 @@ const Placeholder = styled.div`
 `
 
 const mapStateToProps = createStructuredSelector({
-  starredAccounts: starredAccountsSelector,
+  starredAccounts: starredAccountsEnforceHideEmptyTokenSelector,
 })
 
 const mapDispatchToProps = {
@@ -47,7 +47,10 @@ class Stars extends PureComponent<{
   onDragEnd = ({ source, destination }) => {
     const { dragDropStarAction, starredAccounts } = this.props
     if (destination) {
-      dragDropStarAction({ from: source.index, to: destination.index, starredAccounts })
+      const from = source.index
+      const to = destination.index
+
+      dragDropStarAction({ from: starredAccounts[from].id, to: starredAccounts[to].id })
     }
   }
 

--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -6,6 +6,7 @@ import accountModel from 'helpers/accountModel'
 import logger from 'logger'
 import type { Account } from '@ledgerhq/live-common/lib/types'
 import { flattenAccounts, clearAccount, canBeMigrated } from '@ledgerhq/live-common/lib/account'
+import { getEnv } from '@ledgerhq/live-common/lib/env'
 import { OUTDATED_CONSIDERED_DELAY, DEBUG_SYNC } from 'config/constants'
 import { currenciesStatusSelector, currencyDownStatusLocal } from './currenciesStatus'
 import { starredAccountIdsSelector } from './settings'
@@ -113,17 +114,26 @@ export const accountSelector = createSelector(
   (accounts, accountId) => accounts.find(a => a.id === accountId),
 )
 
+const flattenFilterAndSort = (accounts, ids, flattenOptions) =>
+  flattenAccounts(accounts, flattenOptions)
+    .filter(e => ids.includes(e.id))
+    .sort((a, b) => {
+      const posA = ids.indexOf(a.id)
+      const posB = ids.indexOf(b.id)
+      return posA > posB ? 1 : posA === posB ? 0 : -1
+    })
+
 export const starredAccountsSelector = createSelector(
   accountsSelector,
   starredAccountIdsSelector,
-  (accounts, ids) =>
-    flattenAccounts(accounts)
-      .filter(e => ids.includes(e.id))
-      .sort((a, b) => {
-        const posA = ids.indexOf(a.id)
-        const posB = ids.indexOf(b.id)
-        return posA > posB ? 1 : posA === posB ? 0 : -1
-      }),
+  flattenFilterAndSort,
+)
+
+export const starredAccountsEnforceHideEmptyTokenSelector = createSelector(
+  accountsSelector,
+  starredAccountIdsSelector,
+  () => getEnv('HIDE_EMPTY_TOKEN_ACCOUNTS'), // The result of this func is not used but it allows the input params to be different so that reselect recompute the output
+  (accounts, ids) => flattenFilterAndSort(accounts, ids, { enforceHideEmptyTokenAccounts: true }),
 )
 
 export const isStarredAccountSelector = createSelector(

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -143,9 +143,12 @@ const handlers: Object = {
       ? state.starredAccountIds.filter(e => e !== accountId)
       : [...state.starredAccountIds, accountId],
   }),
-  SETTINGS_DRAG_DROP_STAR: (state: SettingsState, { payload: { from, to, starredAccounts } }) => {
-    const ids = starredAccounts.map(a => a.id)
-    ids.splice(to, 0, ids.splice(from, 1)[0])
+  SETTINGS_DRAG_DROP_STAR: (state: SettingsState, { payload: { from, to } }) => {
+    const ids = [...state.starredAccountIds]
+    const fromIndex = ids.indexOf(from)
+    const toIndex = ids.indexOf(to)
+
+    ids.splice(toIndex, 0, ids.splice(fromIndex, 1)[0])
 
     return {
       ...state,


### PR DESCRIPTION
When the user enables _Hide empty token accounts_, also hide them from the _Starred Accounts_ section in the sidebar.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1740

### Parts of the app affected

Starred accounts

### Test plan

- Toggling _Hide empty account_ should immediately reflect on the Starred accounts list
- Re-ordering accounts (via drag and drop) while empty accounts are hidden shouldn't mess up the list, even after toggling the hiding back off
- Special case brought to my attention by @juan-cortes: verify that nothing breaks when the list is shuffled around after deleting (not just unstarring) one of the starred accounts
