### PR TITLE
Release Notes

### DIFF
--- a/src/renderer/components/IsNewVersion.js
+++ b/src/renderer/components/IsNewVersion.js
@@ -15,7 +15,7 @@ const IsNewVersion = () => {
 
   useEffect(() => {
     if (gt(currentVersion, lastUsedVersion)) {
-      dispatch(openModal("MODAL_RELEASES_NOTES", currentVersion));
+      dispatch(openModal("MODAL_RELEASE_NOTES", currentVersion));
       dispatch(saveSettings({ lastUsedVersion: currentVersion }));
     }
   }, [currentVersion, dispatch, lastUsedVersion]);

--- a/src/renderer/modals/ReleaseNotes/ReleaseNotesBody.js
+++ b/src/renderer/modals/ReleaseNotes/ReleaseNotesBody.js
@@ -1,0 +1,131 @@
+// @flow
+import React, { PureComponent } from "react";
+import { withTranslation } from "react-i18next";
+import styled from "styled-components";
+import semver from "semver";
+import type { TFunction } from "react-i18next";
+
+import { ModalBody } from "~/renderer/components/Modal";
+import Box from "~/renderer/components/Box";
+import TranslatedError from "~/renderer/components/TranslatedError";
+import Spinner from "~/renderer/components/Spinner";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Text from "~/renderer/components/Text";
+import Button from "~/renderer/components/Button";
+import Markdown, { Notes } from "~/renderer/components/Markdown";
+import network from "@ledgerhq/live-common/lib/network";
+
+type Props = {
+  version: string,
+  onClose: () => void,
+  t: TFunction,
+};
+
+type State = {
+  notes: *,
+  error: ?Error,
+};
+
+const Title = styled(Text).attrs(() => ({
+  ff: "Inter",
+  fontSize: 5,
+  color: "palette.text.shade100",
+}))``;
+
+class ReleaseNotesBody extends PureComponent<Props, State> {
+  state = {
+    notes: null,
+    error: null,
+  };
+
+  componentDidMount() {
+    const { version } = this.props;
+    this.fetchNotes(version);
+  }
+
+  fetchNotes = async (version: string) => {
+    try {
+      const { data } = await network({
+        method: "GET",
+        url: "https://api.github.com/repos/LedgerHQ/ledger-live-desktop/releases",
+        // `https://api.github.com/repos/LedgerHQ/ledger-live-desktop/releases/tags/v${version}`,
+      });
+      const v = semver.parse(version);
+      if (!v) throw new Error(`can't parse semver ${version}`);
+      const notes = data.filter(
+        d =>
+          semver.gte(
+            d.tag_name,
+            v.prerelease.length
+              ? `${v.major}.${v.minor}.${v.patch}-${v.prerelease[0]}`
+              : `${v.major}.${v.minor}.0`,
+          ) && semver.lte(d.tag_name, version),
+      );
+      this.setState({ notes });
+    } catch (error) {
+      this.setState({ error });
+    }
+  };
+
+  renderContent = () => {
+    const { error, notes } = this.state;
+    const { t } = this.props;
+
+    const { version } = this.props;
+
+    if (notes) {
+      return notes.map(note => (
+        <Notes mb={6} key={note.tag_name}>
+          <Title>{t("releaseNotes.version", { versionNb: note.tag_name })}</Title>
+          <Markdown>{note.body}</Markdown>
+        </Notes>
+      ));
+    } else if (error) {
+      return (
+        <Notes>
+          <Title>{t("releaseNotes.version", { versionNb: version })}</Title>
+          <Box style={{ wordWrap: "break-word" }} color="alertRed" ff="Inter|SemiBold" fontSize={3}>
+            <TranslatedError error={error} />
+          </Box>
+        </Notes>
+      );
+    }
+
+    return (
+      <Box horizontal alignItems="center">
+        <Spinner
+          size={32}
+          style={{
+            margin: "auto",
+          }}
+        />
+      </Box>
+    );
+  };
+
+  render() {
+    const { onClose, t } = this.props;
+
+    return (
+      <ModalBody
+        onClose={onClose}
+        title={t("releaseNotes.title")}
+        render={() => (
+          <Box relative style={{ height: 500 }} px={5} pb={8}>
+            <TrackPage category="Modal" name="ReleaseNotes" />
+            {this.renderContent()}
+          </Box>
+        )}
+        renderFooter={() => (
+          <Box horizontal justifyContent="flex-end">
+            <Button onClick={onClose} primary data-e2e="modal_buttonClose_releaseNote">
+              {t("common.continue")}
+            </Button>
+          </Box>
+        )}
+      />
+    );
+  }
+}
+
+export default withTranslation()(ReleaseNotesBody);

--- a/src/renderer/modals/ReleaseNotes/index.js
+++ b/src/renderer/modals/ReleaseNotes/index.js
@@ -1,0 +1,15 @@
+// @flow
+
+import React from "react";
+import Modal from "~/renderer/components/Modal";
+import ReleaseNotesBody from "./ReleaseNotesBody";
+
+const ReleaseNotesModal = () => (
+  <Modal
+    name="MODAL_RELEASE_NOTES"
+    centered
+    render={({ data, onClose }) => <ReleaseNotesBody version={data} onClose={onClose} />}
+  />
+);
+
+export default ReleaseNotesModal;

--- a/src/renderer/modals/index.js
+++ b/src/renderer/modals/index.js
@@ -16,6 +16,7 @@ import MODAL_EXPORT_ACCOUNTS from "./ExportAccounts";
 import MODAL_TECHNICAL_DATA from "./TechnicalData";
 import MODAL_SHARE_ANALYTICS from "./ShareAnalytics";
 import MODAL_SETTINGS_ACCOUNT from "./SettingsAccount";
+import MODAL_RELEASE_NOTES from "./ReleaseNotes";
 
 const modals: { [_: string]: React$ComponentType<any> } = {
   MODAL_EXPORT_OPERATIONS,
@@ -34,6 +35,7 @@ const modals: { [_: string]: React$ComponentType<any> } = {
   MODAL_TECHNICAL_DATA,
   MODAL_SHARE_ANALYTICS,
   MODAL_SETTINGS_ACCOUNT,
+  MODAL_RELEASE_NOTES,
 };
 
 export default modals;


### PR DESCRIPTION
We didn't backport the release notes modal from v1 to v2, this fixes that.

<img width="1136" alt="Capture d’écran 2020-02-26 à 14 31 22" src="https://user-images.githubusercontent.com/211411/75349229-adae8d00-58a4-11ea-8020-cf013dc7bc93.png">


### Type

Feature

### Parts of the app affected / Test plan

How to test:

- edit `~/Library/Application\ Support/Electron/app.json` file and set "1.19.0" for `lastUsedVersion`
- edit the project package.json version and set `1.20.0`.
- `rm -rf .webpack`
- start Ledger Live with `yarn start`. You should see release notes of 1.20.0
- if you restart the Ledger Live, you should not see it again.