### PR TITLE
styling for locked screen button

### DIFF
--- a/src/components/IsUnlocked.js
+++ b/src/components/IsUnlocked.js
@@ -23,7 +23,7 @@ import Box from 'components/base/Box'
 import InputPassword from 'components/base/InputPassword'
 import LedgerLiveLogo from 'components/base/LedgerLiveLogo'
 import IconArrowRight from 'icons/ArrowRight'
-import Button from 'components/base/Button/index'
+import Button from 'components/base/Button'
 import ConfirmModal from 'components/base/Modal/ConfirmModal'
 
 type InputValue = {
@@ -179,9 +179,14 @@ class IsUnlocked extends Component<Props, State> {
                   />
                 </Box>
                 <Box ml={2}>
-                  <Button style={{ width: 38, height: 38 }} primary onClick={this.handleSubmit}>
-                    <Box style={{ alignItems: 'center' }}>
-                      <IconArrowRight size={16} />
+                  <Button
+                    onClick={this.handleSubmit}
+                    primary
+                    flow={1}
+                    style={{ width: 46, height: 46, padding: 0, justifyContent: 'center' }}
+                  >
+                    <Box alignItems="center">
+                      <IconArrowRight size={20} />
                     </Box>
                   </Button>
                 </Box>


### PR DESCRIPTION
Minor ui polish

![image](https://user-images.githubusercontent.com/4631227/69951670-f9e07000-14f5-11ea-8b6a-2a34fce2bd88.png)

Instead of 
![image](https://user-images.githubusercontent.com/4631227/69951695-05cc3200-14f6-11ea-85de-f1cb1ae0d51b.png)


### Type

UI Polish

### Context

Slack report

### Parts of the app affected / Test plan

Locked screen button
