### PR TITLE
LL-1995 Track sidebar collapse state of live

### DIFF
--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -9,6 +9,7 @@ import { getCurrentDevice } from 'reducers/devices'
 import type { State } from 'reducers'
 
 import { load } from './inject-in-window'
+import { sidebarCollapsedSelector } from '../reducers/settings'
 
 invariant(typeof window !== 'undefined', 'analytics/segment must be called on renderer thread')
 
@@ -34,6 +35,8 @@ const extraProperties = store => {
   const systemLocale = getSystemLocale()
   const device = getCurrentDevice(state)
   const deviceInfo = device
+  const sidebarCollapsed = sidebarCollapsedSelector(state)
+
   return {
     appVersion: __APP_VERSION__,
     language,
@@ -44,6 +47,7 @@ const extraProperties = store => {
     osType,
     osVersion,
     sessionId,
+    sidebarCollapsed,
     ...deviceInfo,
   }
 }


### PR DESCRIPTION
`SidebarCollapsed` is now passed as one of the extra properties when we track an event the same way we do for the language selected.

### Type

Analytics

### Context

https://ledgerhq.atlassian.net/browse/LL-1995

### Parts of the app affected / Test plan

How to test this... I added a trace to the extraProperties method to make sure the selector was getting the right value. It should be fine, right? 🤷‍♂ 