### PR TITLE
Allow to stack modals (for terms)

### DIFF
--- a/src/reducers/modals.js
+++ b/src/reducers/modals.js
@@ -24,14 +24,7 @@ const handlers = {
   MODAL_OPEN: (state, { payload }: { payload: OpenPayload }) => {
     const { name, data } = payload
     return {
-      // Close all modal before
-      ...Object.keys(state).reduce((result, key) => {
-        result[key] = {
-          isOpened: false,
-          data: undefined,
-        }
-        return result
-      }, {}),
+      ...state,
       [name]: {
         isOpened: true,
         data,


### PR DESCRIPTION
it seems some logic was preventing more than one modal at a time to be stacked.

we need that to happen because we have a "Terms" modal that needs to be seen even when there are also the release notes modal..

### Type

bugfix

### Context

terms modal

### Parts of the app affected / Test plan

- all modals.
- test that there are no other glitch.
- i suggest to do a firmware update on this PR as well.