### PR TITLE
Fixes display of firmware version in releasenotes

### DIFF
--- a/src/components/modals/UpdateFirmware/Disclaimer.js
+++ b/src/components/modals/UpdateFirmware/Disclaimer.js
@@ -114,7 +114,7 @@ class DisclaimerModal extends PureComponent<Props, State> {
                       You are about to install
                       <Text ff="Inter|SemiBold" color="palette.text.shade100">
                         {`firmware version ${
-                          firmware && firmware.osu ? getCleanVersion(firmware.osu.name) : ''
+                          firmware && firmware.final ? getCleanVersion(firmware.final.name) : ''
                         }`}
                       </Text>
                     </Trans>


### PR DESCRIPTION
I didn't test it but it should fix the firmware version displayed for osu name.

### Type

display fix

### Context

tf-*-sanitycheck
