### PR TITLE
fixed counter value on chart tooltips

### DIFF
--- a/src/components/AccountPage/BalanceSummary.js
+++ b/src/components/AccountPage/BalanceSummary.js
@@ -43,7 +43,7 @@ class AccountBalanceSummary extends PureComponent<Props> {
     return (
       <Fragment>
         <FormattedVal fontSize={5} color="palette.text.shade100" showCode {...data[0]} />
-        <FormattedVal fontSize={4} color="warmGrey" showCode {...data[1]} />
+        {balanceHistoryWithCountervalue.countervalueAvailable ? <FormattedVal fontSize={4} color="warmGrey" showCode {...data[1]} /> : null}
         <Box ff="Inter|Regular" color="palette.text.shade60" fontSize={3} mt={2}>
           {moment(d.date).format('LL')}
         </Box>

--- a/src/components/AssetPage/BalanceSummary.js
+++ b/src/components/AssetPage/BalanceSummary.js
@@ -44,7 +44,7 @@ class BalanceSummary extends PureComponent<Props> {
     const {
       unit,
       counterValue,
-      portfolio: { history },
+      portfolio: { history, countervalueAvailable },
       countervalueFirst,
     } = this.props
     const displayCountervalue = countervalueFirst && history.countervalueAvailable
@@ -53,7 +53,7 @@ class BalanceSummary extends PureComponent<Props> {
     return (
       <Fragment>
         <FormattedVal fontSize={5} color="palette.text.shade100" showCode {...data[0]} />
-        <FormattedVal fontSize={4} color="warmGrey" showCode {...data[1]} />
+        {countervalueAvailable ? <FormattedVal fontSize={4} color="warmGrey" showCode {...data[1]} /> : null}
         <Box ff="Inter|Regular" color="palette.text.shade60" fontSize={3} mt={2}>
           {moment(d.date).format('LL')}
         </Box>


### PR DESCRIPTION
Fixed counter values being displayed when non available on chart tooltips (assetportfolio / account page)

### Type

Bug Fix

### Context

LL-1959

### Parts of the app affected / Test plan

Account page chart / Asset portfolio chart