### PR TITLE
LL-2034 Send flow - Tezos (XTZ): Amount input blur bug

### DIFF
--- a/src/components/base/InputCurrency/index.js
+++ b/src/components/base/InputCurrency/index.js
@@ -55,6 +55,7 @@ type Props = {
 type State = {
   isFocused: boolean,
   displayValue: string,
+  rawValue: string,
 }
 
 class InputCurrency extends PureComponent<Props, State> {
@@ -72,6 +73,7 @@ class InputCurrency extends PureComponent<Props, State> {
   state = {
     isFocused: false,
     displayValue: '',
+    rawValue: '',
   }
 
   componentDidMount() {
@@ -108,7 +110,7 @@ class InputCurrency extends PureComponent<Props, State> {
     if (!value || !value.isEqualTo(satoshiValue)) {
       onChange(satoshiValue, unit)
     }
-    this.setState({ displayValue: r.display })
+    this.setState({ rawValue: v, displayValue: r.display })
   }
 
   handleBlur = () => {
@@ -122,7 +124,17 @@ class InputCurrency extends PureComponent<Props, State> {
   }
 
   syncInput = ({ isFocused }: { isFocused: boolean }) => {
-    const { value, showAllDigits, subMagnitude, unit, allowZero, locale } = this.props
+    const {
+      showAllDigits,
+      subMagnitude,
+      unit,
+      allowZero,
+      locale,
+      value: fallbackValue,
+    } = this.props
+    const { rawValue } = this.state
+    const value = BigNumber(rawValue || fallbackValue).times(BigNumber(10).pow(unit.magnitude))
+
     this.setState({
       isFocused,
       displayValue:


### PR DESCRIPTION
Clicking outside of an input while the status is being recalculated resulted in the value going back to a previous one and then again to the correct one. For example if I had typed 1 and quickly type 2 and blur the focus it will go back to 1 and after the calculation is done in the background it would go to 12.

I believe we should rethink the way we are controlling the input when we have time, for now, this should patch the buggy behavior.

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2034

### Parts of the app affected / Test plan

Input currency component, which is used in the send flow amount, and fee fields.