### PR TITLE
LL-1938 Fix cutoff text for account name

### DIFF
--- a/src/components/AccountPage/AccountHeader.js
+++ b/src/components/AccountPage/AccountHeader.js
@@ -71,9 +71,7 @@ const AccountName = styled(Text).attrs(() => ({
   color: 'palette.text.shade100',
   ff: 'Inter|SemiBold',
   fontSize: 7,
-}))`
-  line-height: 1.1;
-`
+}))``
 
 type Props = {
   account: AccountLike,


### PR DESCRIPTION
Fun bug, letter were being cut by a parent component having set the line height to `1.1em`. According to [the specs](https://www.w3.org/TR/CSS21/fonts.html#font-size-props):

> _The font size corresponds to the em square, a concept used in typography. **Note that certain glyphs may bleed outside their em squares.**_ 

That's the reason why we were getting the tail of the `g` cut off, the element with a defined line-height limited to 1.1 tries to bleed and gets cut-off, removing the value altogether defaults to `inherit` showing the full letter once again, since the element now extends to the new height.

![image](https://user-images.githubusercontent.com/4631227/67224859-6ade3380-f432-11e9-824a-8165fb694d21.png)

### Type

UI Polish

### Context
https://ledgerhq.atlassian.net/browse/LL-1938
<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan
Accounts page names with letter that go below the base line. (gjq)
