### PR TITLE
LL-1875 Sort account distribution based on distribution percentage

### DIFF
--- a/src/components/AccountDistribution/index.js
+++ b/src/components/AccountDistribution/index.js
@@ -26,16 +26,18 @@ const mapStateToProps = (state, props) => {
   const total = accounts.reduce((total, a) => total.plus(a.balance), BigNumber(0))
 
   return {
-    accountDistribution: accounts.map(a => ({
-      account: a,
-      currency: a.type === 'Account' ? a.currency : a.token,
-      distribution: a.balance.div(total).toFixed(2),
-      amount: a.balance,
-      countervalue: calculateCountervalueSelector(state)(
-        a.type === 'Account' ? a.currency : a.token,
-        a.balance,
-      ),
-    })),
+    accountDistribution: accounts
+      .map(a => ({
+        account: a,
+        currency: a.type === 'Account' ? a.currency : a.token,
+        distribution: a.balance.div(total).toFixed(2),
+        amount: a.balance,
+        countervalue: calculateCountervalueSelector(state)(
+          a.type === 'Account' ? a.currency : a.token,
+          a.balance,
+        ),
+      }))
+      .sort((a, b) => b.distribution - a.distribution),
     counterValueCurrency: counterValueCurrencySelector,
   }
 }

--- a/src/components/AssetPage/index.js
+++ b/src/components/AssetPage/index.js
@@ -1,11 +1,7 @@
 // @flow
 
 import React, { PureComponent } from 'react'
-import {
-  flattenAccounts,
-  getAccountCurrency,
-  getAccountUnit,
-} from '@ledgerhq/live-common/lib/account'
+import { getAccountCurrency, getAccountUnit } from '@ledgerhq/live-common/lib/account'
 import { findCurrencyByTicker, getCurrencyColor } from '@ledgerhq/live-common/lib/currencies'
 import type { PortfolioRange } from '@ledgerhq/live-common/lib/types'
 import { compose } from 'redux'
@@ -24,6 +20,7 @@ import {
   countervalueFirstSelector,
   selectedTimeRangeSelector,
 } from '../../reducers/settings'
+import { flattenSortAccountsEnforceHideEmptyTokenSelector } from '../../actions/general'
 import AssetHeader from './AssetHeader'
 
 type Props = {
@@ -57,9 +54,7 @@ const mapStateToProps = (state, props) => ({
   counterValue: counterValueCurrencySelector(state),
   allAccounts: accountsSelector(state),
   countervalueFirst: countervalueFirstSelector(state),
-  accounts: flattenAccounts(accountsSelector(state), {
-    enforceHideEmptyTokenAccounts: true,
-  }).filter(
+  accounts: flattenSortAccountsEnforceHideEmptyTokenSelector(state).filter(
     a =>
       (a.type === 'Account' ? a.currency : a.token) ===
       findCurrencyByTicker(props.match.params.assetTicker),


### PR DESCRIPTION
Instead of using the global account sorting, rely on the percentage of distribution of an asset for each account

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1875

### Parts of the app affected / Test plan

Change the sorting settings and see if the account distribution block reflects those changes.
It should *not*
