### PR TITLE
Fixes LL-1967

### DIFF
--- a/src/components/OperationsList/ConfirmationCheck.js
+++ b/src/components/OperationsList/ConfirmationCheck.js
@@ -96,7 +96,13 @@ class ConfirmationCheck extends PureComponent<{
 
     return withTooltip ? (
       <Tooltip
-        content={t(isConfirmed ? 'operationDetails.confirmed' : 'operationDetails.notConfirmed')}
+        content={t(
+          hasFailed
+            ? 'operationDetails.failed'
+            : isConfirmed
+            ? 'operationDetails.confirmed'
+            : 'operationDetails.notConfirmed',
+        )}
       >
         {content}
       </Tooltip>


### PR DESCRIPTION
proper tooltip label for failed op

<img width="194" alt="Capture d’écran 2019-10-21 à 11 47 45" src="https://user-images.githubusercontent.com/211411/67195084-9d6b3a80-f3f8-11e9-8452-416142a64de5.png">


### Type

Bug fix

### Context

LL-1967

### Parts of the app affected / Test plan

operation row, eth failed op