### PR TITLE
Hide breadcrumb on send flow for the first two steps when there is an error

### DIFF
--- a/src/components/modals/Send/Body.js
+++ b/src/components/modals/Send/Body.js
@@ -296,7 +296,7 @@ const Body = ({
     parentAccount,
     transaction,
     isAppOpened,
-    hideBreadcrumb: !!error && stepId === 'amount',
+    hideBreadcrumb: !!error && ['recipient', 'amount'].includes(stepId),
     error,
     status,
     bridgePending,


### PR DESCRIPTION
Step recipient and amount from the send flow should hide the breadcrumbs when there is an error. In other words, the banner should take the breadcrumbs' space. Not the same for the rest of the steps since they handle errors differently.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

UI Polish
