### PR TITLE
Fix action-less header regression on modals + stylings

### DIFF
--- a/src/components/base/Modal/ModalHeader.js
+++ b/src/components/base/Modal/ModalHeader.js
@@ -19,6 +19,7 @@ const MODAL_HEADER_STYLE = {
   padding: 10,
   position: 'relative',
   flexDirection: 'row',
+  minHeight: 66,
 }
 
 const ModalTitle = styled(Box).attrs(() => ({
@@ -45,24 +46,29 @@ const ModalHeaderAction = styled(Tabbable).attrs(() => ({
   top: 0;
   align-self: ${p => (p.right ? 'flex-end' : 'flex-start')};
   line-height: 0;
-  cursor: pointer;
-
-  &:hover,
-  &:hover ${Text} {
-    color: ${p => p.theme.colors.palette.text.shade80};
-  }
-
-  &:active,
-  &:active ${Text} {
-    color: ${p => p.theme.colors.palette.text.shade100};
-  }
-
-  ${Text} {
-    border-bottom: 1px dashed transparent;
-  }
-  &:focus span {
-    border-bottom-color: none;
-  }
+  ${p =>
+    p.onClick
+      ? `
+    cursor: pointer;
+  
+    &:hover,
+    &:hover ${Text} {
+      color: ${p => p.theme.colors.palette.text.shade80};
+    }
+  
+    &:active,
+    &:active ${Text} {
+      color: ${p => p.theme.colors.palette.text.shade100};
+    }
+  
+    ${Text} {
+      border-bottom: 1px dashed transparent;
+    }
+    &:focus span {
+      border-bottom-color: none;
+    }
+  `
+      : ''}
 `
 
 const ModalHeader = ({
@@ -85,7 +91,7 @@ const ModalHeader = ({
         </Text>
       </ModalHeaderAction>
     ) : (
-      <div />
+      <ModalHeaderAction />
     )}
     <ModalTitle data-e2e="modalTitle">{children}</ModalTitle>
     {onClose ? (
@@ -93,7 +99,7 @@ const ModalHeader = ({
         <IconCross size={16} />
       </ModalHeaderAction>
     ) : (
-      <div />
+      <ModalHeaderAction />
     )}
   </div>
 )

--- a/src/components/base/Modal/ModalHeader.js
+++ b/src/components/base/Modal/ModalHeader.js
@@ -53,12 +53,12 @@ const ModalHeaderAction = styled(Tabbable).attrs(() => ({
   
     &:hover,
     &:hover ${Text} {
-      color: ${p => p.theme.colors.palette.text.shade80};
+      color: ${p.theme.colors.palette.text.shade80};
     }
   
     &:active,
     &:active ${Text} {
-      color: ${p => p.theme.colors.palette.text.shade100};
+      color: ${p.theme.colors.palette.text.shade100};
     }
   
     ${Text} {

--- a/src/components/modals/Send/index.js
+++ b/src/components/modals/Send/index.js
@@ -20,7 +20,7 @@ class SendModal extends PureComponent<{}, { stepId: string }> {
   render() {
     const { stepId } = this.state
 
-    const isModalLocked = stepId === 'recipient' || stepId === 'amount' || stepId === 'verification'
+    const isModalLocked = !['recipient', 'confirmation'].includes(stepId)
 
     return (
       <Modal


### PR DESCRIPTION
This addresses a regression where the header styles were broken if there were no actions (ie only title) on a modal. Also there were some broken styles (hover/active on header actions) and we've reworked which steps are dismissible on the send flow.

### Type

UI Polish

### Parts of the app affected / Test plan
Modals in general