### PR TITLE
Keep local state of user selected item for bitcoin-like fees

### DIFF
--- a/src/families/FeeField/BitcoinKind.js
+++ b/src/families/FeeField/BitcoinKind.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { BigNumber } from 'bignumber.js'
 import styled from 'styled-components'
 import { Trans, translate } from 'react-i18next'
@@ -64,8 +64,11 @@ const FeesField = ({ transaction, account, onChange, status }: Props) => {
     [networkInfo],
   )
 
+  const [selectedItem, setSelectedItem] = useState(last(feeItems))
   const selectedValue = feePerByte
-    ? feeItems.find(f => f.feePerByte.eq(feePerByte)) || last(feeItems)
+    ? selectedItem.feePerByte.eq(feePerByte)
+      ? selectedItem
+      : feeItems.find(f => f.feePerByte.eq(feePerByte)) || last(feeItems)
     : last(feeItems)
 
   const { units } = account.currency
@@ -74,9 +77,10 @@ const FeesField = ({ transaction, account, onChange, status }: Props) => {
   const onSelectChange = useCallback(
     (item: any) => {
       if (item.label === 'custom') return
+      if (item.label) setSelectedItem(item)
       onChange(bridge.updateTransaction(transaction, { feePerByte: item.feePerByte }))
     },
-    [onChange, transaction, bridge],
+    [onChange, transaction, bridge, setSelectedItem],
   )
 
   const onInputChange = feePerByte => onSelectChange({ feePerByte })

--- a/src/families/FeeField/BitcoinKind.js
+++ b/src/families/FeeField/BitcoinKind.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useRef, useCallback, useMemo, useState } from 'react'
 import { BigNumber } from 'bignumber.js'
 import styled from 'styled-components'
 import { Trans, translate } from 'react-i18next'
@@ -48,7 +48,7 @@ const FeesField = ({ transaction, account, onChange, status }: Props) => {
 
   const bridge = getAccountBridge(account)
   const { feePerByte, networkInfo } = transaction
-  let input: ?HTMLInputElement
+  const inputRef = useRef()
 
   const feeItems = useMemo(
     () =>
@@ -78,13 +78,13 @@ const FeesField = ({ transaction, account, onChange, status }: Props) => {
   const onSelectChange = useCallback(
     (item: any) => {
       setSelectedItem(item)
-      if (item.label === 'custom' && input) {
-        input.select()
+      if (item.label === 'custom' && inputRef.current) {
+        inputRef.current.select()
         return
       }
       onChange(bridge.updateTransaction(transaction, { feePerByte: item.feePerByte }))
     },
-    [onChange, transaction, bridge, setSelectedItem, input],
+    [onChange, transaction, bridge, setSelectedItem, inputRef],
   )
 
   const onInputChange = feePerByte => onSelectChange({ feePerByte })
@@ -107,7 +107,7 @@ const FeesField = ({ transaction, account, onChange, status }: Props) => {
         <InputCurrency
           defaultUnit={satoshi}
           units={units}
-          ref={_input => (input = _input)}
+          ref={inputRef}
           containerProps={{ grow: true }}
           value={feePerByte}
           onChange={onInputChange}


### PR DESCRIPTION
Sometimes the value for low/standard/high fees might overlap so it would appear that the user selection is not respected. This local state will show the selected item as the one the user choses even if there is a previous item in the options that matches the value.

### Type

UX

### Context

https://ledgerhq.atlassian.net/browse/LL-1970

### Parts of the app affected / Test plan

Send flow bitcoin-like
