### PR TITLE
LL-2224 Move the NotifComponent to top-right corner when collapsed

### DIFF
--- a/src/renderer/components/MainSideBar/index.js
+++ b/src/renderer/components/MainSideBar/index.js
@@ -246,7 +246,7 @@ const MainSideBar = () => {
                 iconActiveColor="wallet"
                 onClick={handleClickDashboard}
                 isActive={location.pathname === "/"}
-                NotifComponent={noAccounts ? undefined : UpdateDot}
+                NotifComponent={noAccounts ? undefined : <UpdateDot collapsed={collapsed} />}
                 disabled={noAccounts}
                 collapsed={secondAnim}
               />
@@ -256,7 +256,7 @@ const MainSideBar = () => {
                 iconActiveColor="wallet"
                 isActive={location.pathname === "/accounts"}
                 onClick={handleClickAccounts}
-                NotifComponent={noAccounts ? UpdateDot : undefined}
+                NotifComponent={noAccounts ? <UpdateDot collapsed={collapsed} /> : undefined}
                 collapsed={secondAnim}
               />
               <SideBarListItem

--- a/src/renderer/components/SideBar/SideBarListItem.js
+++ b/src/renderer/components/SideBar/SideBarListItem.js
@@ -58,12 +58,22 @@ class SideBarListItem extends PureComponent<Props> {
               {!!desc && desc(this.props)}
             </Hide>
           </Box>
-          {NotifComponent && <NotifComponent />}
+          {NotifComponent && (
+            <NotifWrapper collapsed={!!collapsed}>
+              <NotifComponent />
+            </NotifWrapper>
+          )}
         </Container>
       </Tooltip>
     );
   }
 }
