### PR TITLE
Make the options button align on accounts page

### DIFF
--- a/src/components/AccountsPage/OptionsButton.js
+++ b/src/components/AccountsPage/OptionsButton.js
@@ -150,8 +150,13 @@ class OptionsButton extends PureComponent<Props, State> {
       <>
         <DropDown border horizontal offsetTop={2} items={this.items} renderItem={this.renderItem}>
           <Tooltip content={this.props.t('accounts.optionsMenu.title')}>
-            <Button small outlineGrey flow={1} style={{ width: 34, padding: 0 }}>
-              <Box horizontal flow={1} alignItems="center" justifyContent="center">
+            <Button
+              small
+              outlineGrey
+              flow={1}
+              style={{ width: 34, padding: 0, justifyContent: 'center' }}
+            >
+              <Box alignItems="center">
                 <IconDots size={14} />
               </Box>
             </Button>


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/68796497-44876e80-0653-11ea-9f18-e2672a8eec8c.png)

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
UI Polish

### Context

@gre on slack

### Parts of the app affected / Test plan

Accounts page, options button