### PR TITLE
LL-1960 Ellipsis missing on account name receive modal

### DIFF
--- a/src/components/CurrentAddress/index.js
+++ b/src/components/CurrentAddress/index.js
@@ -22,6 +22,7 @@ import LinkWithExternalIcon from 'components/base/LinkWithExternalIcon'
 import IconRecheck from 'icons/Recover'
 import IconCopy from 'icons/Copy'
 import IconShield from 'icons/Shield'
+import Ellipsis from '../base/Ellipsis'
 
 const Container = styled(Box).attrs(p => ({
   borderRadius: 1,
@@ -70,6 +71,7 @@ const Label = styled(Box).attrs(() => ({
   flow: 1,
   horizontal: true,
 }))`
+  width: 100%;
   strong {
     color: ${p => p.theme.colors.palette.text.shade100};
     font-weight: 600;
@@ -198,16 +200,16 @@ class CurrentAddress extends PureComponent<Props, { copyFeedback: boolean }> {
           />
         </QRCodeContainer>
         <Label>
-          <Box>
-            {name ? (
-              <Trans i18nKey="currentAddress.for" parent="div">
+          {name ? (
+            <Ellipsis textAlign="center">
+              <Trans i18nKey="currentAddress.for">
                 {'Address for '}
                 <strong>{name}</strong>
               </Trans>
-            ) : (
-              t('currentAddress.title')
-            )}
-          </Box>
+            </Ellipsis>
+          ) : (
+            t('currentAddress.title')
+          )}
         </Label>
         <Address>
           {copyFeedback && <CopyFeedback>{t('common.addressCopied')}</CopyFeedback>}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/68201028-4bfaa800-ffc1-11e9-96f5-17a560a1732e.png)

### Type
UI Polish
<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context
https://ledgerhq.atlassian.net/browse/LL-1960
<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan
Receive flow
<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
