### PR TITLE
LL-2026 Set palette color for AnalyticsTitle

### DIFF
--- a/src/components/Onboarding/steps/Analytics.js
+++ b/src/components/Onboarding/steps/Analytics.js
@@ -226,6 +226,7 @@ export const AnalyticsTitle = styled(Box).attrs(() => ({
   ff: 'Inter|SemiBold',
   fontSize: 4,
   textAlign: 'left',
+  color: 'palette.text.shade100',
 }))``
 const Container = styled(Box).attrs(() => ({
   horizontal: true,


### PR DESCRIPTION

<img width="1316" alt="Screenshot 2019-11-19 at 16 27 38" src="https://user-images.githubusercontent.com/4631227/69160337-b2b3b180-0ae9-11ea-9d0a-1bb256a14e25.png">
<img width="1316" alt="Screenshot 2019-11-19 at 16 27 16" src="https://user-images.githubusercontent.com/4631227/69160341-b2b3b180-0ae9-11ea-9323-1f7ddc1187e8.png">


### Type

UI Polish

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
https://ledgerhq.atlassian.net/browse/LL-2026

### Parts of the app affected / Test plan

Final step of onboarding after having chosen a dark/dusk theme, would show the text as black since it had no style. It should look white now.