### PR TITLE
Fixes a regression in the illustration interactions for devices

### DIFF
--- a/src/icons/device/interactions/index.js
+++ b/src/icons/device/interactions/index.js
@@ -57,8 +57,8 @@ const Interactions = ({
     error: !!error,
     screen: error ? 'fail' : screen,
     usb: wire && usbMap[wire],
-    leftHint: action === 'left' || action === 'accept',
-    rightHing: action === 'accept',
+    leftHint: action === 'left' || (type === 'nanoX' && action === 'accept'),
+    rightHint: action === 'accept',
   }
 
   return <Device open {...rest} {...props} />


### PR DESCRIPTION
This fixes the typo that made only the left button show on a Nano S accept action illustration, and removes that left button hint since validations on the S are only done pressing right. 

Important to note that with the introduction of 1.6.0 we will need to take that into account since the interactions will now be accepted by pressing both buttons. @gre mentioned revisitng this after we reach a percentage of users on 1.6.0

### Type

UI Polish

### Parts of the app affected / Test plan

Interactions that offer an illustration with hints such as the firmware update ones.
