### PR TITLE
LL-1926 Prevent tab navigation from escaping the bounds of a modal

### DIFF
--- a/src/components/base/Box/Tabbable.js
+++ b/src/components/base/Box/Tabbable.js
@@ -45,7 +45,10 @@ export default class Tabbable extends Component<
     const { onClick } = this.props
     const canPress =
       (e.which === KEY_ENTER || e.which === KEY_SPACE) && isGlobalTabEnabled() && isFocused
-    if (canPress && onClick) onClick(e)
+    if (canPress && onClick) {
+      e.preventDefault()
+      onClick(e)
+    }
   }
 
   render() {

--- a/src/components/base/Modal/ModalBody.js
+++ b/src/components/base/Modal/ModalBody.js
@@ -40,7 +40,7 @@ class ModalBody extends PureComponent<Props> {
         <ModalHeader onBack={onBack} onClose={onClose}>
           {title}
         </ModalHeader>
-        <ModalContent tabIndex={0} ref={this._content} noScroll={noScroll}>
+        <ModalContent ref={this._content} noScroll={noScroll}>
           {render && render(renderProps)}
         </ModalContent>
         {renderedFooter && <ModalFooter>{renderedFooter}</ModalFooter>}

--- a/src/components/base/Modal/ModalContent.js
+++ b/src/components/base/Modal/ModalContent.js
@@ -63,7 +63,7 @@ const ModalContent = React.forwardRef(({ children, noScroll }: Props, containerR
 
   return (
     <ContentWrapper>
-      <ContentScrollableContainer ref={containerRef} tabIndex={0} noScroll={noScroll}>
+      <ContentScrollableContainer ref={containerRef} noScroll={noScroll}>
         {children}
       </ContentScrollableContainer>
       <ContentScrollableContainerGradient opacity={isScrollable ? 1 : 0} />

--- a/src/components/base/Modal/index.js
+++ b/src/components/base/Modal/index.js
@@ -101,6 +101,7 @@ class Modal extends PureComponent<Props, State> {
     })
 
     document.addEventListener('keyup', this.handleKeyup)
+    document.addEventListener('keydown', this.preventFocusEscape)
   }
 
   componentDidUpdate(prevProps: Props) {
@@ -118,12 +119,39 @@ class Modal extends PureComponent<Props, State> {
 
   componentWillUnmount() {
     document.removeEventListener('keyup', this.handleKeyup)
+    document.removeEventListener('keydown', this.preventFocusEscape)
   }
 
   handleKeyup = (e: KeyboardEvent) => {
     const { onClose, preventBackdropClick } = this.props
     if (e.which === 27 && onClose && !preventBackdropClick) {
       onClose()
+    }
+  }
+
+  preventFocusEscape = (e: KeyboardEvent) => {
+    if (e.key === 'Tab') {
+      const { target } = e
+      const focusableQuery =
+        'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), *[tabindex]'
+      const modalWrapper = document.getElementById('modals')
+      if (!modalWrapper || !(target instanceof window.HTMLElement)) return
+
+      const focusableElements = modalWrapper.querySelectorAll(focusableQuery)
+      if (!focusableElements.length) return
+
+      const firstFocusable = focusableElements[0]
+      const lastFocusable = focusableElements[focusableElements.length - 1]
+
+      if (e.shiftKey && firstFocusable.isSameNode(target)) {
+        lastFocusable.focus()
+        e.stopPropagation()
+        e.preventDefault()
+      } else if (!e.shiftKey && lastFocusable.isSameNode(target)) {
+        firstFocusable.focus()
+        e.stopPropagation()
+        e.preventDefault()
+      }
     }
   }
 


### PR DESCRIPTION

### What is this
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
There was a way to navigate out of a modal with the tab key and enter the manager while the send/receive flows were open. In order to prevent that we now monitor the tabs/shift+tab key presses and determine whether we want to refocus on the first/last focusable elements or not.

![tabbable](https://user-images.githubusercontent.com/4631227/68693563-ca35ec00-0577-11ea-903e-428408aaa651.gif)
> I had to add the `window.HTMLElement` check to make ci happy, but if someone has a better way of getting around it I'm all eyes 👀 

### Extra
In the process I found a bug when confirming a tab selection with the spacebar the send/receive modals would open with a prefilled select component that rendered broken. This pr addresses that issue as well.
![image](https://user-images.githubusercontent.com/4631227/68693843-4af4e800-0578-11ea-9496-f47181978739.png)





### Type

Feature + Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1926

### Parts of the app affected / Test plan

Send/Receive/Any other modal