### PR TITLE
Cleanup svg id defs and add a collision check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "install-flow-typed": "flow-typed install -s",
     "remove-breaking-flow-typed": "rm -f flow-typed/npm/{reselect_*,redux-actions_*,react-redux_*,react-i18next_v7.x.x.js,styled-components_v3.x.x.js,winston*}",
     "prettier": "prettier --write \"{src,webpack,.storybook,test-e2e}/**/*.{js,json}\"",
-    "ci": "yarn check --integrity && ./scripts/check-no-dups.sh && yarn lint && yarn prettier -l && yarn test",
+    "ci": "yarn check --integrity && ./scripts/check-no-dups.sh && ./scripts/svg-id-collisions.sh && yarn lint && yarn prettier -l && yarn test",
     "storybook": "NODE_ENV=development STORYBOOK_ENV=1 start-storybook -s ./static -p 4444",
     "publish-storybook": "bash ./scripts/legacy/publish-storybook.sh",
     "reset-files": "bash ./scripts/legacy/reset-files.sh"

--- a/scripts/svg-id-collisions.sh
+++ b/scripts/svg-id-collisions.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+allMatches=()
+failed=0
+
+find src/icons/ -type f -name '*.js' | while read f; do
+  if grep -q "<defs>" "${f}"; then
+    matches=($(grep -Eo 'id="[a-zA-Z0-9_\-]+"' ${f} | cut -c4- | sed 's/"//g'))
+    for match in "${matches[@]}"
+    do
+      if [[ " ${allMatches[@]} " =~ " ${match} " ]]; then
+        failed=1
+        echo "SVG def with id '${match}' in ${f} is not unique."
+      else
+        allMatches+=(${match})
+      fi
+    done
+  fi
+  if [ $failed -eq 1 ]; then
+    echo "┌────────────────────────────────────────────────────────────────────┐"
+    echo "│      The above warnings represent cases where an id collision      │"
+    echo "│     has been detected. This can potentially break the rendering    │"
+    echo "│           of the SVG, and we don't want that now, do we?           │"
+    echo "│                                                                    │"
+    echo "│               Add a prefix to the ids inside <defs>                │"
+    echo "└────────────────────────────────────────────────────────────────────┘"
+    exit 1
+  fi
+done
+

