### PR TITLE
Fixes for current sync error situation

### DIFF
--- a/src/helpers/experimental.js
+++ b/src/helpers/experimental.js
@@ -137,8 +137,15 @@ for (const k in process.env) {
 }
 /* eslint-enable guard-for-in */
 
+let lastChange = 0
+
+export function recentlyChangedExperimental() {
+  return Date.now() - lastChange < 10000
+}
+
 changes.subscribe(({ name, value }) => {
   if (experimentalFeatures.find(f => f.name === name) && !isReadOnlyEnv(name)) {
+    lastChange = Date.now()
     setLocalStorageEnv(name, value)
   }
 })

--- a/src/helpers/reset.js
+++ b/src/helpers/reset.js
@@ -2,26 +2,47 @@
 
 import { log } from '@ledgerhq/logs'
 import { ipcRenderer, shell, remote } from 'electron'
+import path from 'path'
+import rimraf from 'rimraf'
 import resolveUserDataDirectory from 'helpers/resolveUserDataDirectory'
 import { disable as disableDBMiddleware } from 'middlewares/db'
 import db from 'helpers/db'
 import { delay } from 'helpers/promise'
-import libcoreReset from 'commands/libcoreReset'
 import { clearBridgeCache } from 'bridge/cache'
 
-async function killInternalProcess() {
+let lastKill = 0
+
+export function recentlyKilledInternalProcess() {
+  return Date.now() - lastKill < 5000
+}
+
+export async function killInternalProcess() {
+  lastKill = Date.now()
   ipcRenderer.send('clean-processes')
   return delay(1000)
 }
+
+const removeSQLite = () =>
+  new Promise((resolve, reject) =>
+    rimraf(path.resolve(resolveUserDataDirectory(), 'sqlite/'), e => {
+      if (e) reject(e)
+      else resolve()
+    }),
+  )
 
 async function resetLibcore() {
   log('clear-cache', 'resetLibcore...')
   // we need to stop everything that is happening right now, like syncs
   await killInternalProcess()
   log('clear-cache', 'killed.')
-  // we can now ask libcore to reset itself
-  await libcoreReset.send().toPromise()
-  log('clear-cache', 'reset.')
+
+  await removeSQLite()
+  log('clear-cache', 'removeSQLite done.')
+}
+
+export function onUnusualInternalProcessError() {
+  if (recentlyKilledInternalProcess()) return
+  resetLibcore()
 }
 
 function reload() {

--- a/src/renderer/events.js
+++ b/src/renderer/events.js
@@ -6,6 +6,7 @@ import debug from 'debug'
 
 import network from 'api/network'
 import db from 'helpers/db'
+import { killInternalProcess } from 'helpers/reset'
 
 import { CHECK_UPDATE_DELAY, DISABLE_ACTIVITY_INDICATORS } from 'config/constants'
 import { onSetDeviceBusy } from 'components/DeviceBusyIndicator'
@@ -28,7 +29,7 @@ export function sendEvent(channel: string, msgType: string, data: any) {
 
 export default ({ store }: { store: Object }) => {
   // Ensure all sub-processes are killed before creating new ones (dev mode...)
-  ipcRenderer.send('clean-processes')
+  killInternalProcess()
 
   ipcRenderer.on('lock', () => {
     if (db.hasEncryptionKey('app', 'accounts')) {
@@ -60,7 +61,7 @@ export default ({ store }: { store: Object }) => {
 
 if (module.hot) {
   module.hot.accept('commands', () => {
-    ipcRenderer.send('clean-processes')
+    killInternalProcess()
   })
 }
 


### PR DESCRIPTION
There is an accumulation of recent changes that was done for last Release 1.19.2 that put ourself in a buggy situation where you can have your Sync stuck in a ERROR state and a clear cache would not help fixing it.

Let me try to explain that situation.

- The real cause of the crash is due to `lib-ledger-core` LOCK mechanism, it's a file somewhere under the `sqlite/` folder. It can sometimes happen that this LOCK file is not "redeemed" and therefore libcore is stuck in a locked state. It happens typically if you kill the Internal Process during a synchronisation (but not always). ( cc @phaazon a bug for you =) )
- https://github.com/LedgerHQ/ledger-live-desktop/commit/e4d18bf0b72ad1e6387527ebd539547337d4b389#diff-4431cab1a850e8b9f662e99d046e7652 Was fixed in 1.19.2 to properly kill the internal process when user do "Clear Cache". In previous releases we had a bug (kill must not be a command) and therefore you were always seeing the modal that asks you to manually delete the **sqlite** folder, this was always just a fallback mechanism because the goal always has been for Ledger Live clear cache feature to effectively do everything to recover from a bad libcore state. The problem is that, the automatic clear cache code only call `freshResetAll()` which does not solve the LOCK situation. => **the decision here is to go back to a `rimraf("sqlite/")` like we used to do in this past.**
- By enabling/disabling an Experimental Settings, and typically **Experimental USB**, we are triggering a KILL on the internal process, in order for that thread to take into account the new conditions of the USB setup. With the growing popularity of the Experimental USB to workaround a recent problem with the original USB implementation (likely consequence of LNS 1.6.0 new productIds), users are triggering the problem more often. **=> we are going to move to implementation of Experimental USB in our future rework**


So let me try to recap what this PR is changing, essentially two things:

- we are no longer going to use `freshResetAll()` but we are just nuking the libcore database with a `rimraf("sqlite/")`. that's the true way for us to strart from a fresh state.
- When a sync error sees an `"Internal process error"` it's just going to clearCache automatically. but only if it was not done recently. => I was able to test locally that this recover from a LOCKed situation **without I had to do anything.**


### Type

Bug fix

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

- Clear Cache
- when synchronisation happens
- switching experimental usb a few times helps to trigger the "LOCK" bug.
- when the auto clear cache mecanism happens, you might see the "internal process error" appearing for a few seconds but after a resync, it's gone.