### PR TITLE
LL-2220 XScroll on op details modal

### DIFF
--- a/src/renderer/modals/OperationDetails/index.js
+++ b/src/renderer/modals/OperationDetails/index.js
@@ -337,7 +337,7 @@ const OperationDetails: React$ComponentType<OwnProps> = connect(mapStateToProps)
                   style={{ marginLeft: 4 }}
                 />
               </OpDetailsSection>
-              <Box>
+              <Box style={{ overflowX: "hidden" }}>
                 {subOperations.map((op, i) => {
                   const opAccount = findSubAccountById(account, op.accountId);
 


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
We are so damn constrained on the X-axis there's virtually no space for anything even though with the smaller size window we still have a lot of room for a wider modal. We managed to change the flows for send, the next step is more sensible modal dimensions!
![image](https://user-images.githubusercontent.com/4631227/75053772-22af4a80-54d2-11ea-907e-79e11eb08524.png)

Back to the task at hand, the only way I can see of easily fixing this is by hiding the overflow for that particular box since it has nowhere to grow to. So that's the solution shown here. The downside is that we used to have a border separator that extended to the edges of the modal but that's another story if you ask me.
![image](https://user-images.githubusercontent.com/4631227/75053931-62763200-54d2-11ea-9982-4254202eba39.png)

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2220

### Parts of the app affected / Test plan
Operation details modals for operations involving subaccounts, tokens, and such where we get the header on top such as on the screenshot.