### PR TITLE
LL-2021 Limit breadcrumb width for accounts dropdown

### DIFF
--- a/src/components/TopBar/Breadcrumb/AccountCrumb.js
+++ b/src/components/TopBar/Breadcrumb/AccountCrumb.js
@@ -23,6 +23,7 @@ import CryptoCurrencyIcon from '../../CryptoCurrencyIcon'
 import DropDown from '../../base/DropDown'
 import Button, { Base } from '../../base/Button'
 import { Separator } from './index'
+import Ellipsis from '../../base/Ellipsis'
 
 type Props = {
   match: {
@@ -119,9 +120,9 @@ class AccountCrumb extends PureComponent<Props> {
     return (
       <Item key={item.account.id} isActive={isActive}>
         <CryptoCurrencyIcon size={16} currency={currency} />
-        <Text ff={`Inter|${isActive ? 'SemiBold' : 'Regular'}`} fontSize={4}>
+        <Ellipsis ff={`Inter|${isActive ? 'SemiBold' : 'Regular'}`} fontSize={4}>
           {getAccountName(item.account)}
-        </Text>
+        </Ellipsis>
         {isActive && (
           <Check>
             <IconCheck size={14} />

--- a/src/components/base/DropDown/index.js
+++ b/src/components/base/DropDown/index.js
@@ -20,6 +20,7 @@ const Drop = styled(Box).attrs(() => ({
 }))`
   border: ${p => (p.border ? `1px solid ${p.theme.colors.palette.divider}` : 'none')};
   max-height: 400px;
+  max-width: 250px;
   position: absolute;
   right: 0;
   top: 100%;


### PR DESCRIPTION
### Before
<img width="1136" alt="Screenshot 2019-11-19 at 16 59 54" src="https://user-images.githubusercontent.com/4631227/69163332-4f784e00-0aee-11ea-997e-191b371b47f9.png">

### After
<img width="1136" alt="Screenshot 2019-11-19 at 16 56 53" src="https://user-images.githubusercontent.com/4631227/69163333-4f784e00-0aee-11ea-8e12-4da07a073ff4.png">

### Type

Bugfix

### Context

https://ledgerhq.atlassian.net/browse/LL-2021

### Parts of the app affected / Test plan

Dropdown when we have a non-selected account that is super long and the selected one is very short, and the sidebar is collapsed. This series of conditions triggered an overflow of the dropdown menu.