### PR TITLE
Polishes and bug fixes for send flow

### DIFF
--- a/src/components/FeeSliderField.js
+++ b/src/components/FeeSliderField.js
@@ -35,6 +35,16 @@ const Error = styled.div`
   }
 `
 
+const Holder = styled.div`
+  font-family: Inter;
+  font-weight: 500;
+  text-align: right;
+  color: ${p => p.theme.colors.wallet};
+  background-color: ${p => p.theme.colors.pillActiveBackground};
+  padding: 0 8px;
+  border-radius: 4px;
+`
+
 export function useDynamicRange({
   value,
   defaultValue,
@@ -65,14 +75,12 @@ const FeeSliderField = ({ value, onChange, unit, error, defaultValue }: Props) =
     <GenericContainer
       i18nKeyOverride="send.steps.details.ethereumGasPrice"
       header={
-        <div style={{ fontFamily: 'Inter', textAlign: 'right' }}>
-          <Text color="#999" fontSize={4}>
+        <Holder>
+          <Text fontSize={4}>
             <CurrencyUnitValue value={constraintValue} unit={unit} />
           </Text>{' '}
-          <Text color="#767676" fontSize={4}>
-            {unit.code}
-          </Text>
-        </div>
+          <Text fontSize={4}>{unit.code}</Text>
+        </Holder>
       }
     >
       <Box flex={1}>

--- a/src/components/base/Input/index.js
+++ b/src/components/base/Input/index.js
@@ -113,10 +113,10 @@ const Base = styled.input.attrs(() => ({
   padding: 0;
   width: 100%;
   background: none;
-  cursor: text;
+  cursor: ${p => (p.disabled ? 'not-allowed' : 'text')};
 
   &::placeholder {
-    color: ${p => p.theme.colors.palette.divider};
+    color: ${p => p.theme.colors.palette.text.shade40};
   }
 `
 

--- a/src/components/base/Label.js
+++ b/src/components/base/Label.js
@@ -4,8 +4,8 @@ import { fontSize, color, alignItems } from 'styled-system'
 import fontFamily from 'styles/styled/fontFamily'
 
 export default styled.label.attrs(p => ({
-  fontSize: p.fontSize || 3,
-  ff: p.ff || 'Inter|Regular',
+  fontSize: p.fontSize || 4,
+  ff: p.ff || 'Inter|Medium',
   color: p.color || 'palette.text.shade60',
   align: 'center',
   display: 'block',

--- a/src/components/base/LabelWithExternalIcon.js
+++ b/src/components/base/LabelWithExternalIcon.js
@@ -7,9 +7,9 @@ import Label from 'components/base/Label'
 import Box from 'components/base/Box'
 import IconExternalLink from 'icons/ExternalLink'
 
-const LabelWrapper = styled(Label).attrs(p => ({ ff: p.ff ? p.ff : 'Inter|Bold' }))`
+const LabelWrapper = styled(Label).attrs(p => ({ ff: p.ff ? p.ff : 'Inter|Medium' }))`
   display: inline-flex;
-  color: ${p => p.theme.colors[p.color] || 'inherit'};
+  color: ${p => p.theme.colors[p.color] || 'palette.text.shade60'};
   &:hover {
     color: ${p => p.theme.colors.wallet};
     cursor: pointer;

--- a/src/components/base/Modal/ModalHeader.js
+++ b/src/components/base/Modal/ModalHeader.js
@@ -10,37 +10,40 @@ import Box from 'components/base/Box'
 import Text from 'components/base/Text'
 import IconAngleLeft from 'icons/AngleLeft'
 import IconCross from 'icons/Cross'
+import Tabbable from '../Box/Tabbable'
 
 const MODAL_HEADER_STYLE = {
-  position: 'relative',
   display: 'flex',
   alignItems: 'center',
-  justifyContent: 'center',
-  padding: 20,
+  justifyContent: 'space-between',
+  padding: 10,
+  position: 'relative',
+  flexDirection: 'row',
 }
 
 const ModalTitle = styled(Box).attrs(() => ({
   color: 'palette.text.shade100',
   ff: 'Inter|Medium',
   fontSize: 6,
-  grow: true,
-  shrink: true,
 }))`
+  position: absolute;
+  left: 0;
+  right: 0;
   text-align: center;
   line-height: 1;
+  pointer-events: none;
 `
 
-const ModalHeaderAction = styled(Box).attrs(() => ({
+const ModalHeaderAction = styled(Tabbable).attrs(() => ({
   horizontal: true,
   align: 'center',
   fontSize: 3,
-  p: 4,
+  p: 3,
 }))`
+  border-radius: 8px;
   color: ${p => p.color || p.theme.colors.palette.text.shade60};
-  position: absolute;
   top: 0;
-  left: ${p => (p.right ? 'auto' : 0)};
-  right: ${p => (p.right ? 0 : 'auto')};
+  align-self: ${p => (p.right ? 'flex-end' : 'flex-start')};
   line-height: 0;
   cursor: pointer;
 
@@ -58,7 +61,7 @@ const ModalHeaderAction = styled(Box).attrs(() => ({
     border-bottom: 1px dashed transparent;
   }
   &:focus span {
-    border-bottom-color: inherit;
+    border-bottom-color: none;
   }
 `
 
@@ -74,19 +77,23 @@ const ModalHeader = ({
   t: T,
 }) => (
   <div style={MODAL_HEADER_STYLE}>
-    {onBack && (
+    {onBack ? (
       <ModalHeaderAction onClick={onBack}>
         <IconAngleLeft size={12} />
         <Text ff="Inter|Medium" fontSize={4} color="palette.text.shade40">
           {t('common.back')}
         </Text>
       </ModalHeaderAction>
+    ) : (
+      <div />
     )}
     <ModalTitle data-e2e="modalTitle">{children}</ModalTitle>
-    {onClose && (
+    {onClose ? (
       <ModalHeaderAction right color="palette.text.shade40" onClick={onClose}>
         <IconCross size={16} />
       </ModalHeaderAction>
+    ) : (
+      <div />
     )}
   </div>
 )

--- a/src/components/modals/Send/Body.js
+++ b/src/components/modals/Send/Body.js
@@ -82,7 +82,7 @@ const createSteps = () => [
     label: <Trans i18nKey="send.steps.device.title" />,
     component: StepConnectDevice,
     footer: StepConnectDeviceFooter,
-    onBack: ({ transitionTo }) => transitionTo('recipient'),
+    onBack: ({ transitionTo }) => transitionTo('summary'),
   },
   {
     id: 'verification',


### PR DESCRIPTION
Polishes to the send flow

![image](https://user-images.githubusercontent.com/4631227/68881281-254d1780-070d-11ea-8283-2a3dd92cc75e.png)

- Fixed the back action on the Device step of the send flow to actually go back to Summary instead of Recipient steps.
- Polish of fonts (size/weight/color) for labels
- Changed cursor for inactive input app wide
- Increased opacity of placeholders
- Accessibility of header actions, they are now accessible through tabs
- New styles for the gwei slider value

### Type

UI Polish + Bug fix

### Parts of the app affected / Test plan

Send flow, but also affects all inputs and modals, maybe there's a broken modal header somewhere 🤞 
