### PR TITLE
LL-2245 (ManagerV2): placeholder for supported tokens added to search

### DIFF
--- a/src/renderer/components/ByteSize.js
+++ b/src/renderer/components/ByteSize.js
@@ -3,18 +3,35 @@ import React from "react";
 import { Trans } from "react-i18next";
 import type { DeviceModel } from "@ledgerhq/devices";
 
-const ByteSize = ({ value, deviceModel }: { value: number, deviceModel: DeviceModel }) =>
-  !value ? (
-    "–"
-  ) : (
+/** formats a byte value into its correct size in kb or mb unit takling in account the device block size */
+const ByteSize = ({
+  value,
+  deviceModel,
+  decimals = 2,
+}: {
+  value: number,
+  deviceModel: DeviceModel,
+  decimals?: number,
+}) => {
+  if (!value) return "–";
+
+  const k = 1024; // 1kb unit
+  const sizes = ["bytes", "kbUnit", "mbUnit"];
+
+  const bytes = Math.ceil(value / deviceModel.blockSize) * deviceModel.blockSize;
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  const dm = Math.max(0, decimals);
+
+  return (
     <Trans
-      i18nKey="byteSize.kbUnit"
+      i18nKey={`byteSize.${sizes[i]}`}
       values={{
-        size: ((Math.ceil(value / deviceModel.blockSize) * deviceModel.blockSize) / 1024).toFixed(
-          0,
-        ),
+        size: parseFloat((bytes / Math.pow(k, i)).toFixed(dm)),
       }}
     />
   );
+};
 
 export default ByteSize;

--- a/src/renderer/components/ByteSize.js
+++ b/src/renderer/components/ByteSize.js
@@ -3,6 +3,9 @@ import React from "react";
 import { Trans } from "react-i18next";
 import type { DeviceModel } from "@ledgerhq/devices";
 
+const k = 1024; // 1kb unit
+const sizes = ["bytes", "kbUnit", "mbUnit"];
+
 /** formats a byte value into its correct size in kb or mb unit takling in account the device block size */
 const ByteSize = ({
   value,
@@ -14,9 +17,6 @@ const ByteSize = ({
   decimals?: number,
 }) => {
   if (!value) return "–";
-
-  const k = 1024; // 1kb unit
-  const sizes = ["bytes", "kbUnit", "mbUnit"];
 
   const bytes = Math.ceil(value / deviceModel.blockSize) * deviceModel.blockSize;
 

--- a/src/renderer/screens/manager/AppsList/AppsList.js
+++ b/src/renderer/screens/manager/AppsList/AppsList.js
@@ -216,7 +216,12 @@ const AppsList = ({
             {displayedAppList.length ? (
               displayedAppList.map(app => mapApp(app, !isDeviceTab))
             ) : (
-              <Placeholder />
+              <Placeholder
+                query={query}
+                addAccount={addAccount}
+                dispatch={dispatch}
+                installed={installedApps}
+              />
             )}
           </>
         )}

--- a/src/renderer/screens/manager/AppsList/Placeholder.js
+++ b/src/renderer/screens/manager/AppsList/Placeholder.js
@@ -1,23 +1,128 @@
 // @flow
-import React from "react";
+import React, { useMemo, useCallback } from "react";
 import { Trans } from "react-i18next";
+
+import type { Action, InstalledItem } from "@ledgerhq/live-common/lib/apps/types";
+
+import { listTokens } from "@ledgerhq/live-common/lib/currencies";
 
 import Text from "~/renderer/components/Text";
 import NoResults from "~/renderer/icons/NoResults";
 import Box from "~/renderer/components/Box/Box";
+import Button from "~/renderer/components/Button";
 
-const Placeholder = () => (
-  <Box in vertical py={6} flex alignContent="center">
-    <Box mb={4} horizontal color="palette.text.shade30" justifyContent="center">
-      <NoResults />
+const tokens = listTokens();
+
+type Props = {
+  query: string,
+  addAccount: (*) => void,
+  dispatch: Action => void,
+  installed: InstalledItem[],
+};
+
+const Placeholder = ({ query, addAccount, dispatch, installed }: Props) => {
+  const found = useMemo(
+    () =>
+      tokens.find(
+        token =>
+          token.name.toLocaleLowerCase().includes(query.toLowerCase()) ||
+          token.ticker.toLocaleLowerCase().includes(query.toLowerCase()),
+      ),
+    [query],
+  );
+
+  const install = useCallback(
+    () =>
+      found &&
+      found.parentCurrency &&
+      dispatch({ type: "install", name: found.parentCurrency.name }),
+    [found, dispatch],
+  );
+
+  const parentInstalled = useMemo(
+    () =>
+      found &&
+      found.parentCurrency &&
+      installed.find(({ name }) => name === found.parentCurrency.name),
+    [found, installed],
+  );
+
+  const goToAccounts = useCallback(() => addAccount(found), [addAccount, found]);
+
+  return found && found.parentCurrency ? (
+    <Box alignItems="center" pt={5} py={6}>
+      <Box ff="Inter|Regular" fontSize={5} color="palette.text.shade100">
+        <Trans
+          i18nKey="manager.applist.item.noAppNeededForToken"
+          values={{
+            appName: found.parentCurrency.name,
+            tokenName: `${found.name} (${found.ticker})`,
+          }}
+        />
+      </Box>
+      <Box pt={2} style={{ maxWidth: 500 }} alignItems="center">
+        <Text
+          ff="Inter|Regular"
+          color="palette.text.shade80"
+          fontSize={4}
+          textAlign="center"
+          style={{ lineHeight: 1.6 }}
+        >
+          <Trans
+            i18nKey={
+              !parentInstalled
+                ? "manager.applist.item.tokenAppDisclaimer"
+                : "manager.applist.item.tokenAppDisclaimerInstalled"
+            }
+            values={{
+              appName: found.parentCurrency.name,
+              tokenName: found.name,
+              tokenType: found.tokenType.toUpperCase(),
+            }}
+          >
+            {"placeholder"}
+            <Text ff="Inter|SemiBold" color="palette.text.shade100">
+              {"placeholder"}
+            </Text>
+            {"placeholder"}
+            <Text ff="Inter|SemiBold" color="palette.text.shade100">
+              {"placeholder"}
+            </Text>
+          </Trans>
+        </Text>
+      </Box>
+      <Box pt={5} horizontal>
+        <Button
+          outline
+          outlineColor="palette.text.shade60"
+          onClick={goToAccounts}
+          style={{ marginRight: 32 }}
+        >
+          <Trans i18nKey="manager.applist.item.goToAccounts" />
+        </Button>
+        {!parentInstalled && (
+          <Button primary onClick={install}>
+            <Trans
+              i18nKey="manager.applist.item.intallParentApp"
+              values={{ appName: found.parentCurrency.name }}
+            />
+          </Button>
+        )}
+      </Box>
     </Box>
-    <Text textAlign="center" ff="Inter|SemiBold" fontSize={6}>
-      <Trans i18nKey="manager.applist.noResultsFound" />
-    </Text>
-    <Text textAlign="center" fontSize={4}>
-      <Trans i18nKey="manager.applist.noResultsDesc" />
-    </Text>
-  </Box>
-);
+  ) : (
+    <Box vertical py={6} flex alignContent="center">
+      <Box mb={4} horizontal color="palette.text.shade30" justifyContent="center">
+        <NoResults />
+      </Box>
+      <Text textAlign="center" ff="Inter|SemiBold" fontSize={6}>
+        <Trans i18nKey="manager.applist.noResultsFound" />
+      </Text>
+      <Text textAlign="center" fontSize={4}>
+        <Trans i18nKey="manager.applist.noResultsDesc" />
+      </Text>
+    </Box>
+  );
+};
 
 export default Placeholder;

--- a/src/renderer/screens/manager/AppsList/Placeholder.js
+++ b/src/renderer/screens/manager/AppsList/Placeholder.js
@@ -25,8 +25,8 @@ const Placeholder = ({ query, addAccount, dispatch, installed }: Props) => {
     () =>
       tokens.find(
         token =>
-          token.name.toLocaleLowerCase().includes(query.toLowerCase()) ||
-          token.ticker.toLocaleLowerCase().includes(query.toLowerCase()),
+          token.name.toLowerCase().includes(query.toLowerCase()) ||
+          token.ticker.toLowerCase().includes(query.toLowerCase()),
       ),
     [query],
   );

--- a/src/renderer/screens/manager/AppsList/Progress.js
+++ b/src/renderer/screens/manager/AppsList/Progress.js
@@ -52,7 +52,7 @@ const Progress = ({ installing, uninstalling, progress }: Props) => {
           ) : installing && progress !== 1 ? (
             <ProgressBar infinite timing={1200} progress={progress || 0} />
           ) : (
-            <ProgressBar infinite color="palette.text.shade20" timing={1200} />
+            <ProgressBar color="palette.text.shade20" progress={-1} />
           )}
         </Holder>
       </Box>

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -73,9 +73,9 @@
     }
   },
   "byteSize": {
-    "bytes": "{{size}}bytes",
-    "kbUnit": "{{size}}Kb",
-    "mbUnit": "{{size}}Mb"
+    "bytes": "{{size}} bytes",
+    "kbUnit": "{{size}} Kb",
+    "mbUnit": "{{size}} Mb"
   },
   "time": {
     "minute": "Minute",

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -420,7 +420,12 @@
         "addAccountWarn": "Please wait for the app updates to finish",
         "learnMore": "Learn more",
         "learnMoreTooltip": "Learn more about {{appName}}",
-        "removeTooltip": "Uninstall {{appName}}"
+        "removeTooltip": "Uninstall {{appName}}",
+        "noAppNeededForToken": "Install {{appName}} app for {{tokenName}}",
+        "tokenAppDisclaimer": "{{tokenName}} is an {{tokenType}} token using the {{appName}} app. To manage {{tokenName}}, <1>install the {{appName}} app</1> and send the tokens <3>to your {{appName}} account</3>",
+        "tokenAppDisclaimerInstalled": "{{tokenName}} is an {{tokenType}} token using the {{appName}} app. To manage {{tokenName}}, <1>open the {{appName}} app</1> and send the tokens <3>to your {{appName}} account</3>",
+        "goToAccounts": "Go to accounts",
+        "intallParentApp": "Install {{appName}} app"
       },
       "uninstall": {
         "title": "Uninstall all",

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -73,7 +73,9 @@
     }
   },
   "byteSize": {
-    "kbUnit": "{{size}}Kb"
+    "bytes": "{{size}}bytes",
+    "kbUnit": "{{size}}Kb",
+    "mbUnit": "{{size}}Mb"
   },
   "time": {
     "minute": "Minute",
@@ -362,7 +364,7 @@
     },
     "deviceStorage": {
       "freeSpace": "<0>{{space}}</0> free",
-      "noFreeSpace": "no storage left",
+      "noFreeSpace": "No storage left",
       "installed": "Installed",
       "capacity": "Capacity",
       "used": "Used",
@@ -397,8 +399,8 @@
       },
       "updatable": {
         "title": "Updates available",
-        "progressTitle": "{{number}} app updates",
-        "progressWarning": "Do not quit manager during update",
+        "progressTitle": "{{number}} App updates",
+        "progressWarning": "Do not quit the Manager during updates",
         "progress": "Updating all..."
       },
       "item": {


### PR DESCRIPTION
Manager search query now shows if the searched token is supported
and redirects to the accounts or installs the app if needed.

![localhost_8080_webpack_index html](https://user-images.githubusercontent.com/11752937/75045430-9007af00-54c3-11ea-8672-40e85236e32d.png)

+ some polishes:
* scheduled queue bar now static in animation
* wording capitalization issues
* Bytesize component now takes in account both KB and MB size and does the correct rounding for better readability

### Type

Feature

### Context

Managerv2

LL-2245

### Parts of the app affected / Test plan

Managerv2