--- a/src/icons/CoinWallet.js
+++ b/src/icons/CoinWallet.js
@@ -5,311 +5,347 @@ import React from 'react'
 export default ({ size }: { size?: number }) => (
   <svg viewBox="0 0 106 144" width={size}>
     <defs>
-      <linearGradient x1=".015%" y1="49.989%" x2="100%" y2="49.989%" id="a">
+      <linearGradient x1=".015%" y1="49.989%" x2="100%" y2="49.989%" id="CoinWallet-a">
         <stop stopColor="#A3B4CE" offset="0%" />
         <stop stopColor="#DFEAFF" stopOpacity="0" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-.025%" y1="50.011%" x2="99.999%" y2="50.011%" id="b">
+      <linearGradient x1="-.025%" y1="50.011%" x2="99.999%" y2="50.011%" id="CoinWallet-b">
         <stop stopColor="#B6BFC7" offset="0%" />
         <stop stopColor="#7F95BF" offset="100%" />
       </linearGradient>
-      <linearGradient x1=".025%" y1="50%" x2="99.999%" y2="50%" id="c">
+      <linearGradient x1=".025%" y1="50%" x2="99.999%" y2="50%" id="CoinWallet-c">
         <stop stopColor="#38516F" offset="0%" />
         <stop stopColor="#4E647E" offset="100%" />
       </linearGradient>
-      <linearGradient x1="49.972%" y1="38.707%" x2="49.972%" y2="1.158%" id="d">
+      <linearGradient x1="49.972%" y1="38.707%" x2="49.972%" y2="1.158%" id="CoinWallet-d">
         <stop stopColor="#2A3448" offset="0%" />
         <stop stopColor="#3B597E" offset="100%" />
       </linearGradient>
-      <linearGradient x1="49.984%" y1="57.177%" x2="49.984%" y2="1.975%" id="e">
+      <linearGradient x1="49.984%" y1="57.177%" x2="49.984%" y2="1.975%" id="CoinWallet-e">
         <stop stopColor="#2A3448" offset="0%" />
         <stop stopColor="#3B597E" offset="100%" />
       </linearGradient>
-      <linearGradient x1="49.987%" y1="39.499%" x2="49.987%" y2="-1.927%" id="f">
+      <linearGradient x1="49.987%" y1="39.499%" x2="49.987%" y2="-1.927%" id="CoinWallet-f">
         <stop stopColor="#2A3448" offset="0%" />
         <stop stopColor="#3B597E" offset="100%" />
       </linearGradient>
-      <linearGradient x1=".003%" y1="49.996%" x2="99.998%" y2="49.996%" id="g">
+      <linearGradient x1=".003%" y1="49.996%" x2="99.998%" y2="49.996%" id="CoinWallet-g">
         <stop stopColor="#B6BFC7" offset="0%" />
         <stop stopColor="#7F95BF" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-.002%" y1="49.997%" x2="100.004%" y2="49.997%" id="h">
+      <linearGradient x1="-.002%" y1="49.997%" x2="100.004%" y2="49.997%" id="CoinWallet-h">
         <stop stopColor="#5F748F" offset="0%" />
         <stop stopColor="#65769D" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-.096%" y1="49.993%" x2="100.081%" y2="49.993%" id="i">
+      <linearGradient x1="-.096%" y1="49.993%" x2="100.081%" y2="49.993%" id="CoinWallet-i">
         <stop stopColor="#A3B4CE" offset="0%" />
         <stop stopColor="#DFEAFF" stopOpacity=".7" offset="100%" />
       </linearGradient>
-      <linearGradient x1="22.244%" y1="34.472%" x2="68.608%" y2="50.48%" id="j">
+      <linearGradient x1="22.244%" y1="34.472%" x2="68.608%" y2="50.48%" id="CoinWallet-j">
         <stop stopColor="#B6BFC7" offset="0%" />
         <stop stopColor="#7F95BF" offset="100%" />
       </linearGradient>
-      <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="k">
+      <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="CoinWallet-k">
         <stop stopColor="#2A3448" offset="0%" />
         <stop stopColor="#3B597E" offset="100%" />
       </linearGradient>
-      <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="l">
+      <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="CoinWallet-l">
         <stop stopColor="#FBA03A" offset="0%" />
         <stop stopColor="#FA9A38" offset="21%" />
         <stop stopColor="#F78732" offset="50%" />
         <stop stopColor="#F36A29" offset="85%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="0%" y1="49.946%" x2="100%" y2="49.946%" id="m">
+      <linearGradient x1="0%" y1="49.946%" x2="100%" y2="49.946%" id="CoinWallet-m">
         <stop stopColor="#FBA03A" offset="0%" />
         <stop stopColor="#FA9A38" offset="21%" />
         <stop stopColor="#F78732" offset="50%" />
         <stop stopColor="#F36A29" offset="85%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="n">
+      <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="CoinWallet-n">
         <stop stopColor="#FBDF7A" offset="13%" />
         <stop stopColor="#FBDD74" offset="33%" />
         <stop stopColor="#FBD864" offset="58%" />
         <stop stopColor="#FBD04A" offset="86%" />
         <stop stopColor="#FBCB3A" offset="100%" />
       </linearGradient>
-      <linearGradient x1="29.725%" y1="-9.878%" x2="74.409%" y2="118.073%" id="o">
+      <linearGradient x1="29.725%" y1="-9.878%" x2="74.409%" y2="118.073%" id="CoinWallet-o">
         <stop stopColor="#FBDF7A" offset="13%" />
         <stop stopColor="#FBDD74" offset="33%" />
         <stop stopColor="#FBD864" offset="58%" />
         <stop stopColor="#FBD04A" offset="86%" />
         <stop stopColor="#FBCB3A" offset="100%" />
       </linearGradient>
-      <linearGradient x1="25.181%" y1="53.984%" x2="93.702%" y2="42.93%" id="p">
+      <linearGradient x1="25.181%" y1="53.984%" x2="93.702%" y2="42.93%" id="CoinWallet-p">
         <stop stopColor="#FBA03A" offset="0%" />
         <stop stopColor="#FA9A38" offset="21%" />
         <stop stopColor="#F78732" offset="50%" />
         <stop stopColor="#F36A29" offset="85%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="55.319%" y1="8.328%" x2="47.544%" y2="88.534%" id="q">
+      <linearGradient x1="55.319%" y1="8.328%" x2="47.544%" y2="88.534%" id="CoinWallet-q">
         <stop stopColor="#FBA03A" offset="0%" />
         <stop stopColor="#FA9A38" offset="21%" />
         <stop stopColor="#F78732" offset="50%" />
         <stop stopColor="#F36A29" offset="85%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="20.049%" y1="27.955%" x2="84.811%" y2="65.553%" id="r">
+      <linearGradient x1="20.049%" y1="27.955%" x2="84.811%" y2="65.553%" id="CoinWallet-r">
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-2269.309%" y1="-1223.862%" x2="-2192.752%" y2="-1206.706%" id="s">
+      <linearGradient
+        x1="-2269.309%"
+        y1="-1223.862%"
+        x2="-2192.752%"
+        y2="-1206.706%"
+        id="CoinWallet-s"
+      >
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-1816.468%" y1="-627.851%" x2="-1734.035%" y2="-615.52%" id="t">
+      <linearGradient
+        x1="-1816.468%"
+        y1="-627.851%"
+        x2="-1734.035%"
+        y2="-615.52%"
+        id="CoinWallet-t"
+      >
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-2118.424%" y1="-624.064%" x2="-2016.187%" y2="-610.759%" id="u">
+      <linearGradient
+        x1="-2118.424%"
+        y1="-624.064%"
+        x2="-2016.187%"
+        y2="-610.759%"
+        id="CoinWallet-u"
+      >
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-2411.654%" y1="-2000.391%" x2="-2330.913%" y2="-1972.656%" id="v">
+      <linearGradient
+        x1="-2411.654%"
+        y1="-2000.391%"
+        x2="-2330.913%"
+        y2="-1972.656%"
+        id="CoinWallet-v"
+      >
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-1670.808%" y1="-1863.152%" x2="-1604.949%" y2="-1832.606%" id="w">
+      <linearGradient
+        x1="-1670.808%"
+        y1="-1863.152%"
+        x2="-1604.949%"
+        y2="-1832.606%"
+        id="CoinWallet-w"
+      >
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-3092.735%" y1="-2295.075%" x2="-2966.325%" y2="-2254.925%" id="x">
+      <linearGradient
+        x1="-3092.735%"
+        y1="-2295.075%"
+        x2="-2966.325%"
+        y2="-2254.925%"
+        id="CoinWallet-x"
+      >
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="53.95%" y1="1.131%" x2="39.983%" y2="97.606%" id="y">
+      <linearGradient x1="53.95%" y1="1.131%" x2="39.983%" y2="97.606%" id="CoinWallet-y">
         <stop stopColor="#FFF" offset="0%" />
         <stop stopColor="#FFF" stopOpacity=".5" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-10387%" y1="-8156%" x2="-10364%" y2="-8127%" id="z">
+      <linearGradient x1="-10387%" y1="-8156%" x2="-10364%" y2="-8127%" id="CoinWallet-z">
         <stop stopColor="#FFF" offset="0%" />
         <stop stopColor="#FFF" stopOpacity=".5" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-10243%" y1="-8119.5%" x2="-10212%" y2="-8079.5%" id="A">
+      <linearGradient x1="-10243%" y1="-8119.5%" x2="-10212%" y2="-8079.5%" id="CoinWallet-A">
         <stop stopColor="#FFF" offset="0%" />
         <stop stopColor="#FFF" stopOpacity=".5" offset="100%" />
       </linearGradient>
-      <linearGradient x1="20.027%" y1="-5.141%" x2="84.448%" y2="114.42%" id="B">
+      <linearGradient x1="20.027%" y1="-5.141%" x2="84.448%" y2="114.42%" id="CoinWallet-B">
         <stop stopColor="#FBDF7A" offset="13%" />
         <stop stopColor="#FBDD74" offset="33%" />
         <stop stopColor="#FBD864" offset="58%" />
         <stop stopColor="#FBD04A" offset="86%" />
         <stop stopColor="#FBCB3A" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-90.827%" y1="-8.032%" x2="-32.221%" y2="-103.708%" id="C">
+      <linearGradient x1="-90.827%" y1="-8.032%" x2="-32.221%" y2="-103.708%" id="CoinWallet-C">
         <stop stopColor="#FBA03A" offset="0%" />
         <stop stopColor="#FA9A38" offset="21%" />
         <stop stopColor="#F78732" offset="50%" />
         <stop stopColor="#F36A29" offset="85%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="49.636%" y1="43.026%" x2="62.312%" y2="109.046%" id="D">
+      <linearGradient x1="49.636%" y1="43.026%" x2="62.312%" y2="109.046%" id="CoinWallet-D">
         <stop stopColor="#FBA03A" offset="0%" />
         <stop stopColor="#FA9A38" offset="21%" />
         <stop stopColor="#F78732" offset="50%" />
         <stop stopColor="#F36A29" offset="85%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="100.748%" y1="47.663%" x2="5.991%" y2="53.885%" id="E">
+      <linearGradient x1="100.748%" y1="47.663%" x2="5.991%" y2="53.885%" id="CoinWallet-E">
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="105.914%" y1="47.584%" x2=".144%" y2="53.833%" id="F">
+      <linearGradient x1="105.914%" y1="47.584%" x2=".144%" y2="53.833%" id="CoinWallet-F">
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="104.46%" y1="47.917%" x2=".28%" y2="52.841%" id="G">
+      <linearGradient x1="104.46%" y1="47.917%" x2=".28%" y2="52.841%" id="CoinWallet-G">
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="103.203%" y1="49.271%" x2="1.6%" y2="50.939%" id="H">
+      <linearGradient x1="103.203%" y1="49.271%" x2="1.6%" y2="50.939%" id="CoinWallet-H">
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="99.02%" y1="47.861%" x2="4.184%" y2="52.606%" id="I">
+      <linearGradient x1="99.02%" y1="47.861%" x2="4.184%" y2="52.606%" id="CoinWallet-I">
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="101.43%" y1="48.367%" x2="4.107%" y2="52.423%" id="J">
+      <linearGradient x1="101.43%" y1="48.367%" x2="4.107%" y2="52.423%" id="CoinWallet-J">
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="100.069%" y1="48.642%" x2="1.908%" y2="52.186%" id="K">
+      <linearGradient x1="100.069%" y1="48.642%" x2="1.908%" y2="52.186%" id="CoinWallet-K">
         <stop stopColor="#FB6B3A" offset="0%" />
         <stop stopColor="#F86634" offset="45%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="36.5%" y1="33.446%" x2="66.5%" y2="71.446%" id="L">
+      <linearGradient x1="36.5%" y1="33.446%" x2="66.5%" y2="71.446%" id="CoinWallet-L">
         <stop stopColor="#FFF" offset="0%" />
         <stop stopColor="#FFF" stopOpacity=".5" offset="100%" />
       </linearGradient>
-      <linearGradient x1="48.033%" y1="37.8%" x2="64.775%" y2="111.42%" id="M">
+      <linearGradient x1="48.033%" y1="37.8%" x2="64.775%" y2="111.42%" id="CoinWallet-M">
         <stop stopColor="#FFF" stopOpacity=".3" offset="0%" />
         <stop stopColor="#FFF" stopOpacity="0" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-.03%" y1="49.995%" x2="100%" y2="49.995%" id="N">
+      <linearGradient x1="-.03%" y1="49.995%" x2="100%" y2="49.995%" id="CoinWallet-N">
         <stop stopColor="#E59730" offset="0%" />
         <stop stopColor="#E75440" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-.051%" y1="50.012%" x2="99.886%" y2="50.012%" id="O">
+      <linearGradient x1="-.051%" y1="50.012%" x2="99.886%" y2="50.012%" id="CoinWallet-O">
         <stop stopColor="#FBDF7A" offset="13%" />
         <stop stopColor="#FBDD74" offset="33%" />
         <stop stopColor="#FBD864" offset="58%" />
         <stop stopColor="#FBD04A" offset="86%" />
         <stop stopColor="#FBCB3A" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-.032%" y1="49.963%" x2="99.952%" y2="49.963%" id="P">
+      <linearGradient x1="-.032%" y1="49.963%" x2="99.952%" y2="49.963%" id="CoinWallet-P">
         <stop stopColor="#FBA03A" offset="0%" />
         <stop stopColor="#FA9A38" offset="21%" />
         <stop stopColor="#F78732" offset="50%" />
         <stop stopColor="#F36A29" offset="85%" />
         <stop stopColor="#F15A24" offset="100%" />
       </linearGradient>
-      <linearGradient x1="0%" y1="50.028%" x2="99.939%" y2="50.028%" id="Q">
+      <linearGradient x1="0%" y1="50.028%" x2="99.939%" y2="50.028%" id="CoinWallet-Q">
         <stop stopColor="#FB8F60" offset="0%" />
         <stop stopColor="#FB895E" offset="23%" />
         <stop stopColor="#FD765A" offset="55%" />
         <stop stopColor="#FE5953" offset="92%" />
         <stop stopColor="#FF5151" offset="100%" />
       </linearGradient>
-      <linearGradient x1=".215%" y1="49.457%" x2="100%" y2="49.457%" id="R">
+      <linearGradient x1=".215%" y1="49.457%" x2="100%" y2="49.457%" id="CoinWallet-R">
         <stop stopColor="#FB8F60" offset="0%" />
         <stop stopColor="#FB895E" offset="23%" />
         <stop stopColor="#FD765A" offset="55%" />
         <stop stopColor="#FE5953" offset="92%" />
         <stop stopColor="#FF5151" offset="100%" />
       </linearGradient>
-      <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="S">
+      <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="CoinWallet-S">
         <stop stopColor="#FB8F60" offset="0%" />
         <stop stopColor="#FB895E" offset="23%" />
         <stop stopColor="#FD765A" offset="55%" />
         <stop stopColor="#FE5953" offset="92%" />
         <stop stopColor="#FF5151" offset="100%" />
       </linearGradient>
-      <linearGradient x1="0%" y1="50.149%" x2="100%" y2="50.149%" id="T">
+      <linearGradient x1="0%" y1="50.149%" x2="100%" y2="50.149%" id="CoinWallet-T">
         <stop stopColor="#FB8F60" offset="0%" />
         <stop stopColor="#FB895E" offset="23%" />
         <stop stopColor="#FD765A" offset="55%" />
         <stop stopColor="#FE5953" offset="92%" />
         <stop stopColor="#FF5151" offset="100%" />
       </linearGradient>
-      <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="U">
+      <linearGradient x1="0%" y1="50%" x2="100%" y2="50%" id="CoinWallet-U">
         <stop stopColor="#FB8F60" offset="0%" />
         <stop stopColor="#FB895E" offset="23%" />
         <stop stopColor="#FD765A" offset="55%" />
         <stop stopColor="#FE5953" offset="92%" />
         <stop stopColor="#FF5151" offset="100%" />
       </linearGradient>
-      <linearGradient x1=".264%" y1="49.821%" x2="100%" y2="49.821%" id="V">
+      <linearGradient x1=".264%" y1="49.821%" x2="100%" y2="49.821%" id="CoinWallet-V">
         <stop stopColor="#FB8F60" offset="0%" />
         <stop stopColor="#FB895E" offset="23%" />
         <stop stopColor="#FD765A" offset="55%" />
         <stop stopColor="#FE5953" offset="92%" />
         <stop stopColor="#FF5151" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-.28%" y1="50.042%" x2="100%" y2="50.042%" id="W">
+      <linearGradient x1="-.28%" y1="50.042%" x2="100%" y2="50.042%" id="CoinWallet-W">
         <stop stopColor="#FB8F60" offset="0%" />
         <stop stopColor="#FB895E" offset="23%" />
         <stop stopColor="#FD765A" offset="55%" />
         <stop stopColor="#FE5953" offset="92%" />
         <stop stopColor="#FF5151" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-.194%" y1="50%" x2="100%" y2="50%" id="X">
+      <linearGradient x1="-.194%" y1="50%" x2="100%" y2="50%" id="CoinWallet-X">
         <stop stopColor="#FB8F60" offset="0%" />
         <stop stopColor="#FB895E" offset="23%" />
         <stop stopColor="#FD765A" offset="55%" />
         <stop stopColor="#FE5953" offset="92%" />
         <stop stopColor="#FF5151" offset="100%" />
       </linearGradient>
-      <linearGradient x1="0%" y1="50.139%" x2="99.701%" y2="50.139%" id="Y">
+      <linearGradient x1="0%" y1="50.139%" x2="99.701%" y2="50.139%" id="CoinWallet-Y">
         <stop stopColor="#FB8F60" offset="0%" />
         <stop stopColor="#FB895E" offset="23%" />
         <stop stopColor="#FD765A" offset="55%" />
         <stop stopColor="#FE5953" offset="92%" />
         <stop stopColor="#FF5151" offset="100%" />
       </linearGradient>
-      <linearGradient x1="0%" y1="49.614%" x2="100%" y2="49.614%" id="Z">
+      <linearGradient x1="0%" y1="49.614%" x2="100%" y2="49.614%" id="CoinWallet-Z">
         <stop stopColor="#FB8F60" offset="0%" />
         <stop stopColor="#FB895E" offset="23%" />
         <stop stopColor="#FD765A" offset="55%" />
         <stop stopColor="#FE5953" offset="92%" />
         <stop stopColor="#FF5151" offset="100%" />
       </linearGradient>
-      <linearGradient x1="-.067%" y1="50.023%" x2="99.916%" y2="50.023%" id="aa">
+      <linearGradient x1="-.067%" y1="50.023%" x2="99.916%" y2="50.023%" id="CoinWallet-aa">
         <stop stopColor="#FFF" stopOpacity=".3" offset="0%" />
         <stop stopColor="#FFF" stopOpacity="0" offset="100%" />
       </linearGradient>
     </defs>
     <g fill="none" fillRule="evenodd">
       <path
-        fill="url(#a)"
+        fill="url(#CoinWallet-a)"
         fillRule="nonzero"
         opacity=".4"
         d="M71.948 118.962l22.687 11.852-31.952 8.687 1.994-19.043z"
       />
       <path
         d="M75.788 62.73v55.459c0 2.712-2.414 2.255-2.414 2.255h-9.647l-61.052-3.467s-.466-4.558-1.04-10.859c-.237-2.568-.465-5.43-.73-8.389-.029-.275-.047-.554-.075-.83v-.181c-.22-2.396-.41-4.86-.583-7.275 0-.284-.047-.564-.065-.848v-.247c-.047-.667-.093-1.333-.135-1.99 0-1.552.042-3.08.079-4.549l-.028-1.738h.056c.265-7.834.885-14.089 2.111-15.962 0-.023.037-.042.056-.042.019 0 0 0 0-.028a6.184 6.184 0 014.716-1.766s63.163-1.506 66.025-1.506c2.861 0 2.726 1.962 2.726 1.962z"
-        fill="url(#b)"
+        fill="url(#CoinWallet-b)"
         fillRule="nonzero"
       />
       <path
         d="M75.345 63.289v55.151c0 2.694-2.4 2.242-2.4 2.242h-9.591l-60.702-3.444s-.466-4.53-1.035-10.798c-.238-2.554-.466-5.397-.727-8.338-.028-.275-.046-.555-.07-.825v-.182c-.2-2.4-.391-4.851-.564-7.251 0-.28-.046-.564-.065-.844v-.247c-.08-.67-.126-1.323-.191-1.976 0-1.547.047-3.062.084-4.525l-.028-1.724h.088c.266-7.774.881-13.982 2.102-15.846 0-.028.033-.046.052-.046.018 0 0 0 0-.028a6.142 6.142 0 014.693-1.776s62.799-1.496 65.642-1.496c2.843 0 2.712 1.953 2.712 1.953z"
-        fill="url(#c)"
+        fill="url(#CoinWallet-c)"
         fillRule="nonzero"
       />
       <path
@@ -319,17 +355,17 @@ export default ({ size }: { size?: number }) => (
       />
       <path
         d="M74.334 79.768v9.619H63.82l-49.102.037H.27c0-.284-.046-.564-.065-.848v-.247c-.047-.666-.093-1.333-.135-1.99 0-1.552.042-3.08.08-4.548L.12 80.052h.033l14.564-.056 48.846-.181 6.64-.028 4.13-.02z"
-        fill="url(#d)"
+        fill="url(#CoinWallet-d)"
         fillRule="nonzero"
       />
       <path
         d="M74.334 88.082v9.62l-73.057.055a.932.932 0 01-.466-.83v-.186c-.2-2.419-.392-4.884-.564-7.298 0-.28-.047-.564-.065-.848v-.247l14.554-.056 49.22-.182h6.267l4.11-.028z"
-        fill="url(#e)"
+        fill="url(#CoinWallet-e)"
         fillRule="nonzero"
       />
       <path
         d="M74.334 96.47v9.62l-72.325.056a58.018 58.018 0 01-1.105-8.389c-.028-.275-.046-.554-.074-.83v-.181l62.752-.238 10.752-.037z"
-        fill="url(#f)"
+        fill="url(#CoinWallet-f)"
         fillRule="nonzero"
       />
       <path
@@ -344,17 +380,17 @@ export default ({ size }: { size?: number }) => (
       />
       <path
         d="M67.05 82.802l-.196 6.058v.122c-.07 2.4-.173 5.378-.27 8.687-.047 1.56-.103 3.206-.15 4.888-.144 4.377-.293 9.07-.428 13.637-.038 1.3-.084 2.586-.117 3.845-.35 11.385-.652 21.135-.652 21.862 0 1.813-3.463.606-3.463.606S5.69 126.964 3.728 126.363c-1.962-.601-1.663-1.808-1.663-1.808s-1.04-21.15-.84-38.626c0-1.552.047-3.08.08-4.549 0-.587.037-1.17.047-1.738.274-7.839-1.352-14.61 1.976-15.98.104-.043.202-.101.288-.173a.75.75 0 00-.07.121s-.465.499-.465.508c-.466.848-.252 2.33 1.7 2.796 20.064 4.568 60.507 11.474 60.507 11.474a1.529 1.529 0 011.324.993c.62 1.305.438 3.42.438 3.42z"
-        fill="url(#g)"
+        fill="url(#CoinWallet-g)"
         fillRule="nonzero"
       />
       <path
         d="M65.838 83.23s-.07 2.33-.191 6.06v.116c-.075 2.404-.173 5.382-.275 8.691-.047 1.562-.098 3.207-.145 4.885a4052.52 4052.52 0 00-.428 13.64c-.038 1.296-.084 2.587-.122 3.845-.344 11.386-.647 21.13-.647 21.863 0 1.808-3.463.605-3.463.605S4.483 127.393 2.53 126.792c-1.953-.602-1.664-1.809-1.664-1.809S-.177 103.834.028 86.358c0-1.552.042-3.08.08-4.549 0-.587.036-1.17.046-1.738.265-7.834.885-14.089 2.111-15.962.042-.068.09-.132.144-.191a.527.527 0 00-.074.121v.028c-.466.848-.713 2.82 1.24 3.262C23.638 71.901 64.08 78.808 64.08 78.808a1.529 1.529 0 011.323.993c.616 1.29.434 3.43.434 3.43z"
-        fill="url(#h)"
+        fill="url(#CoinWallet-h)"
         fillRule="nonzero"
       />
       <path
         d="M.932 123.762s.718 1.431 3.817 2.144c3.1.713 56.517 15.738 56.517 15.738s1.43.718 1.43-2.143c0-2.862 1.19-56.517 1.19-56.517s0-2.862-2.862-2.862S2.843 68.937 2.843 68.937a3.528 3.528 0 01-1.599-.736"
-        stroke="url(#i)"
+        stroke="url(#CoinWallet-i)"
         strokeWidth=".5"
         strokeDasharray=".466"
       />
@@ -364,7 +400,7 @@ export default ({ size }: { size?: number }) => (
         fillRule="nonzero"
       />
       <ellipse
-        fill="url(#j)"
+        fill="url(#CoinWallet-j)"
         fillRule="nonzero"
         transform="rotate(-13.23 54.778 107.686)"
         cx="54.778"
@@ -373,217 +409,222 @@ export default ({ size }: { size?: number }) => (
         ry="2.782"
       />
       <path
-        fill="url(#k)"
+        fill="url(#CoinWallet-k)"
         fillRule="nonzero"
         d="M65.227 102.972l1.207-.424-.428 13.637-1.207.428z"
       />
       <path
-        fill="url(#l)"
+        fill="url(#CoinWallet-l)"
         fillRule="nonzero"
         d="M67.511 30.908l1.193 2.176 2.172 1.189-2.172 1.188-1.193 2.177-1.188-2.177-2.177-1.188 2.177-1.189zM25.26 68.028l.755 1.384 1.384.755-1.384.755-.755 1.385-.755-1.385-1.385-.755 1.385-.755z"
       />
       <path
-        fill="url(#m)"
+        fill="url(#CoinWallet-m)"
         fillRule="nonzero"
         d="M96.215 0l.755 1.384 1.384.755-1.384.76-.755 1.384-.755-1.384-1.385-.76 1.385-.755z"
       />
       <path
-        fill="url(#n)"
+        fill="url(#CoinWallet-n)"
         fillRule="nonzero"
         d="M95.679 62.66l1.188 2.176 2.176 1.188-2.176 1.189-1.188 2.176-1.189-2.176-2.176-1.189 2.176-1.188zM48.64 19.201l.737 1.347 1.347.736-1.347.737-.736 1.346-.736-1.346-1.347-.737 1.347-.736z"
       />
       <path
         d="M101.504 39.642s.494.158.466.172c-.303.732-1.142 1.366-1.575 2.116l-.042.065c-.466.704-.359 1.468-.797 2.074-.615.88-1.3 1.707-2.05 2.475-.285.289-.583.568-.881.834-.135.135-.29.26-.443.387a16.228 16.228 0 01-2.21 1.524 12.518 12.518 0 01-4.66 1.682 8.487 8.487 0 01-1.328 0c-.135 0-.14-.522-.28-.531-.065 0-.107-.028-.172 0a10.691 10.691 0 01-1.98-.7 6.883 6.883 0 01-3.03-3.574c-1.253-3.16-.932-7.592 1.072-11.847.2-.396.434-.824.639-1.216.43-.816.925-1.595 1.482-2.33a17.635 17.635 0 014.264-4.195 11.04 11.04 0 015.56-2.045 6.608 6.608 0 011.65.116 6.329 6.329 0 011.901.643c.257.13.501.287.727.466.342.242.654.522.932.834.193.205.364.43.508.672.177.251.839.657.984.932.419.805.716 1.67.88 2.563.148.707.226 1.426.233 2.148 0 .797-.526 1.487-.652 2.33l.503.14c-.103.759-.259 1.51-.466 2.247l-.503-.13a17.737 17.737 0 01-.732 2.148z"
-        fill="url(#o)"
+        fill="url(#CoinWallet-o)"
         fillRule="nonzero"
       />
       <path
         d="M89.014 46.138a3.034 3.034 0 01-.843-.26 2.037 2.037 0 01-.508-.206 4.772 4.772 0 01-2.084-2.535c-.782-2.144-.582-5.099.82-7.997.117-.215.224-.499.34-.713.31-.57.659-1.116 1.045-1.636 1.864-2.46 4.264-4.018 6.436-4.157a4.563 4.563 0 012.47.489c.169.09.325.201.466.33.23.15.432.337.597.556.107.102.2.22.274.349 1.399 1.92 1.538 5.15.27 8.342-.218.564-.465 1.1-.764 1.673-.265.466-.535.872-.801 1.273-2.125 3.15-5.196 4.907-7.718 4.492z"
-        fill="url(#p)"
+        fill="url(#CoinWallet-p)"
         fillRule="nonzero"
       />
       <path
         d="M105.153 36.608a16.955 16.955 0 01-.433 2.241c-.191.73-.432 1.447-.723 2.144v.065a16.89 16.89 0 01-1.062 2.223c-.513.7-.932 1.399-1.398 2.042-.518.699-1.067 1.365-1.59 1.994a20.166 20.166 0 01-1.784 1.706 12.523 12.523 0 01-2.051 1.398 14.14 14.14 0 01-2.796 1.189 8.23 8.23 0 01-2.88.233 5.779 5.779 0 01-.932-.173 4.893 4.893 0 01-1.026-.391c-.14-.056-1.22-.639-1.398-.727l-1.212-.662.13.051c.15.06.304.117.467.163.383.171.785.295 1.198.368.19.043.387.059.582.047h.033a9.055 9.055 0 002.717-.289.247.247 0 01.056 0 13.702 13.702 0 002.656-1.118h.042c.04-.02.08-.044.117-.07a12.989 12.989 0 001.934-1.375h.028a20.427 20.427 0 001.733-1.645h.024a14.447 14.447 0 001.584-1.995c.391-.538.736-1.109 1.03-1.706.056-.093.103-.19.15-.289l.027-.037v-.032c.413-.736.774-1.499 1.082-2.284.023-.103.083-.177.107-.284l.037-.033c0-.047.033-.089.051-.13.019-.042.028-.084.047-.126a.778.778 0 01.037-.094c.056-.135.098-.27.14-.405.042-.135.13-.387.186-.583.056-.195.103-.35.168-.526v-.033c.191-.745.326-1.482.466-2.218v-.042a.298.298 0 010-.042v-.047a18.4 18.4 0 00.15-1.864v-.466a12.485 12.485 0 00-.206-2.144 9.843 9.843 0 00-.88-2.544l-.467-.737-.023-.037a3.328 3.328 0 00-.256-.359l-.14-.177-.107-.13c-.075-.08-.145-.154-.224-.229l-.056-.051a2.638 2.638 0 00-.2-.196 2.14 2.14 0 00-.191-.167c-.08-.07-.168-.131-.257-.196l-.037-.028a1.822 1.822 0 00-.191-.14l-.103-.065h.042l2.368 1.314-.177-.084c.45.306.872.654 1.258 1.04a7.364 7.364 0 01.615.764c.57.781.983 1.666 1.217 2.605a.606.606 0 010 .098c.251.88.402 1.785.447 2.698v.75c0 .615-.042 1.228-.126 1.837z"
-        fill="url(#q)"
+        fill="url(#CoinWallet-q)"
         fillRule="nonzero"
       />
       <path
         d="M102.772 43.314l-1.245 2.027-2.372-1.36c.46-.621.866-1.281 1.212-1.972l2.405 1.305z"
-        fill="url(#r)"
+        fill="url(#CoinWallet-r)"
         fillRule="nonzero"
       />
       <path
         d="M99.901 47.303a18.93 18.93 0 01-1.785 1.706l-2.33-1.337h.028a19.108 19.108 0 001.733-1.646l2.354 1.277z"
-        fill="url(#s)"
+        fill="url(#CoinWallet-s)"
         fillRule="nonzero"
       />
       <path
         d="M96.06 50.43c-.885.498-1.822.895-2.795 1.184l-2.298-1.347h.051a13.278 13.278 0 002.657-1.113l2.386 1.277z"
-        fill="url(#t)"
+        fill="url(#CoinWallet-t)"
         fillRule="nonzero"
       />
       <path
         d="M90.356 51.82a5.346 5.346 0 01-1.966-.57c-.14-.05-1.217-.628-1.398-.717l-1.012-.555c.154.061.308.112.466.159a4.81 4.81 0 001.198.368c.19.047.387.064.583.051h.037l2.092 1.263z"
-        fill="url(#u)"
+        fill="url(#CoinWallet-u)"
         fillRule="nonzero"
       />
       <path
         d="M104.72 38.85a17.085 17.085 0 01-.755 2.208l-2.47-1.398a.191.191 0 010-.037c.042-.092.078-.187.107-.284.04-.082.074-.166.103-.252.088-.238.167-.466.247-.699.037-.126.074-.256.116-.382.042-.126.103-.35.168-.527l2.484 1.37z"
-        fill="url(#v)"
+        fill="url(#CoinWallet-v)"
         fillRule="nonzero"
       />
       <path
         d="M105.153 36.608l-2.446-1.37v-.08c.087-.64.14-1.284.158-1.93v-.465l2.405 1.328v.685c0 .612-.04 1.224-.117 1.832z"
-        fill="url(#w)"
+        fill="url(#CoinWallet-w)"
         fillRule="nonzero"
       />
       <path
         d="M104.832 31.225l-2.163-.583a9.75 9.75 0 00-.88-2.54l1.784.466c0 .028.042.061.066.094.555.772.96 1.641 1.193 2.563z"
-        fill="url(#x)"
+        fill="url(#CoinWallet-x)"
         fillRule="nonzero"
       />
       <path
         d="M102.711 35.2v.033c-.126.736-.26 1.473-.466 2.218v.033l-.182.54c-.056.196-.12.387-.186.583l-.14.405a.778.778 0 00-.037.094c0 .042-.033.084-.047.125-.014.042-.032.084-.051.131l-.037.033c-.024.107-.084.181-.107.284a18.367 18.367 0 01-1.082 2.284v.032l-.028.037a2.13 2.13 0 00-.149.29 11.79 11.79 0 01-1.044 1.658c-.468.71-.998 1.378-1.584 1.995h-.024a20.427 20.427 0 01-1.733 1.645h-.028c-.602.517-1.249.977-1.934 1.375-3.682-5.653-5.192-13.78-3.845-22.43a11.073 11.073 0 015.532-2.032c.554-.031 1.11.008 1.654.116a6.46 6.46 0 011.902.643c.161.088.317.186.466.294h-.042l.102.065c.067.042.13.09.191.14l.038.028c.088.065.177.126.256.196.067.052.13.108.191.167.07.062.137.127.2.196l.056.051.192.196.14.163.14.177c.083.104.158.215.223.331a.35.35 0 00.056.065l.466.737c.409.804.705 1.66.88 2.544.13.708.2 1.425.206 2.144v.466a18.4 18.4 0 01-.15 1.864.27.27 0 00.005.084z"
-        fill="url(#y)"
+        fill="url(#CoinWallet-y)"
         fillRule="nonzero"
         opacity=".5"
       />
-      <path fill="url(#z)" fillRule="nonzero" opacity=".5" d="M103.56 34.021l-.103-.065.042.023z" />
+      <path
+        fill="url(#CoinWallet-z)"
+        fillRule="nonzero"
+        opacity=".5"
+        d="M103.56 34.021l-.103-.065.042.023z"
+      />
       <path
         d="M101.667 39.231c0-.041.028-.083.047-.125a.778.778 0 01.037-.094l-.084.22z"
-        fill="url(#A)"
+        fill="url(#CoinWallet-A)"
         fillRule="nonzero"
         opacity=".5"
       />
       <path
         d="M77.545 13.366a8.664 8.664 0 01-.438 2.768 5.48 5.48 0 01-1.608 2.507c-.21.172-.443.317-.69.43a3.141 3.141 0 01-.932.293 2.06 2.06 0 01-.424.023 2.652 2.652 0 01-.606-.065 1.706 1.706 0 01-.396-.116c-.14-.052-.517 0-.657-.084a4.535 4.535 0 01-1.077-.75 5.48 5.48 0 01-.708-.784c-.242-.307-.22-.74-.42-1.113l-.237.093a8.235 8.235 0 01-.466-1.025l.237-.094a8.081 8.081 0 01-.33-1.062s-.229.074-.243.074a11.912 11.912 0 010-1.286v-.037c-.023-.41-.28-.685-.284-1.054a9.517 9.517 0 01.098-1.565c.032-.196.065-.392.107-.583 0-.093.042-.186.065-.28.108-.425.253-.84.434-1.24a6.133 6.133 0 011.351-2.003 4.87 4.87 0 01.518-.354c.055-.038.21.167.265.13.056-.037.051 0 .075-.042.181-.092.374-.16.573-.2.063-.021.126-.038.191-.052l.22-.042a3.356 3.356 0 012.222.536c1.398.89 2.563 2.727 2.992 4.992.033.214.065.466.098.662.054.439.078.88.07 1.323z"
-        fill="url(#B)"
+        fill="url(#CoinWallet-B)"
         fillRule="nonzero"
       />
       <path
         d="M71.831 8.235c.13-.065.268-.112.41-.14.085-.028.172-.045.261-.051a2.33 2.33 0 011.552.4 5.178 5.178 0 011.98 3.393c0 .122.057.266.07.383.043.309.063.62.061.932-.023 1.505-.526 2.796-1.346 3.495a2.237 2.237 0 01-1.114.522c-.095.01-.19.01-.285 0a1.282 1.282 0 01-.396-.047.713.713 0 01-.21-.06c-1.109-.354-2.087-1.59-2.507-3.216a9.903 9.903 0 01-.182-.885c-.05-.313-.037-.494-.046-.732-.075-1.846.634-3.425 1.752-3.994z"
-        fill="url(#C)"
+        fill="url(#CoinWallet-C)"
         fillRule="nonzero"
       />
       <path
         d="M73.663 19.392h-.089l-1.31.163h.094a4.138 4.138 0 01-.797-.051 3.104 3.104 0 01-.41-.103h-.056a3.7 3.7 0 01-1.212-.68l-.037-.033a5.97 5.97 0 01-.956-.932v-.023c-.06-.093-.135-.182-.195-.27a6.888 6.888 0 01-.466-.755 8.818 8.818 0 01-.466-1.016 8.389 8.389 0 01-.331-1.054v-.032a8.324 8.324 0 01-.224-1.184c0-.424-.047-.83-.047-1.202 0-.373.028-.849.056-1.245.047-.4.119-.797.215-1.188.095-.396.23-.782.4-1.151.21-.45.464-.876.76-1.273a4.003 4.003 0 011.072-.932 2.88 2.88 0 01.42-.2c.166-.067.34-.114.517-.14.074-.023.671-.102.764-.121l.737-.093-.131.023-.228.07a2.53 2.53 0 00-.583.2.932.932 0 00-.242.15 4.45 4.45 0 00-.993.894c-.31.361-.578.755-.802 1.175v.023a.322.322 0 00-.023.06c-.16.354-.285.722-.373 1.1-.093.38-.165.764-.214 1.152a6.846 6.846 0 00-.051 1.244c-.004.33.02.658.07.983v.154c.048.41.124.817.228 1.217 0 .046 0 .093.037.14.008.043.02.087.033.13.021.091.048.182.08.27.027.089.055.177.088.261.032.084.06.168.084.256.14.35.298.68.466 1.007.01.02.02.043.028.065.144.28.312.518.466.779.042.065.088.12.135.181.211.281.445.545.699.788a4.79 4.79 0 001.081.75l.373.154h.028l.214.07.182.047h.144c.154.03.31.045.466.042.094.055.194.099.299.13z"
-        fill="url(#D)"
+        fill="url(#CoinWallet-D)"
         fillRule="nonzero"
       />
       <path
         d="M67.208 13.32l-.093-1.16 1.333-.145c-.007.377.023.755.088 1.127l-1.328.178z"
-        fill="url(#E)"
+        fill="url(#CoinWallet-E)"
         fillRule="nonzero"
       />
       <path
         d="M67.194 10.915c.047-.4.119-.797.214-1.189l1.31-.144c-.094.377-.166.76-.214 1.146l-1.31.187z"
-        fill="url(#F)"
+        fill="url(#CoinWallet-F)"
         fillRule="nonzero"
       />
       <path
         d="M67.81 8.575c.208-.449.462-.875.759-1.272l1.296-.126a6.646 6.646 0 00-.746 1.212l-1.31.186z"
-        fill="url(#G)"
+        fill="url(#CoinWallet-G)"
         fillRule="nonzero"
       />
       <path
         d="M69.664 6.385c.286-.173.602-.29.932-.345.07 0 .662-.098.76-.117l.554-.07-.223.066a2.796 2.796 0 00-.583.2.932.932 0 00-.242.15l-1.198.116z"
-        fill="url(#H)"
+        fill="url(#CoinWallet-H)"
         fillRule="nonzero"
       />
       <path
         d="M67.725 15.645a8.724 8.724 0 01-.33-1.058v-.032l1.398-.159.042.14c.008.044.019.088.032.13.033.122.07.233.103.35.032.116.046.121.065.182.019.06.06.167.084.256l-1.394.191z"
-        fill="url(#I)"
+        fill="url(#CoinWallet-I)"
         fillRule="nonzero"
       />
       <path
         d="M68.2 16.656l1.362-.167v.037c.149.289.321.536.494.806.042.065.088.121.135.182l-1.333.168c-.06-.094-.135-.182-.196-.27a6.473 6.473 0 01-.461-.756z"
-        fill="url(#J)"
+        fill="url(#CoinWallet-J)"
         fillRule="nonzero"
       />
       <path
         d="M69.906 18.693l1.021-.391a4.79 4.79 0 001.081.75l-.834.34h-.056a3.7 3.7 0 01-1.212-.699z"
-        fill="url(#K)"
+        fill="url(#CoinWallet-K)"
         fillRule="nonzero"
       />
       <path
         d="M73.663 19.392h-.238c.08.007.159.007.238 0z"
-        fill="url(#L)"
+        fill="url(#CoinWallet-L)"
         fillRule="nonzero"
         opacity=".5"
       />
       <path
         d="M77.545 13.366a8.664 8.664 0 01-.438 2.768c-3.057-.764-5.364-4.194-5.364-8.272 0-.668.062-1.334.186-1.99l.22-.042a3.356 3.356 0 012.222.536c1.398.89 2.563 2.726 2.992 4.991.033.215.065.467.098.662.06.447.088.897.084 1.347z"
-        fill="url(#M)"
+        fill="url(#CoinWallet-M)"
         fillRule="nonzero"
       />
       <path
         d="M81.93 75.135v.466c0 .406 0 .797-.037 1.189a27.538 27.538 0 01-.746 5.164c-.16.649-.353 1.29-.577 1.92a17.304 17.304 0 01-2.088 4.194 12.36 12.36 0 01-4.428 4.003 10.78 10.78 0 01-1.45.625l-.628.196-4.013 1.216c.48-.167.948-.37 1.398-.606l.434-.237c.44-.258.864-.544 1.267-.858l.168-.13c.261-.21.513-.434.755-.667l.08-.08c.12-.116.237-.237.353-.358a12.896 12.896 0 001.193-1.44l.234-.326.06-.094c.075-.111.145-.223.214-.335.07-.112.108-.168.159-.252.051-.084.084-.135.121-.205.117-.19.228-.391.336-.592.042-.084.088-.167.125-.251.038-.084.117-.224.168-.336.052-.112.07-.14.103-.21l.19-.414a8.464 8.464 0 00.191-.461c.048-.122.113-.28.173-.43.247-.652.466-1.337.662-2.05.047-.177.093-.35.135-.527l.126-.54.08-.396c.027-.131.055-.266.079-.401.023-.135.05-.275.074-.41.023-.136.051-.322.075-.466l.07-.466.042-.36c.028-.232.056-.465.074-.708v-.079c.023-.26.042-.522.06-.788v-.35c.029-.546.043-1.1.043-1.663v-.177-.396a.9.9 0 000-.112v-.433c0-.602-.056-1.198-.108-1.795 0-.205-.037-.414-.055-.62a39.46 39.46 0 00-.182-1.49l-.112-.746c-.042-.247-.084-.5-.13-.746v-.093c-.042-.21-.08-.42-.126-.63 0-.125-.047-.251-.075-.372-.028-.122-.06-.285-.093-.424-.047-.21-.093-.415-.145-.625-.05-.21-.111-.466-.167-.676a15.389 15.389 0 00-.145-.545l-.088-.326c-.056-.187-.108-.368-.164-.55-.14-.466-.288-.932-.466-1.422l-.223-.643a52.278 52.278 0 00-.285-.778l-.158-.42c0-.023 0-.046-.033-.074-.084-.205-.163-.41-.247-.62a32.493 32.493 0 00-.578-1.347l-.307-.661c-.023-.042-.042-.089-.065-.131-.08-.177-.168-.35-.252-.522a25.386 25.386 0 00-.308-.601c-.102-.196-.19-.378-.293-.564a28.303 28.303 0 00-.671-1.202l-.368-.62c-.126-.205-.252-.415-.383-.62a36.636 36.636 0 00-.806-1.217c-.047-.065-.088-.135-.135-.195a33.627 33.627 0 00-.564-.783l-.098-.13c-.121-.164-.238-.322-.363-.467l-.117-.154c-.116-.144-.233-.293-.35-.433a25.98 25.98 0 00-.978-1.151 6.677 6.677 0 00-.242-.27c-.168-.187-.34-.378-.518-.56l-.251-.256a10.234 10.234 0 00-.387-.391l-.392-.383-.498-.466-.499-.466-.247-.21-.06-.046h-.033l-.196-.168-.089-.07c-.153-.12-.298-.242-.466-.354l-.517-.391h-.028c-.182-.135-.368-.261-.55-.387a10.378 10.378 0 00-.415-.275l-.335-.214a8.932 8.932 0 00-.816-.467 3.519 3.519 0 00-.321-.172c-.126-.07-.252-.14-.382-.205-.466-.228-.905-.466-1.366-.63h-.042l-.573-.218-.214-.08-.266-.088a2.739 2.739 0 00-.256-.084l-.261-.08-.285-.078-.28-.075-.251-.219-.317-.07c-.34-.074-.68-.13-1.011-.172l-.331-.042h-.047l-.6-.047h-1.46c-.493.033-.983.1-1.468.2l-.564.131 3.514-1.044 1.739-.517a10.253 10.253 0 011.575-.205h.07a13.217 13.217 0 014.819.68c.387.126.778.27 1.174.429.668.274 1.32.585 1.953.932a22.37 22.37 0 012.768 1.813 26.234 26.234 0 012.186 1.864c.728.695 1.42 1.426 2.074 2.19.587.68 1.153 1.394 1.696 2.14a38.07 38.07 0 011.627 2.432c.422.684.828 1.388 1.216 2.112.037.074.075.149.117.223.466.853.876 1.734 1.263 2.629.363.82.699 1.663 1.01 2.512.336.932.64 1.872.91 2.82l.042.148c.233.844.466 1.692.629 2.545.21 1.007.387 2.018.517 3.034a35.32 35.32 0 01.298 4.59z"
-        fill="url(#N)"
+        fill="url(#CoinWallet-N)"
         fillRule="nonzero"
       />
       <path
         d="M64.78 48.25a22.678 22.678 0 00-4.441-3.02 15.605 15.605 0 00-1.399-.648 13.772 13.772 0 00-5.998-1.1h-.177c-.493.033-.983.1-1.468.2-.19.042-.382.084-.564.135h-.05l-.5.145a6.84 6.84 0 00-.545.19c-5.387 2.07-8.994 8.45-8.994 17.43.034 4.372.81 8.705 2.293 12.817 12.443 2.26 22.37 3.957 22.37 3.957a1.529 1.529 0 011.323.992c.634 1.31.466 3.426.466 3.426s-.074 2.33-.196 6.058v.122c-.046 1.593-.107 3.444-.172 5.476.145-.033.289-.056.429-.094.27-.065.536-.149.797-.237H68a10.355 10.355 0 001.832-.844 12.075 12.075 0 003.327-2.885 6.06 6.06 0 00.215-.27c2.447-3.164 3.905-7.825 3.905-13.515v-.177c-.098-10.766-5.294-21.97-12.499-28.159z"
-        fill="url(#O)"
+        fill="url(#CoinWallet-O)"
         fillRule="nonzero"
       />
       <path
         d="M62.841 52.663a17.71 17.71 0 00-3.504-2.382 14.852 14.852 0 00-1.11-.512 10.966 10.966 0 00-4.73-.872h-.14c-.391.027-.78.08-1.165.159l-.443.107h-.042l-.391.116c-4.483 1.45-7.527 6.58-7.527 13.902a31.052 31.052 0 002.466 11.852c10.835 1.957 19.019 3.355 19.019 3.355a1.529 1.529 0 011.324.993c.633 1.31.466 3.426.466 3.426l-.173 5.303a9.703 9.703 0 002.713-2.437c1.929-2.498 3.085-6.175 3.085-10.682v-.14c-.06-8.482-4.18-17.327-9.848-22.188z"
-        fill="url(#P)"
+        fill="url(#CoinWallet-P)"
         fillRule="nonzero"
       />
       <path
         d="M62.45 42.722l-3.472 1.864h-.042l-.573-.219-.215-.079-.265-.088a2.739 2.739 0 00-.257-.084l-.26-.08-.285-.079-.28-.074-.27-.075-.317-.07c-.34-.074-.68-.13-1.011-.172l-.331-.042h-.042l2.722-1.468h.07c1.636-.08 3.274.147 4.828.666z"
-        fill="url(#Q)"
+        fill="url(#CoinWallet-Q)"
         fillRule="nonzero"
       />
       <path
         d="M68.34 45.9l-3.868 2.093h-.032l-.196-.168-.089-.07c-.153-.12-.298-.242-.466-.354l-.517-.391h-.028c-.182-.135-.368-.261-.55-.387a10.378 10.378 0 00-.415-.275l-.335-.214 3.728-2.004a22.37 22.37 0 012.769 1.77z"
-        fill="url(#R)"
+        fill="url(#CoinWallet-R)"
         fillRule="nonzero"
       />
       <path
         d="M72.6 49.97l-4.054 2.19a25.98 25.98 0 00-.98-1.152 6.677 6.677 0 00-.241-.27c-.168-.186-.34-.377-.518-.56l-.251-.255 3.97-2.144c.728.695 1.42 1.426 2.074 2.19z"
-        fill="url(#S)"
+        fill="url(#CoinWallet-S)"
         fillRule="nonzero"
       />
       <path
         d="M75.923 54.527l-4.194 2.265-.368-.62c-.126-.205-.252-.415-.383-.62a36.636 36.636 0 00-.806-1.216l4.125-2.228c.563.779 1.109 1.59 1.626 2.419z"
-        fill="url(#T)"
+        fill="url(#CoinWallet-T)"
         fillRule="nonzero"
       />
       <path
         d="M78.519 59.504l-4.306 2.33a32.493 32.493 0 00-.578-1.346l-.308-.662c-.023-.042-.042-.089-.065-.13-.08-.178-.168-.35-.252-.523l4.246-2.297c.447.853.876 1.734 1.263 2.628z"
-        fill="url(#U)"
+        fill="url(#CoinWallet-U)"
         fillRule="nonzero"
       />
       <path
         d="M80.439 64.836l-4.427 2.395a15.389 15.389 0 00-.145-.545l-.088-.326c-.056-.187-.108-.368-.164-.55-.14-.466-.288-.932-.466-1.422l4.367-2.358c.345.92.653 1.855.923 2.806z"
-        fill="url(#V)"
+        fill="url(#CoinWallet-V)"
         fillRule="nonzero"
       />
       <path
         d="M81.627 70.564l-4.571 2.47a39.46 39.46 0 00-.182-1.492l-.112-.745c-.042-.247-.084-.5-.13-.746v-.093l4.46-2.428c.228 1.006.405 2.018.535 3.034z"
-        fill="url(#W)"
+        fill="url(#CoinWallet-W)"
         fillRule="nonzero"
       />
       <path
         d="M81.93 75.135v.466c0 .406 0 .797-.037 1.189l-4.768 2.577c.024-.26.042-.522.061-.787v-.35c.028-.547.042-1.101.042-1.664v-.177-.396l4.66-2.563c.024.573.042 1.137.042 1.705z"
-        fill="url(#X)"
+        fill="url(#CoinWallet-X)"
         fillRule="nonzero"
       />
       <path
         d="M81.558 80a24.93 24.93 0 01-.401 1.954c-.16.649-.354 1.29-.578 1.92l-5.252 2.81a8.464 8.464 0 00.191-.461c.046-.122.111-.28.172-.43.247-.652.466-1.337.662-2.05.046-.177.093-.35.135-.526l.126-.541 4.945-2.675z"
-        fill="url(#Y)"
+        fill="url(#CoinWallet-Y)"
         fillRule="nonzero"
       />
       <path
         d="M78.472 88.082a12.36 12.36 0 01-4.427 4.003 10.78 10.78 0 01-2.079.82l-4.012 1.217c.48-.167.947-.37 1.398-.606l.433-.237c.442-.258.865-.544 1.268-.858l.168-.13c.26-.21.512-.434.755-.667l.079-.08 6.417-3.462z"
-        fill="url(#Z)"
+        fill="url(#CoinWallet-Z)"
         fillRule="nonzero"
       />
       <path
         d="M64.78 48.25a22.678 22.678 0 00-4.441-3.02 15.605 15.605 0 00-1.399-.648 13.772 13.772 0 00-5.998-1.1h-.177c-.493.033-.983.1-1.468.2-.19.042-.382.084-.564.135h-.05l-.5.145a6.84 6.84 0 00-.545.19 59.755 59.755 0 00-.116 3.73c0 11.184 3.001 21.367 7.922 29.104 4.81.848 7.84 1.365 7.84 1.365a1.529 1.529 0 011.323.993c.634 1.31.466 3.425.466 3.425s-.051 1.631-.14 4.344a26.434 26.434 0 006.208 3.225 6.06 6.06 0 00.214-.27c2.447-3.165 3.906-7.825 3.906-13.516v-.177c-.08-10.733-5.276-21.937-12.481-28.126z"
-        fill="url(#aa)"
+        fill="url(#CoinWallet-aa)"
         fillRule="nonzero"
       />
       <path

--- a/src/icons/LockScreen.js
+++ b/src/icons/LockScreen.js
@@ -7,7 +7,7 @@ import React from 'react'
 const defs = (
   <defs>
     <filter
-      id="a"
+      id="LockScreen-a"
       width="178.9%"
       height="178.9%"
       x="-39.4%"
@@ -30,7 +30,7 @@ const defs = (
 )
 
 const group = (
-  <g fill="none" fillRule="evenodd" filter="url(#a)" transform="translate(23 21)">
+  <g fill="none" fillRule="evenodd" filter="url(#LockScreen-a)" transform="translate(23 21)">
     <rect width="90" height="90" fill="#FFF" rx="20" />
     <path fill="#6490F1" d="M45 13.36c-17.475 0-31.64 14.165-31.64 31.64S27.524 76.64 45 76.64" />
     <path fill="#142533" fillOpacity=".1" d="M13.36 45c0 17.475 14.165 31.64 31.64 31.64V45" />

--- a/src/icons/SensitiveOperationShield.js
+++ b/src/icons/SensitiveOperationShield.js
@@ -5,12 +5,15 @@ import React from 'react'
 export default () => (
   <svg width="27" height="31">
     <defs>
-      <path id="a" d="M4 0h600a4 4 0 0 1 4 4v112a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V4a4 4 0 0 1 4-4z" />
-      <mask id="b" width="608" height="120" x="0" y="0" fill="#fff">
-        <use xlinkHref="#a" />
+      <path
+        id="sensitiveOperationShield-a"
+        d="M4 0h600a4 4 0 0 1 4 4v112a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V4a4 4 0 0 1 4-4z"
+      />
+      <mask id="sensitiveOperationShield-b" width="608" height="120" x="0" y="0" fill="#fff">
+        <use xlinkHref="#sensitiveOperationShield-a" />
       </mask>
       <filter
-        id="c"
+        id="sensitiveOperationShield-c"
         width="153.8%"
         height="141.9%"
         x="-26.9%"
@@ -29,12 +32,20 @@ export default () => (
           <feMergeNode in="SourceGraphic" />
         </feMerge>
       </filter>
-      <path id="d" d="M13 30s13-4.426 13-14.016V4.795L13 0 0 4.795v11.189C0 25.574 13 30 13 30z" />
+      <path
+        id="sensitiveOperationShield-d"
+        d="M13 30s13-4.426 13-14.016V4.795L13 0 0 4.795v11.189C0 25.574 13 30 13 30z"
+      />
     </defs>
     <g fill="none" fillRule="evenodd" transform="translate(-567 -15)">
-      <g filter="url(#c)" transform="translate(567 15)">
+      <g filter="url(#sensitiveOperationShield-c)" transform="translate(567 15)">
         <g strokeLinecap="round" strokeLinejoin="round">
-          <use fill="#FFF" stroke="#EA2E49" strokeWidth="1.5" xlinkHref="#d" />
+          <use
+            fill="#FFF"
+            stroke="#EA2E49"
+            strokeWidth="1.5"
+            xlinkHref="#sensitiveOperationShield-d"
+          />
         </g>
         <path
           fill="#EA2E49"

--- a/src/icons/Transfer.js
+++ b/src/icons/Transfer.js
@@ -7,14 +7,14 @@ const Transfer = ({ size = 16, color = 'currentColor' }: { size?: number, color?
     <defs>
       <path
         d="M2.775 3.525h-.75a.75.75 0 010-1.5h11.9a.75.75 0 110 1.5H2.775zM11.124.901a.75.75 0 011.06-1.06l2.405 2.404a.75.75 0 010 1.06L12.184 5.71a.75.75 0 01-1.06-1.06l1.874-1.874L11.124.901zm2.801 10.374a.75.75 0 01-.75.75H2.025a.75.75 0 110-1.5h11.15a.75.75 0 01.75.75zm-10.973 0l1.874 1.874a.75.75 0 01-1.06 1.06L1.36 11.805a.75.75 0 010-1.06L3.766 8.34a.75.75 0 111.06 1.06l-1.874 1.874z"
-        id="prefix__a"
+        id="Transfer-a"
       />
     </defs>
     <use
       fill={color}
       fillRule="nonzero"
       transform="rotate(-180 7.475 7.5)"
-      xlinkHref="#prefix__a"
+      xlinkHref="#Transfer-a"
     />
   </svg>
 )

--- a/src/icons/device/NanoXBanner.js
+++ b/src/icons/device/NanoXBanner.js
@@ -6,7 +6,7 @@ export default ({ size = 30, ...p }: { size: number }) => (
   <svg viewBox="0 0 6 16" height={size} width={size} {...p}>
     <defs>
       <path
-        id="a"
+        id="NanoXBanner-a"
         d="M5.75 6.835a3.509 3.509 0 0 0-1.5-1.105V1.75h-2.5v3.98a3.509 3.509 0 0 0-1.5 1.105V1.666C.25.884.884.25 1.666.25h2.668c.782 0 1.416.634 1.416 1.416v5.169zm-1.5 7.415V9.5a1.25 1.25 0 1 0-2.5 0v4.75h2.5zM3 6.75A2.75 2.75 0 0 1 5.75 9.5v4.834c0 .782-.634 1.416-1.416 1.416H1.666A1.416 1.416 0 0 1 .25 14.334V9.5A2.75 2.75 0 0 1 3 6.75z"
       />
     </defs>
@@ -17,11 +17,11 @@ export default ({ size = 30, ...p }: { size: number }) => (
         d="M5.75 6.835a3.509 3.509 0 0 0-1.5-1.105V1.75h-2.5v3.98a3.509 3.509 0 0 0-1.5 1.105V1.666C.25.884.884.25 1.666.25h2.668c.782 0 1.416.634 1.416 1.416v5.169zm-1.5 7.415V9.5a1.25 1.25 0 1 0-2.5 0v4.75h2.5zM3 6.75A2.75 2.75 0 0 1 5.75 9.5v4.834c0 .782-.634 1.416-1.416 1.416H1.666A1.416 1.416 0 0 1 .25 14.334V9.5A2.75 2.75 0 0 1 3 6.75z"
       />
       <g>
-        <mask id="b" fill="#fff">
-          <use xlinkHref="#a" />
+        <mask id="NanoXBanner-b" fill="#fff">
+          <use xlinkHref="#NanoXBanner-a" />
         </mask>
-        <use fill="#FFF" xlinkHref="#a" />
-        <g fill="#FFF" mask="url(#b)">
+        <use fill="#FFF" xlinkHref="#NanoXBanner-a" />
+        <g fill="#FFF" mask="url(#NanoXBanner-b)">
           <path d="M-5 0h16v16H-5z" />
         </g>
       </g>

--- a/src/icons/device/interactions/NanoS/Frame.js
+++ b/src/icons/device/interactions/NanoS/Frame.js
@@ -23,12 +23,12 @@ export default ({ children, overlay, error }: Props) => {
       <defs />
       <defs>
         <path
-          id="a"
+          id="NanoSFrame-a"
           d="M129 2c1.104569 0 2 .8954305 2 2v38c0 1.1045695-.895431 2-2 2H2c-1.1045695 0-2-.8954305-2-2V4c0-1.1045695.8954305-2 2-2h127zm-19 11c-5.522847 0-10 4.4771525-10 10s4.477153 10 10 10 10-4.4771525 10-10-4.477153-10-10-10z"
         />
       </defs>
       <g fill="none" fillRule="evenodd">
-        <use fill={colors[type].stroke} xlinkHref="#a" />
+        <use fill={colors[type].stroke} xlinkHref="#NanoSFrame-a" />
         <path
           fill={error ? colors[type].errorFrame : colors[type].frame}
           stroke={colors[type].stroke}

--- a/src/icons/device/interactions/NanoS/Screen.js
+++ b/src/icons/device/interactions/NanoS/Screen.js
@@ -23,11 +23,16 @@ const getScreens = color => ({
       <defs />
       <defs>
         <path
-          id="id3"
+          id="NanoSScreen-id3"
           d="M71.8 15.5h2.4v1.2222222H73h2.4v1.2222222h1.2v1.2222223h1.2v1.2222222H79v1.2222222h-2.4V26.5h-2.4v-3.6666667h-2.4V26.5h-2.4v-4.8888889H67v-1.2222222h1.2v-1.2222222h1.2v-1.2222223h1.2v-1.2222222h1.2z"
         />
       </defs>
-      <use fill={color} fillRule="nonzero" transform="translate(-67 -15)" xlinkHref="#id3" />
+      <use
+        fill={color}
+        fillRule="nonzero"
+        transform="translate(-67 -15)"
+        xlinkHref="#NanoSScreen-id3"
+      />
     </g>
   ),
   validation: (
@@ -80,7 +85,7 @@ export default ({ active, display, error, ...props }: Props) => {
   return (
     <ScreenSVG {...props} width="58" height="20">
       <defs />
-      <g id="screen">
+      <g id="NanoSScreen-screen">
         <rect
           width="57"
           height="19"
@@ -91,7 +96,7 @@ export default ({ active, display, error, ...props }: Props) => {
           rx="2"
           transform="translate(-40 -6)"
         />
-        <g id="screen-content" opacity={active ? 1 : 0}>
+        <g id="NanoSScreen-screen-content" opacity={active ? 1 : 0}>
           {display ? screens[display] : null}
         </g>
       </g>

--- a/src/icons/device/interactions/NanoX/Frame.js
+++ b/src/icons/device/interactions/NanoX/Frame.js
@@ -22,7 +22,7 @@ export default ({ children, overlay, error }: Props) => {
     <FrameSVG width="156" height="42">
       <defs />
       <defs>
-        <circle id="a" cx="135" cy="21" r="11" />
+        <circle id="NanoXFrame-a" cx="135" cy="21" r="11" />
       </defs>
       <g fill="none" fillRule="evenodd">
         <rect
@@ -45,7 +45,7 @@ export default ({ children, overlay, error }: Props) => {
         />
         {children}
         <g>
-          <use fill="#131415" xlinkHref="#a" />
+          <use fill="#131415" xlinkHref="#NanoXFrame-a" />
           <circle
             cx="135"
             cy="21"

--- a/src/icons/device/interactions/NanoX/Screen.js
+++ b/src/icons/device/interactions/NanoX/Screen.js
@@ -23,11 +23,16 @@ const getScreens = color => ({
       <defs />
       <defs>
         <path
-          id="id3"
+          id="NanoXScreen-id3"
           d="M71.8 15.5h2.4v1.2222222H73h2.4v1.2222222h1.2v1.2222223h1.2v1.2222222H79v1.2222222h-2.4V26.5h-2.4v-3.6666667h-2.4V26.5h-2.4v-4.8888889H67v-1.2222222h1.2v-1.2222222h1.2v-1.2222223h1.2v-1.2222222h1.2z"
         />
       </defs>
-      <use fill={color} fillRule="nonzero" transform="translate(-67 -15)" xlinkHref="#id3" />
+      <use
+        fill={color}
+        fillRule="nonzero"
+        transform="translate(-67 -15)"
+        xlinkHref="#NanoXScreen-id3"
+      />
     </g>
   ),
   validation: (
@@ -80,7 +85,7 @@ export default ({ active, display, error, ...props }: Props) => {
   return (
     <ScreenSVG {...props} width="66" height="30">
       <defs />
-      <g id="screen">
+      <g id="NanoXScreen-screen">
         <rect
           width="65"
           height="29"
@@ -91,7 +96,7 @@ export default ({ active, display, error, ...props }: Props) => {
           rx="2"
           transform="translate(-40 -6)"
         />
-        <g id="screen-content" opacity={active ? 1 : 0}>
+        <g id="NanoXScreen-screen-content" opacity={active ? 1 : 0}>
           {display ? screens[display] : null}
         </g>
       </g>


### PR DESCRIPTION
This pr provides a new script to find svg collisions in the ids defined inside `<defs>`. This usually happens when we use a tool to cleanup a raw svg and it gives ids such as `a` or `shape` to the definitions. Then sometimes we get a collision and it ends up triggering something like this which, say what you want but doesn't make the nanoX look good.

![image](https://user-images.githubusercontent.com/4631227/69056466-53ce3980-0a10-11ea-80c1-9f1e1572e524.png)

### Type

Code Quality Improvement

### Context

https://ledgerhq.atlassian.net/browse/LL-2043

### Parts of the app affected / Test plan

Overall svgs in case I broke one.