### PR TITLE
LL-1939 Styling of select component

### DIFF
--- a/src/components/base/Select/createStyles.js
+++ b/src/components/base/Select/createStyles.js
@@ -63,10 +63,10 @@ export default (
         : theme.colors.palette.text.shade80,
     padding: small ? '8px 15px 8px 15px' : '10px 15px 11px 15px',
     cursor: isDisabled ? 'not-allowed' : 'default',
-    backgroundColor: isFocused ? theme.colors.palette.text.shade04 : null,
+    backgroundColor: isFocused ? theme.colors.palette.background.default : null,
     // NB hover doesn't trigger isFocused since we disabled the onMouseMove/onMouseOver
     ':hover:not(:active)': {
-      backgroundColor: theme.colors.palette.text.shade04,
+      backgroundColor: theme.colors.palette.background.default,
       color: theme.colors.palette.text.shade100,
     },
     ':hover:active': {

--- a/src/components/base/Select/createStyles.js
+++ b/src/components/base/Select/createStyles.js
@@ -53,28 +53,29 @@ export default (
     ...styles,
     fontSize: small ? 12 : 13,
   }),
-  option: (styles: Object, { isFocused, isSelected }: Object) => ({
+  option: (styles: Object, { isFocused, isSelected, isDisabled }: Object) => ({
     ...styles,
-    ...ff('Inter|Regular'),
+    ...(isSelected ? ff('Inter|SemiBold') : ff('Inter|Regular')),
     fontSize: small ? 12 : 13,
-    color: theme.colors.palette.text.shade80,
-    padding: '10px 15px 10px 15px',
+    color:
+      isSelected || isFocused
+        ? theme.colors.palette.text.shade100
+        : theme.colors.palette.text.shade80,
+    padding: small ? '8px 15px 8px 15px' : '10px 15px 11px 15px',
+    cursor: isDisabled ? 'not-allowed' : 'default',
+    backgroundColor: isFocused ? theme.colors.palette.text.shade04 : null,
+    // NB hover doesn't trigger isFocused since we disabled the onMouseMove/onMouseOver
+    ':hover:not(:active)': {
+      backgroundColor: theme.colors.palette.text.shade04,
+      color: theme.colors.palette.text.shade100,
+    },
+    ':hover:active': {
+      color: theme.colors.palette.text.shade100,
+    },
     ':active': {
       ...styles[':active'],
-      backgroundColor: theme.colors.palette.action.active,
+      backgroundColor: isDisabled ? null : theme.colors.palette.text.shade10,
     },
-    ...(isFocused
-      ? {
-          background: theme.colors.palette.background.default,
-          color: theme.colors.palette.text.shade100,
-        }
-      : {}),
-    ...(isSelected
-      ? {
-          background: 'unset !important',
-          ...ff('Inter|SemiBold'),
-        }
-      : {}),
   }),
   menu: (styles: Object) => ({
     ...styles,

--- a/src/components/base/Select/index.js
+++ b/src/components/base/Select/index.js
@@ -43,15 +43,7 @@ export type Option = {
   data: any,
 }
 
-const Row = styled.div`
-  &:hover {
-    background: ${p => p.theme.colors.palette.background.default};
-  }
-  &:active {
-    background: ${p => p.theme.colors.palette.background.default};
-  }
-`
-const rowHeight = 40 // Fixme We should pass this as a prop for dynamic rows?
+const Row = styled.div``
 class MenuList extends PureComponent<*, *> {
   state = {
     children: null,
@@ -94,12 +86,12 @@ class MenuList extends PureComponent<*, *> {
       options,
       maxHeight,
       getValue,
-      selectProps: { noOptionsMessage },
+      selectProps: { noOptionsMessage, small },
     } = this.props
     const { children } = this.state
     if (!children) return null
-
     const [value] = getValue()
+    const rowHeight = small ? 34 : 40
     const initialOffset = options.indexOf(value) * rowHeight
     const minHeight = Math.min(...[maxHeight, rowHeight * children.length])
 
@@ -190,6 +182,7 @@ class Select extends PureComponent<Props> {
     } = this.props
 
     const Comp = async ? AsyncReactSelect : ReactSelect
+    const rowHeight = small ? 34 : 40
 
     return (
       <Comp
@@ -213,6 +206,7 @@ class Select extends PureComponent<Props> {
         backspaceRemovesValue
         menuShouldBlockScroll
         menuPortalTarget={document.body}
+        small={small}
         {...props}
         onChange={this.handleChange}
       />

--- a/src/styles/palette.js
+++ b/src/styles/palette.js
@@ -13,6 +13,8 @@ module.exports = {
       shade60: 'rgba(20,37,51, 0.6)',
       shade40: 'rgba(20,37,51, 0.4)',
       shade20: 'rgba(20,37,51, 0.2)',
+      shade10: 'rgba(20,37,51, 0.1)',
+      shade04: 'rgba(20,37,51, 0.04)',
     },
     divider: 'rgba(20,37,51, 0.1)',
     background: {
@@ -41,6 +43,8 @@ module.exports = {
       shade60: 'rgba(255, 255, 255, 0.6)',
       shade40: 'rgba(255, 255, 255, 0.4)',
       shade20: 'rgba(255, 255, 255, 0.2)',
+      shade10: 'rgba(255, 255, 255, 0.1)',
+      shade04: 'rgba(255, 255, 255, 0.04)',
     },
     divider: 'rgba(255, 255, 255, 0.1)',
     background: {
@@ -69,6 +73,8 @@ module.exports = {
       shade60: 'rgba(255, 255, 255, 0.6)',
       shade40: 'rgba(255, 255, 255, 0.4)',
       shade20: 'rgba(255, 255, 255, 0.2)',
+      shade10: 'rgba(255, 255, 255, 0.1)',
+      shade04: 'rgba(255, 255, 255, 0.04)',
     },
     divider: 'rgba(255, 255, 255, 0.1)',
     background: {

--- a/src/styles/palette.js
+++ b/src/styles/palette.js
@@ -14,7 +14,6 @@ module.exports = {
       shade40: 'rgba(20,37,51, 0.4)',
       shade20: 'rgba(20,37,51, 0.2)',
       shade10: 'rgba(20,37,51, 0.1)',
-      shade04: 'rgba(20,37,51, 0.04)',
     },
     divider: 'rgba(20,37,51, 0.1)',
     background: {
@@ -44,7 +43,6 @@ module.exports = {
       shade40: 'rgba(255, 255, 255, 0.4)',
       shade20: 'rgba(255, 255, 255, 0.2)',
       shade10: 'rgba(255, 255, 255, 0.1)',
-      shade04: 'rgba(255, 255, 255, 0.04)',
     },
     divider: 'rgba(255, 255, 255, 0.1)',
     background: {
@@ -74,7 +72,6 @@ module.exports = {
       shade40: 'rgba(255, 255, 255, 0.4)',
       shade20: 'rgba(255, 255, 255, 0.2)',
       shade10: 'rgba(255, 255, 255, 0.1)',
-      shade04: 'rgba(255, 255, 255, 0.04)',
     },
     divider: 'rgba(255, 255, 255, 0.1)',
     background: {


### PR DESCRIPTION
Style overhaul for the select component option's states. Since the introduction of the custom `menuOption` component for performance on lists including erc20 tokens, we've been experiencing a glitchy render where all rows were not quite the right height. This PR addresses tgat and the linked issue LL-1939 where the selected option did not highlight on hover/keyboard-over.

### Type

UI Polish

### Context
https://ledgerhq.atlassian.net/browse/LL-1939




### Parts of the app affected / Test plan
All select components (Account selection, currency selection, language, etc)