### PR TITLE
Rollback the topbar padding

### DIFF
--- a/src/components/layout/Default.js
+++ b/src/components/layout/Default.js
@@ -50,7 +50,7 @@ const Main = styled(GrowScroll).attrs(() => ({
   px: 6,
 }))`
   outline: none;
-  padding-top: ${p => p.theme.sizes.topBarHeight + p.theme.space[4]}px;
+  padding-top: ${p => p.theme.sizes.topBarHeight + p.theme.space[6]}px;
 `
 
 type Props = {


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/70797540-02ae2d00-1da5-11ea-9d87-7ce603afc6b5.png)

We broke the UI when polishing for the delegation banner, we didn't check that the update banner was affected by this padding too. This rolls back that change, ideally we would have a way to test these things automatically at some point.

### Type

UI Fix
