### PR TITLE
Nest KT (or any childaccount) in account selectors

### DIFF
--- a/src/components/SelectAccount/index.js
+++ b/src/components/SelectAccount/index.js
@@ -30,7 +30,7 @@ const mapStateToProps = createStructuredSelector({
 const Tick = styled.div`
   position: absolute;
   top: -10px;
-  height: 48px;
+  height: 40px;
   width: 1px;
   background: ${p => p.theme.colors.palette.divider};
 `
@@ -92,10 +92,10 @@ const AccountOption = React.memo(
     const currency = getAccountCurrency(account)
     const unit = getAccountUnit(account)
     const name = getAccountName(account)
-
+    const nested = ['TokenAccount', 'ChildAccount'].includes(account.type)
     return (
       <Box grow horizontal alignItems="center" flow={2} style={{ opacity: disabled ? 0.2 : 1 }}>
-        {!isValue && account.type === 'TokenAccount' ? tokenTick : null}
+        {!isValue && nested ? tokenTick : null}
         <CryptoCurrencyIcon currency={currency} size={16} />
         <Ellipsis ff="Inter|SemiBold" fontSize={4}>
           {name}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/68856545-0fc1f880-06e1-11ea-9645-a26ba81c5a1b.png)

(the misaligned options button is fixed in the other pr dont worry)

### Type

UI Polish

### Context

That google doc

### Parts of the app affected / Test plan

Account selector, with child tezos accounts