### PR TITLE
Fix overflowing TOS footer

### DIFF
--- a/src/renderer/modals/Terms/index.js
+++ b/src/renderer/modals/Terms/index.js
@@ -68,13 +68,13 @@ const TermsModal = () => {
         modalFooterStyle={{ justifyContent: "stretch" }}
         renderFooter={() => (
           <Box
-            style={{ position: "relative" }}
+            style={{ position: "relative", width: "100%" }}
             grow
             horizontal
             justifyContent="space-between"
             alignItems="center"
           >
-            <Box style={{ width: "50%" }} horizontal alignItems="center" onClick={onSwitchAccept}>
+            <Box style={{ width: "75%" }} horizontal alignItems="center" onClick={onSwitchAccept}>
               <CheckBox isChecked={accepted} />
               <Text ff="Inter|SemiBold" fontSize={4} style={{ marginLeft: 8, flex: 1 }}>
                 <Trans i18nKey="Terms.switchLabel" />


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/75324267-dae44680-5876-11ea-80db-d6f9df8e500d.png)

### Type

UI Polish

### Parts of the app affected / Test plan
When the TOS were shown in french the footer text pushed the button to the right outside of the modal, this should fix it.
