### PR TITLE
LL-1904 Make context menu's width adapt to the text

### DIFF
--- a/src/components/ContextMenu/ContextMenuWrapper.js
+++ b/src/components/ContextMenu/ContextMenuWrapper.js
@@ -44,7 +44,7 @@ const ContextMenuContainer = styled(Box)`
   position: absolute;
   top: ${p => p.y}px;
   left: ${p => p.x}px;
-  width: 170px;
+  width: auto;
   border-radius: 4px;
   box-shadow: 0 4px 8px 0 #00000007;
   border: 1px solid ${p => p.theme.colors.palette.divider};


### PR DESCRIPTION
### Show me
<img width="630" alt="image" src="https://user-images.githubusercontent.com/4631227/66782628-69fb4e00-eed6-11e9-86d6-d3f03dd3d20c.png">

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1904

### Parts of the app affected / Test plan

Context menus


