### PR TITLE
Fix setEnv event not supported

### DIFF
--- a/src/internal/index.js
+++ b/src/internal/index.js
@@ -1,6 +1,7 @@
 // @flow
 import { unsubscribeSetup } from "./live-common-setup";
 
+import { setEnvUnsafe } from "@ledgerhq/live-common/lib/env";
 import { serializeError } from "@ledgerhq/errors";
 import { getCurrencyBridge } from "@ledgerhq/live-common/lib/bridge";
 import { getCryptoCurrencyById } from "@ledgerhq/live-common/lib/currencies";
@@ -94,6 +95,12 @@ process.on("message", m => {
         getCurrencyBridge(currency).hydrate(data);
       });
 
+      break;
+    }
+
+    case "setEnv": {
+      const { name, value } = m.env;
+      setEnvUnsafe(name, value);
       break;
     }
 

--- a/src/internal/live-common-setup.js
+++ b/src/internal/live-common-setup.js
@@ -21,14 +21,6 @@ for (const k in process.env) {
 }
 /* eslint-enable guard-for-in */
 
-process.on("message", message => {
-  if (message.type === "setEnv") {
-    const { name, value } = message.env;
-
-    setEnvUnsafe(name, value);
-  }
-});
-
 let busy = false;
 
 const refreshBusyUIState = throttle(() => {


### PR DESCRIPTION
The app was wrongly displaying `'setEnv' event not supported` in the console, while the event was handled just fine.

### Type

Bug fix