+
+const NotifWrapper = styled.div`
+  ${p => p.collapsed && "margin-left:-10px;"}
+  ${p => p.collapsed && "margin-top:-18px;"}
+  transition: margin-top ease-in-out 200ms;
+`;
 
 const Container = styled(Tabbable).attrs(() => ({
   alignItems: "center",

--- a/src/renderer/components/SideBar/SideBarListItem.js
+++ b/src/renderer/components/SideBar/SideBarListItem.js
@@ -74,6 +74,7 @@ const Container = styled(Tabbable).attrs(() => ({
   px: 3,
   py: 2,
 }))`
+  position: relative;
   width: 100%;
   cursor: ${p => (p.disabled ? "not-allowed" : "pointer")};
   color: ${p =>

--- a/src/renderer/components/SideBar/SideBarListItem.js
+++ b/src/renderer/components/SideBar/SideBarListItem.js
@@ -58,22 +58,12 @@ class SideBarListItem extends PureComponent<Props> {
               {!!desc && desc(this.props)}
             </Hide>
           </Box>
-          {NotifComponent && (
-            <NotifWrapper collapsed={!!collapsed}>
-              <NotifComponent />
-            </NotifWrapper>
-          )}
+          {NotifComponent && <NotifComponent collapsed={!!collapsed} />}
         </Container>
       </Tooltip>
     );
   }
 }
-
-const NotifWrapper = styled.div`
-  ${p => p.collapsed && "margin-left:-10px;"}
-  ${p => p.collapsed && "margin-top:-18px;"}
-  transition: margin-top ease-in-out 200ms;
-`;
 
 const Container = styled(Tabbable).attrs(() => ({
   alignItems: "center",

--- a/src/renderer/components/SideBar/SideBarListItem.js
+++ b/src/renderer/components/SideBar/SideBarListItem.js
@@ -13,7 +13,7 @@ export type Props = {
   icon?: any, // TODO: type should be more precise, but, eh ¯\_(ツ)_/¯
   disabled?: boolean,
   iconActiveColor: ?string,
-  NotifComponent?: React$ComponentType<*>,
+  NotifComponent?: React$Node,
   isActive?: boolean,
   onClick?: void => void,
   isActive?: boolean,
@@ -58,7 +58,7 @@ class SideBarListItem extends PureComponent<Props> {
               {!!desc && desc(this.props)}
             </Hide>
           </Box>
-          {NotifComponent && <NotifComponent collapsed={!!collapsed} />}
+          {NotifComponent}
         </Container>
       </Tooltip>
     );

--- a/src/renderer/components/Updater/UpdateDot.js
+++ b/src/renderer/components/Updater/UpdateDot.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { useContext } from "react";
-import styled from "styled-components";
+import styled, { keyframes, css } from "styled-components";
 
 import { colors } from "~/renderer/styles/theme";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
@@ -17,6 +17,36 @@ const getColor = ({ status }: { status: UpdateStatus }) =>
 const getOpacity = ({ status }: { status: UpdateStatus }) =>
   status === "download-progress" || status === "checking" ? 0.5 : 1;
 
+const collapseAnim = keyframes`
+  0% {
+    opacity: 0;
+    top: -5px;
+    right: -5px;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 1;
+    top: -5px;
+    right: -5px;
+    transform: translateY(0);
+  }
+`;
+
+const openAnim = keyframes`
+  0% {
+    opacity: 0;
+    top: 50%;
+    right: 10px;
+    transform: translateY(-50%);
+  }
+  100% {
+    opacity: 1;
+    top: 50%;
+    right: 10px;
+    transform: translateY(-50%);
+  }
+`;
+
 export const Dot: ThemedComponent<{ status: UpdateStatus, collapsed?: ?boolean }> = styled.div`
   opacity: ${getOpacity};
   background-color: ${getColor};
@@ -24,9 +54,20 @@ export const Dot: ThemedComponent<{ status: UpdateStatus, collapsed?: ?boolean }
   position: absolute;
   top: -5px;
   right: -5px;
+  transform: translateY(0);
+  opacity: 0;
   width: 12px;
   height: 12px;
   border: 1.5px solid ${p => p.theme.colors.palette.background.paper};
+  animation: ${p =>
+      p.collapsed
+        ? css`
+            ${collapseAnim}
+          `
+        : css`
+            ${openAnim}
+          `}
+    200ms 500ms ease forwards;
 `;
 
 const UpdateDot = ({ collapsed }: { collapsed: ?boolean }) => {

--- a/src/renderer/components/Updater/UpdateDot.js
+++ b/src/renderer/components/Updater/UpdateDot.js
@@ -17,20 +17,32 @@ const getColor = ({ status }: { status: UpdateStatus }) =>
 const getOpacity = ({ status }: { status: UpdateStatus }) =>
   status === "download-progress" || status === "checking" ? 0.5 : 1;
 
-export const Dot: ThemedComponent<{ status: UpdateStatus }> = styled.div`
+export const Dot: ThemedComponent<{ status: UpdateStatus, collapsed?: ?boolean }> = styled.div`
   opacity: ${getOpacity};
-  width: 8px;
-  height: 8px;
   background-color: ${getColor};
   border-radius: 50%;
+  ${p =>
+    p.collapsed
+      ? `
+      width: 12px;
+      height: 12px;
+      margin-left: -4px;
+      margin-top: -36px;
+      border:1.5px solid ${p.theme.colors.palette.background.paper};
+  `
+      : `
+      width: 8px;
+      height: 8px;
+  `}
+  transition: margin-top linear 200ms;
 `;
 
-const UpdateDot = () => {
+const UpdateDot = ({ collapsed }: { collapsed: ?boolean }) => {
   const context = useContext(UpdaterContext);
   if (context) {
     const { status } = context;
     if (!VISIBLE_STATUS.includes(status)) return null;
-    return <Dot status={status} />;
+    return <Dot collapsed={collapsed} status={status} />;
   }
 
   return null;

--- a/src/renderer/components/Updater/UpdateDot.js
+++ b/src/renderer/components/Updater/UpdateDot.js
@@ -21,20 +21,12 @@ export const Dot: ThemedComponent<{ status: UpdateStatus, collapsed?: ?boolean }
   opacity: ${getOpacity};
   background-color: ${getColor};
   border-radius: 50%;
-  ${p =>
-    p.collapsed
-      ? `
-      width: 12px;
-      height: 12px;
-      margin-left: -4px;
-      margin-top: -36px;
-      border:1.5px solid ${p.theme.colors.palette.background.paper};
-  `
-      : `
-      width: 8px;
-      height: 8px;
-  `}
-  transition: margin-top linear 200ms;
+  position: absolute;
+  top: -5px;
+  right: -5px;
+  width: 12px;
+  height: 12px;
+  border: 1.5px solid ${p => p.theme.colors.palette.background.paper};
 `;
 
 const UpdateDot = ({ collapsed }: { collapsed: ?boolean }) => {


### PR DESCRIPTION
Moved the `NotifComponent` a bit so that it's no longer out of the sidebar. I don't like this catch-all style inside `Box` (the reason why it was getting the left margin)  but we'll have to deal with it for now. Had to wrap it further to restyle it.
https://github.com/LedgerHQ/ledger-live-desktop/blob/19b092792100ec2944e2f55569054b91d8c30192/src/renderer/components/Box/Box.js#L84-L87 

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2224

![image](https://user-images.githubusercontent.com/4631227/75240016-f8a4a380-57c3-11ea-8e9d-12c0ca131935.png)


### Parts of the app affected / Test plan

Enable the `DEBUG_UPDATE` flag to get the update debug UI visible, and set a state that has a notification component, then collapse the sidebar.