### PR TITLE
Fixes XRP transaction to "converge" in the proxy

### DIFF
--- a/src/bridge/proxy.js
+++ b/src/bridge/proxy.js
@@ -139,7 +139,10 @@ export const getAccountBridge = (
         transaction,
       })
       .toPromise()
-    if (isEqual(transaction, result)) {
+
+    // this will remove the `undefined` fields due to JSON back&forth
+    const sentTransaction = JSON.parse(JSON.stringify(transaction))
+    if (isEqual(sentTransaction, result)) {
       return t // preserve reference by deep equality of the TransactionRaw
     }
     return fromTransactionRaw(result)


### PR DESCRIPTION
a recent regression due to `tag:undefined` was not correctly working on desktop because the proxy do a deep equal on the transaction for prepareTransaction but JSON stringify will remove the tag:undefined field..