### PR TITLE
LL-1862 Add a separator in the disclaimer modal

### DIFF
--- a/src/components/base/Modal/ModalBody.js
+++ b/src/components/base/Modal/ModalBody.js
@@ -77,10 +77,10 @@ class ModalBody extends PureComponent<Props, State> {
           noScroll={noScroll}
         >
           {render && render(renderProps)}
+          <div style={GRADIENT_WRAPPER_STYLE}>
+            <Animated.div style={gradientStyle} />
+          </div>
         </ModalContent>
-        <div style={GRADIENT_WRAPPER_STYLE}>
-          <Animated.div style={gradientStyle} />
-        </div>
         {renderedFooter && <ModalFooter>{renderedFooter}</ModalFooter>}
       </Fragment>
     )

--- a/src/components/modals/UpdateFirmware/Disclaimer.js
+++ b/src/components/modals/UpdateFirmware/Disclaimer.js
@@ -2,8 +2,8 @@
 /* eslint react/jsx-no-literals: 0 */
 
 import React, { PureComponent } from 'react'
-import { translate, Trans } from 'react-i18next'
-import type { OsuFirmware, FinalFirmware } from '@ledgerhq/live-common/lib/types/manager'
+import { Trans, translate } from 'react-i18next'
+import type { FinalFirmware, OsuFirmware } from '@ledgerhq/live-common/lib/types/manager'
 import type { T } from 'types/common'
 
 import Modal from 'components/base/Modal'
@@ -13,6 +13,7 @@ import Button from 'components/base/Button'
 import GrowScroll from 'components/base/GrowScroll'
 import GradientBox from 'components/GradientBox'
 import Markdown, { Notes } from 'components/base/Markdown'
+import styled from 'styled-components'
 import TrackPage from 'analytics/TrackPage'
 
 import type { ModalStatus } from 'components/ManagerPage/FirmwareUpdate'
@@ -32,6 +33,13 @@ type Props = {
 }
 
 type State = *
+
+const NotesWrapper = styled(Box)`
+  border-top: 1px solid ${p => p.theme.colors.lightGrey};
+  height: 250px;
+  margin-top: 8px;
+  position: relative;
+`
 
 class DisclaimerModal extends PureComponent<Props, State> {
   render(): React$Node {
@@ -59,17 +67,18 @@ class DisclaimerModal extends PureComponent<Props, State> {
               </Text>
               <Text ff="Open Sans|Regular" fontSize={4} color="graphite" align="center">
                 {t('manager.firmware.disclaimerAppDelete')}
+                {' '}
                 {t('manager.firmware.disclaimerAppReinstall')}
               </Text>
               {firmware && firmware.osu ? (
-                <Box relative pb={0} style={{ height: 250, width: '100%' }}>
+                <NotesWrapper>
                   <GrowScroll pb={5}>
                     <Notes>
                       <Markdown>{firmware.osu.notes}</Markdown>
                     </Notes>
                   </GrowScroll>
                   <GradientBox />
-                </Box>
+                </NotesWrapper>
               ) : null}
             </Box>
           )}


### PR DESCRIPTION

![modal](https://user-images.githubusercontent.com/4631227/64693629-f3fb6580-d497-11e9-9d3f-15e85a0a5d25.gif)
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

This simply adds a border and a little bit of padding to the header so that it doesn't cut the content when scrolling. I did not do anything to the percentage loader referred to in the issue because I believe it's better to show 78% and then finish or whatever than get stuck in 100%. The screenshot is not really representative since it wont look exactly like that but the black border shown is the new addition (gray in the real world)

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1862

### Parts of the app affected / Test plan

Firmware update modal, disclaimer step.
