### PR TITLE
Fix loading button behaviour on step amount of the send flow

### DIFF
--- a/src/components/modals/Send/steps/StepAmount.js
+++ b/src/components/modals/Send/steps/StepAmount.js
@@ -70,12 +70,7 @@ export class StepAmountFooter extends PureComponent<StepProps> {
     return (
       <Fragment>
         <AccountFooter account={account} />
-        <Button
-          isLoading={bridgePending && !hasErrors}
-          primary
-          disabled={!canNext}
-          onClick={this.onNext}
-        >
+        <Button isLoading={bridgePending} primary disabled={!canNext} onClick={this.onNext}>
           {t('common.continue')}
         </Button>
       </Fragment>


### PR DESCRIPTION
The `isLoading` prop was killed if there were errors in the transaction, meaning that to begin with since we always have the `amountRequired` error it wouldn't show as loading or would do so erratically.

### Type

Bug Fix

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Send flow, step amount.