### PR TITLE
LL-2221 Fix asset breadcrumb navigation and chart colors

### DIFF
--- a/src/renderer/components/Breadcrumb/AssetCrumb.js
+++ b/src/renderer/components/Breadcrumb/AssetCrumb.js
@@ -17,7 +17,7 @@ import Text from "~/renderer/components/Text";
 
 import IconCheck from "~/renderer/icons/Check";
 import IconAngleDown from "~/renderer/icons/AngleDown";
-// import CryptoCurrencyIcon from '~/renderer/icons/CryptoCurrencyIcon'
+import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
 
 import { Separator, Item, TextLink, AngleDown, Check } from "./common";
 
@@ -41,7 +41,7 @@ const AssetCrumb = () => {
   const renderItem = useCallback(
     ({ item, isActive }) => (
       <Item key={item.currency.id} isActive={isActive}>
-        {/* <CryptoCurrencyIcon size={16} currency={item.currency} /> */}
+        <CryptoCurrencyIcon size={16} currency={item.currency} />
         <Text ff={`Inter|${isActive ? "SemiBold" : "Regular"}`} fontSize={4}>
           {item.label}
         </Text>
@@ -56,7 +56,7 @@ const AssetCrumb = () => {
   );
 
   const onAccountSelected = useCallback(
-    ({ selectedIem: item }) => {
+    ({ selectedItem: item }) => {
       if (!item) {
         return null;
       }
@@ -102,7 +102,7 @@ const AssetCrumb = () => {
         onStateChange={onAccountSelected}
       >
         <TextLink>
-          {/* {activeItem && <CryptoCurrencyIcon size={14} currency={activeItem.currency} />} */}
+          {activeItem && <CryptoCurrencyIcon size={14} currency={activeItem.currency} />}
           <Button>{activeItem.currency.name}</Button>
           <AngleDown>
             <IconAngleDown size={16} />

--- a/src/renderer/screens/asset/BalanceSummary.js
+++ b/src/renderer/screens/asset/BalanceSummary.js
@@ -109,6 +109,7 @@ class BalanceSummary extends PureComponent<Props> {
 
         <Box px={5} ff="Inter" fontSize={4} color="palette.text.shade80" pt={6}>
           <Chart
+            key={chartId}
             id={chartId}
             color={chartColor}
             data={portfolio.history}


### PR DESCRIPTION
The asset navigation from the assets page was broken and after fixing it I noticed that the color of the assets chart was not updating. Adding a key to the chart seems to fix it, hopefully not introducing any performance hit cc @gre 

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2221
