### PR TITLE
Fixes screen rendering on device frames

### DIFF
--- a/src/icons/device/interactions/Blue/Screen.js
+++ b/src/icons/device/interactions/Blue/Screen.js
@@ -8,11 +8,11 @@ import colors from '../colors'
 const ScreenSVG = styled.svg`
   overflow: visible;
 
-  #screen {
+  #Blue-screen {
     transform: translate(0%, -50%);
   }
 
-  #screen-content {
+  #Blue-screen-content {
     transition: opacity 200ms;
   }
 `
@@ -80,7 +80,7 @@ export default ({ active, display, error, ...props }: Props) => {
   return (
     <ScreenSVG {...props} width="83" height="111">
       <defs />
-      <g id="screen">
+      <g id="Blue-screen">
         <rect
           transform="translate(-40 -16)"
           width="83"
@@ -92,7 +92,7 @@ export default ({ active, display, error, ...props }: Props) => {
           stroke={error ? '#EA2E49' : colors[type].screenStroke}
           rx="2"
         />
-        <g id="screen-content" opacity={active ? 1 : 0}>
+        <g id="Blue-screen-content" opacity={active ? 1 : 0}>
           {display ? screens[display] : null}
         </g>
       </g>

--- a/src/icons/device/interactions/NanoS/Screen.js
+++ b/src/icons/device/interactions/NanoS/Screen.js
@@ -8,11 +8,11 @@ import colors from '../colors'
 const ScreenSVG = styled.svg`
   overflow: visible;
 
-  #screen {
+  #NanoSScreen-screen {
     transform: translate(0%, -50%);
   }
 
-  #screen-content {
+  #NanoSScreen-screen-content {
     transition: opacity 200ms;
   }
 `

--- a/src/icons/device/interactions/NanoX/Screen.js
+++ b/src/icons/device/interactions/NanoX/Screen.js
@@ -8,11 +8,11 @@ import colors from '../colors'
 const ScreenSVG = styled.svg`
   overflow: visible;
 
-  #screen {
+  #NanoXScreen-screen {
     transform: translate(0%, -50%);
   }
 
-  #screen-content {
+  #NanoXScreen-screen-content {
     transition: opacity 200ms;
   }
 `

--- a/src/icons/device/interactions/USBCable.js
+++ b/src/icons/device/interactions/USBCable.js
@@ -68,17 +68,17 @@ export default ({ active, state, vertical, ...props }: Props) => {
   return (
     <USBCable {...props} width="126" height="23">
       <defs>
-        <linearGradient id="gradient">
+        <linearGradient id="USBCable-gradient">
           <stop offset="0" stopColor="black" stopOpacity="1" />
           <stop offset="1" stopColor="white" stopOpacity="1" />
         </linearGradient>
-        <mask id="myMask">
-          <rect x="20" y="0" width="36" height="25" fill="url(#gradient)" />
+        <mask id="USBCable-myMask">
+          <rect x="20" y="0" width="36" height="25" fill="url(#USBCable-gradient)" />
           <rect x="56" y="0" width="57" height="25" fill="white" />
         </mask>
       </defs>
       <g
-        mask="url(#myMask)"
+        mask="url(#USBCable-myMask)"
         opacity={active ? 1 : 0}
         transform={`rotate(${vertical ? -90 : 0} 126 11.5)`}
       >


### PR DESCRIPTION
There were some styles linking directly to the ids defined in the path defs, this basically broke the positioning of the screens within the frame. 

### Type

UI Bug