### PR TITLE
LL-2031 For nightly builds, avoid update, change banner

### DIFF
--- a/src/components/Updater/Banner.js
+++ b/src/components/Updater/Banner.js
@@ -10,6 +10,7 @@ import Spinner from 'components/base/Spinner'
 import IconUpdate from 'icons/Update'
 import IconDonjon from 'icons/Donjon'
 import IconWarning from 'icons/TriangleWarning'
+import IconInfoCircle from 'icons/InfoCircle'
 
 import { withUpdaterContext } from './UpdaterContext'
 import type { UpdaterContextType } from './UpdaterContext'
@@ -62,10 +63,22 @@ class UpdaterTopBanner extends PureComponent<Props> {
     const { status, quitAndInstall, downloadProgress } = context
     if (!VISIBLE_STATUS.includes(status)) return null
 
-    const content: ?Content = CONTENT_BY_STATUS(quitAndInstall, this.reDownload, downloadProgress)[
+    let content: ?Content = CONTENT_BY_STATUS(quitAndInstall, this.reDownload, downloadProgress)[
       status
     ]
     if (!content) return null
+
+    if (__APP_VERSION__.includes('nightly')) {
+      content = {
+        Icon: IconInfoCircle,
+        message: <Trans i18nKey="update.nightlyWarning" />,
+        right: (
+          <FakeLink onClick={() => openURL(urls.liveHome)}>
+            <Trans i18nKey="update.downloadNow" />
+          </FakeLink>
+        ),
+      }
+    }
 
     return <TopBanner content={content} status={status} />
   }

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -788,7 +788,7 @@
     "quitAndInstall": "Install now",
     "error": "Error during update. Please download again",
     "reDownload": "Download again",
-    "nightlyWarning":  "This version cannot auto-update, please install latest version manually",
+    "nightlyWarning":  "This version cannot auto-update, please install the latest version manually",
     "downloadNow": "Download now"
   },
   "crash": {

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -787,7 +787,9 @@
     "checkSuccess": "Update ready to install",
     "quitAndInstall": "Install now",
     "error": "Error during update. Please download again",
-    "reDownload": "Download again"
+    "reDownload": "Download again",
+    "nightlyWarning":  "This version cannot auto-update, please install latest version manually",
+    "downloadNow": "Download now"
   },
   "crash": {
     "oops": "Oops, something went wrong",


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/69420682-710c4c00-0d1f-11ea-8411-15c2c0847a53.png)


### Type

UX Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2031

### Parts of the app affected / Test plan

On an app with nightly build version, or with the `DEBUG_UPDATE` flag, check that we don't see a download progress, or any other banner than the above one.