### PR TITLE
LL-1847 Make Transaction invalid if fees are 0 for bitcoin family

### DIFF
--- a/src/bridge/LibcoreBridge.js
+++ b/src/bridge/LibcoreBridge.js
@@ -87,7 +87,7 @@ const createTransaction = () => ({
 const feesLoaded = (a, t) => {
   switch (a.currency.family) {
     case 'bitcoin':
-      return !!t.feePerByte
+      return !!t.feePerByte && BigNumber(t.feePerByte).gt(0)
     case 'ethereum':
       return !!t.gasPrice
     case 'ripple':


### PR DESCRIPTION
In the send flow for a bitcoin like currency we can pass the validation and click on continue even when the fees are set to zero. This addresses that issue.

<img width="1452" alt="image" src="https://user-images.githubusercontent.com/4631227/64608819-c6e18100-d3cb-11e9-9fa0-c63d9163880e.png">
<img width="1452" alt="image" src="https://user-images.githubusercontent.com/4631227/64608833-ccd76200-d3cb-11e9-8c6d-07e661fc97d7.png">


### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1847

### Parts of the app affected / Test plan

Send flow
