### PR TITLE
LL-2019 Add the account column to operation row on asset page

### DIFF
--- a/src/components/AssetPage/index.js
+++ b/src/components/AssetPage/index.js
@@ -33,6 +33,7 @@ type Props = {
     path: string,
     url: string,
   },
+  push: Function,
   t: T,
   accounts: Account[],
   allAccounts: Account[],
@@ -65,6 +66,8 @@ class AssetPage extends PureComponent<Props, State> {
   lookupParentAccount = (id: string): ?Account =>
     this.props.allAccounts.find(a => a.id === id) || null
 
+  onAccountClick = account => this.props.push(`/account/${account.id}`)
+
   render() {
     const { t, accounts, counterValue, range, countervalueFirst, theme } = this.props
     const parentAccount =
@@ -92,7 +95,12 @@ class AssetPage extends PureComponent<Props, State> {
           <AccountDistribution accounts={accounts} />
         </Box>
         <Box mt={40}>
-          <OperationsList accounts={accounts} title={t('dashboard.recentActivity')} />
+          <OperationsList
+            accounts={accounts}
+            title={t('dashboard.recentActivity')}
+            onAccountClick={this.onAccountClick}
+            withAccount
+          />
         </Box>
       </Box>
     )


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/69148770-5777c400-0ad5-11ea-94a2-d1ddc2ffb786.png)


### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2019

### Parts of the app affected / Test plan

The operation list for a particular asset should show the account column and allow to navigate to it via the operation details.