### PR TITLE
Fixes optimistic op

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@ledgerhq/hw-transport-node-hid": "^4.72.2",
     "@ledgerhq/hw-transport-node-hid-singleton": "^4.72.2",
     "@ledgerhq/ledger-core": "^3.3.0",
-    "@ledgerhq/live-common": "^8.0.0-alpha.12",
+    "@ledgerhq/live-common": "^8.0.0-alpha.15",
     "@ledgerhq/logs": "^4.72.0",
     "@tippy.js/react": "^3.1.0",
     "add": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@ledgerhq/hw-transport-node-hid": "^4.72.2",
     "@ledgerhq/hw-transport-node-hid-singleton": "^4.72.2",
     "@ledgerhq/ledger-core": "^3.3.0",
-    "@ledgerhq/live-common": "^8.0.0-alpha.10",
+    "@ledgerhq/live-common": "^8.0.0-alpha.12",
     "@ledgerhq/logs": "^4.72.0",
     "@tippy.js/react": "^3.1.0",
     "add": "^2.0.6",

--- a/src/components/TokenRow.js
+++ b/src/components/TokenRow.js
@@ -72,7 +72,7 @@ class TokenRow extends PureComponent<Props> {
     const Row = nested ? NestedRow : TopLevelRow
     return (
       <Row index={index} onClick={this.onClick}>
-        <Header nested={nested} account={account} name={currency.name} />
+        <Header nested={nested} account={account} />
         <Balance unit={unit} balance={account.balance} disableRounding={disableRounding} />
         <Countervalue account={account} currency={currency} range={range} />
         <Delta account={account} range={range} />

--- a/src/components/modals/Send/Body.js
+++ b/src/components/modals/Send/Body.js
@@ -107,6 +107,7 @@ const Body = ({
   stepId,
   params,
   accounts,
+  updateAccountWithUpdater,
 }: Props) => {
   const openedFromAccount = !!params.account
   const [steps] = useState(createSteps)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1794,15 +1794,6 @@
     "@ledgerhq/logs" "^4.72.0"
     rxjs "^6.5.3"
 
-"@ledgerhq/devices@^4.72.2":
-  version "4.72.2"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.72.2.tgz#9f91371c6a08cd4d93be0d6fe1c5d53a9ccd4a14"
-  integrity sha512-iX6ZfxFrKxlO3A7rDypjsqbu1Ta2IB+OsOk/7jnd3fzcvwlSEQwflAHb81CsjOPhdVG2aPIFU/VxzMioDFz24g==
-  dependencies:
-    "@ledgerhq/errors" "^4.72.2"
-    "@ledgerhq/logs" "^4.72.0"
-    rxjs "^6.5.3"
-
 "@ledgerhq/electron-updater@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/electron-updater/-/electron-updater-3.3.1.tgz#d7d175aa1371e68ec10ba198f8539f403c9bb76e"
@@ -1824,12 +1815,7 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.72.2.tgz#62a87a249c3c05e7295f66c3d49d78e7d46d611f"
   integrity sha512-Q9SnjsoIiNhoTujUWfNgGqvYHgaPGRLzuYAC0Rx2WjEKp7swO42BMukYtSgXyyrz4yfHhMBMYerEF2sonBVzXw==
 
-"@ledgerhq/errors@^4.72.1":
-  version "4.72.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.72.1.tgz#de2d0390476078d5bd5a0659dae796f36ed3970a"
-  integrity sha512-zzxy/pGSLPBkd9RJXhiQj53lsx4c3vMFMy0rMymhnKcBZboI+uD2E7WOToHvxtY34jka9vnH/ySjUIB/Ytvyzg==
-
-"@ledgerhq/hw-app-btc@4.72.2":
+"@ledgerhq/hw-app-btc@4.72.2", "@ledgerhq/hw-app-btc@^4.72.2":
   version "4.72.2"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-4.72.2.tgz#d4fbfb93a34729b5d5087249632be240d9607952"
   integrity sha512-ANa1Dmcmvm1S4CKvnbmEhEYHdIslAF3p/3cd7VspC3Z4NbJbRxgQTV/9o9e23/6brkDKDPYLmPyTZcLCf4JSUQ==
@@ -1837,15 +1823,7 @@
     "@ledgerhq/hw-transport" "^4.72.2"
     create-hash "^1.1.3"
 
-"@ledgerhq/hw-app-btc@^4.72.1":
-  version "4.72.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-4.72.1.tgz#19c5666e8a4213e73d8392473db9b861389ef958"
-  integrity sha512-VCV+hv6arrOTc5Upb5B6WhQJOXOd5ZVVtfaCLDidSF8sTqx8K9W3lILf9545v34Nu41WxWFnMargcR9z5u2Wwg==
-  dependencies:
-    "@ledgerhq/hw-transport" "^4.72.2"
-    create-hash "^1.1.3"
-
-"@ledgerhq/hw-app-eth@4.72.2":
+"@ledgerhq/hw-app-eth@4.72.2", "@ledgerhq/hw-app-eth@^4.72.2":
   version "4.72.2"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.72.2.tgz#64ec0377efa462bc8092cba88b700d11ed51c13f"
   integrity sha512-pW2vOX29M5UvjqvEHVQsd3pDskJBcRPtQCSXtknLj4ZlSuCCuZtOhtD4qO3/nEiiHZL0DejTlRB9gl2Qug50lw==
@@ -1853,26 +1831,10 @@
     "@ledgerhq/errors" "^4.72.2"
     "@ledgerhq/hw-transport" "^4.72.2"
 
-"@ledgerhq/hw-app-eth@^4.72.1":
-  version "4.72.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.72.1.tgz#4098a64d20d337d808aad92428cda95ef00ac31d"
-  integrity sha512-rx1gQOkUF9GVN5qg6VdlyD2Ap+/4E+2svb0RBj5tk94WBiiQv477on5fZCjQVEd/VOuSInNGSeoArbK9DTspJw==
-  dependencies:
-    "@ledgerhq/errors" "^4.72.2"
-    "@ledgerhq/hw-transport" "^4.72.2"
-
-"@ledgerhq/hw-app-xrp@4.72.2":
+"@ledgerhq/hw-app-xrp@4.72.2", "@ledgerhq/hw-app-xrp@^4.72.2":
   version "4.72.2"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-xrp/-/hw-app-xrp-4.72.2.tgz#d0c99c3a6a182be29afdcf435e55e2ad95a1ae76"
   integrity sha512-iJG//i3rlwp+LMxKQT+onIY/nXpaywKfjHlRgzqyGqiZDea1sVp+Zh1vXEPyqpINfX8q48T64nwmUNmdQKBixg==
-  dependencies:
-    "@ledgerhq/hw-transport" "^4.72.2"
-    bip32-path "0.4.2"
-
-"@ledgerhq/hw-app-xrp@^4.72.1":
-  version "4.72.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-xrp/-/hw-app-xrp-4.72.1.tgz#58879d391759c83222444b458589cdd98a58b060"
-  integrity sha512-6NJN1ZQK4fd1ANGYA/NSQ/fuCHi6468i5zYptaH/LWB9pLzGdA9BVB0VQmHhlBg5XMw1lEtFrlbDFz4tfAUrVQ==
   dependencies:
     "@ledgerhq/hw-transport" "^4.72.2"
     bip32-path "0.4.2"
@@ -1944,15 +1906,6 @@
     "@ledgerhq/errors" "^4.72.2"
     events "^3.0.0"
 
-"@ledgerhq/hw-transport@^4.72.1":
-  version "4.72.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.72.1.tgz#431be99e883c71be6fc6bd7480902bcd41ae24a0"
-  integrity sha512-6RBiDALBiVfBWK6zaZzhVj/jPZR4vEfxfRvh8iDerxYhcFY/uVVbQkoegt6dBtCX0q5T4nDLAWp5jqV8j0dcZw==
-  dependencies:
-    "@ledgerhq/devices" "^4.72.2"
-    "@ledgerhq/errors" "^4.72.2"
-    events "^3.0.0"
-
 "@ledgerhq/ledger-core@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-3.3.0.tgz#befe6a11acfce72eb2774c00c4fc207710d31a00"
@@ -1961,10 +1914,10 @@
     bindings "^1.3.0"
     nan "^2.6.2"
 
-"@ledgerhq/live-common@^8.0.0-alpha.10":
-  version "8.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-8.0.0-alpha.10.tgz#82d30f56acf82828008f9406975ffcf5c114f7cf"
-  integrity sha512-923xkqKN8JNypQP+AJ1ZuFcij3ofv6RJn25deEUZMcjPdh6MOozKnmlRFY4MyOQpFjIuUHz73K7ThatkB0GXWg==
+"@ledgerhq/live-common@^8.0.0-alpha.12":
+  version "8.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-8.0.0-alpha.12.tgz#db5c0f6c7f0ed147109d4e92e47313205fbb3844"
+  integrity sha512-gAdlYuvv9A7F+ov8ekd0vN+CwvVPYTOk/zOGU9SvN1YcJGffdJnbwxAU2eRJZeDLFpB5iCbkVGcaZJF/rNXuPA==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/errors" "4.72.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,10 +1914,10 @@
     bindings "^1.3.0"
     nan "^2.6.2"
 
-"@ledgerhq/live-common@^8.0.0-alpha.12":
-  version "8.0.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-8.0.0-alpha.12.tgz#db5c0f6c7f0ed147109d4e92e47313205fbb3844"
-  integrity sha512-gAdlYuvv9A7F+ov8ekd0vN+CwvVPYTOk/zOGU9SvN1YcJGffdJnbwxAU2eRJZeDLFpB5iCbkVGcaZJF/rNXuPA==
+"@ledgerhq/live-common@^8.0.0-alpha.15":
+  version "8.0.0-alpha.15"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-8.0.0-alpha.15.tgz#dfc48d5a751d3eca387dcce4899658bf0d44c36b"
+  integrity sha512-oZkWWCtI045EajXwgeCi8HAfGa6Sey9S+qRg97GkfnxJI+Dj/2bCexEgLsNwTlwMDRjIozzslrdzK321juU9uw==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/errors" "4.72.2"


### PR DESCRIPTION
This fixes optimistic operation to correctly appear in the operations list as well as in operation detail. It also fixes other minor bugs.

A regression was done during the bridge rework and should now be fixed (it was not in production). Moreover, there should be a fix in live-common that no longer make the operation temporarily disappearing (this one we can sometimes see it in production in ERC20).

### Type

Bug fixes

### Context

LL-1816
LL-1962
LL-1933


### Parts of the app affected / Test plan

send
