### PR TITLE
Add sanity check to prevent libraries dup

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@ledgerhq/hw-transport-node-hid": "4.78.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "4.78.0",
     "@ledgerhq/ledger-core": "^4.2.0",
-    "@ledgerhq/live-common": "^9.0.0",
+    "@ledgerhq/live-common": "^9.1.0",
     "@ledgerhq/logs": "4",
     "@tippy.js/react": "^3.1.0",
     "add": "^2.0.6",

--- a/src/components/AppError.js
+++ b/src/components/AppError.js
@@ -3,16 +3,26 @@
 import React from 'react'
 import { ThemeProvider } from 'styled-components'
 import { I18nextProvider } from 'react-i18next'
-import theme from 'styles/theme'
+import theme, { colors } from 'styles/theme'
+import palette from 'styles/palette'
 import i18n from 'renderer/i18n/electron'
 import TriggerAppReady from './TriggerAppReady'
 import RenderError from './RenderError'
 
 // Like App except it just render an error
 
+const themePalette = palette.light
+const lightLiveTheme = {
+  ...theme,
+  colors: {
+    ...colors,
+    palette: themePalette,
+  },
+}
+
 const App = ({ language, error }: { error: Error, language: string }) => (
   <I18nextProvider i18n={i18n} initialLanguage={language}>
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={lightLiveTheme}>
       <RenderError withoutAppData error={error}>
         <TriggerAppReady />
       </RenderError>

--- a/src/renderer/init.js
+++ b/src/renderer/init.js
@@ -7,6 +7,10 @@ import 'helpers/experimental'
 import logger from 'logger'
 import LoggerTransport from 'logger/logger-transport-renderer'
 import React from 'react'
+import Transport from '@ledgerhq/hw-transport'
+import { NotEnoughBalance } from '@ledgerhq/errors'
+import { log } from '@ledgerhq/logs'
+import { checkLibs } from '@ledgerhq/live-common/lib/sanityChecks'
 import { remote, webFrame } from 'electron'
 import { render } from 'react-dom'
 import createHistory from 'history/createHashHistory'
@@ -53,6 +57,13 @@ const TAB_KEY = 9
 db.init(userDataDirectory)
 
 async function init() {
+  checkLibs({
+    NotEnoughBalance,
+    React,
+    log,
+    Transport,
+  })
+
   db.init(userDataDirectory)
   db.registerTransform('app', 'accounts', { get: decodeAccountsModel, set: encodeAccountsModel })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,10 +1963,10 @@
     bindings "1.3.0"
     nan "^2.6.2"
 
-"@ledgerhq/live-common@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-9.0.0.tgz#19c513396a3656c41ccc4e57d6367bf43e95547c"
-  integrity sha512-gH6VYNvkG6mK8b0sJI6N6pgArZ3quCf2uD551gqdqCARQN/obgEtINwswbHKiotlrdsMqzjj1urX5YxznFBe1g==
+"@ledgerhq/live-common@^9.1.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-9.1.0.tgz#4f1a733f4afda8bd49ab9531a1e2af651a147733"
+  integrity sha512-OItcwWfR8ZG+tk8ifGeRmD95r0tnoGNX8XELKqqAyGEvIjJDyUdFu8yb7VXX5imZrPvZM1xaMLDMtE0IuxCK4w==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "4"


### PR DESCRIPTION
this will prevent in the future to see errors not getting properly displayed (due to dup library)

@Arnaud97234 there is no change to expect in this PR, things should just work. but when a dup lib happen we'll get an error straight away at boot of the app, that way we are able to see something is wrong statically by simply running the build to test them.

<img width="1136" alt="Capture d’écran 2019-12-11 à 14 16 06" src="https://user-images.githubusercontent.com/211411/70645114-9fa58480-1c44-11ea-91ae-b79d59bf1059.png">
