### PR TITLE
Use the deleteLibcore function when resetting libcore.

### DIFF
--- a/src/commands/libcoreReset.js
+++ b/src/commands/libcoreReset.js
@@ -2,13 +2,13 @@
 
 import { createCommand, Command } from 'helpers/ipc'
 import { from } from 'rxjs'
-import { withLibcore } from '@ledgerhq/live-common/lib/libcore/access'
+import { deleteLibcore, withLibcore } from '@ledgerhq/live-common/lib/libcore/access'
 
 type Input = void
 type Result = void
 
 const cmd: Command<Input, Result> = createCommand('libcoreReset', () =>
-  from(withLibcore(core => core.getPoolInstance().freshResetAll())),
+  from(withLibcore(core => core.getPoolInstance().freshResetAll()).then(_ => deleteLibcore())),
 )
 
 export default cmd


### PR DESCRIPTION
This call will make future withLibcore calls to actually recreate the
Core structure.
