### PR TITLE
Firmware identifier fix

### DIFF
--- a/src/components/modals/UpdateFirmware/steps/01-step-install-full-firmware.js
+++ b/src/components/modals/UpdateFirmware/steps/01-step-install-full-firmware.js
@@ -63,7 +63,7 @@ type State = {
 class StepFullFirmwareInstall extends PureComponent<Props, State> {
   state = {
     progress: 0,
-    displayedOnDevice: true,
+    displayedOnDevice: false,
   }
 
   componentDidMount() {


### PR DESCRIPTION
A flash of seeing Identifier before the OSU is even uploaded to the device was caused by a recent regression.