### PR TITLE
fix device not recognized after repair on manager genuine check

### DIFF
--- a/src/components/SettingsPage/RepairDeviceButton.js
+++ b/src/components/SettingsPage/RepairDeviceButton.js
@@ -49,8 +49,12 @@ class RepairDeviceButton extends PureComponent<Props, State> {
   timeout: *
 
   close = () => {
+    const { onRepair } = this.props
     if (this.sub) this.sub.unsubscribe()
     if (this.timeout) clearTimeout(this.timeout)
+    if (onRepair) {
+      onRepair(false)
+    }
     this.setState({ opened: false, isLoading: false, error: null, progress: 0 })
   }
 


### PR DESCRIPTION
Fixing a strange case where the manager would not find the device after a repair on the Manager Genuine Check. Found kind of a solution but not completely sure this is  over yet. More investigation / discussion is needed is think to resolve this issue

### Type

Bug Fix

### Context

LL-1856

### Parts of the app affected / Test plan

Manager Genuine Check

### Examples

Video examples are available on the Jira issues @Arnaud97234 @gre 


