### PR TITLE
Update live-common to includes websocket workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@ledgerhq/hw-transport-node-hid": "4.78.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "4.78.0",
     "@ledgerhq/ledger-core": "^4.2.0",
-    "@ledgerhq/live-common": "^9.1.0",
+    "@ledgerhq/live-common": "^9.3.0-beta.0",
     "@ledgerhq/logs": "4",
     "@tippy.js/react": "^3.1.0",
     "add": "^2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1963,10 +1963,10 @@
     bindings "1.3.0"
     nan "^2.6.2"
 
-"@ledgerhq/live-common@^9.1.0":
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-9.1.0.tgz#4f1a733f4afda8bd49ab9531a1e2af651a147733"
-  integrity sha512-OItcwWfR8ZG+tk8ifGeRmD95r0tnoGNX8XELKqqAyGEvIjJDyUdFu8yb7VXX5imZrPvZM1xaMLDMtE0IuxCK4w==
+"@ledgerhq/live-common@^9.3.0-beta.0":
+  version "9.3.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-9.3.0-beta.0.tgz#921896724f4ca6b08b11c18857ce605ff587b55d"
+  integrity sha512-6aahD0n8cE6xjQfOq4ViPHPls+zKNNyr3p9iDSLCpQc9pOgqcNKs1llCGcBs4TU47Tjt43bkXpsFoEQ7/83XYg==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "4"


### PR DESCRIPTION
includes https://github.com/LedgerHQ/ledger-live-common/pull/422

This is required for mobile android but we need to check all is fine to move on to this update.

### Type

Bug fix

### Context

LL-2084

### Parts of the app affected / Test plan

Everything that involve a websocket connection with our script runners (genuine check, install, uninstall, firmware update)

- we need to test the normal feature works
- we need to test the error cases still behave like on develop branch
- test it against the normal script runner and the staging script runner