### PR TITLE
Manager v2 polish

### DIFF
--- a/src/renderer/components/NavigationGuard.js
+++ b/src/renderer/components/NavigationGuard.js
@@ -90,8 +90,8 @@ const NavigationGuard = ({
         analyticsName={analyticsName}
         isOpened={modalVisible}
         onCancel={closeModal}
-        onReject={closeModal}
-        onConfirm={handleConfirmNavigationClick}
+        onReject={handleConfirmNavigationClick}
+        onConfirm={closeModal}
       />
     </>
   );

--- a/src/renderer/screens/manager/AppsList/AppActions.js
+++ b/src/renderer/screens/manager/AppsList/AppActions.js
@@ -124,6 +124,7 @@ const AppActions: React$ComponentType<Props> = React.memo(
           <Progress
             updating={updating}
             installing={installing}
+            isCurrent={installQueue.length > 0 && installQueue[0] === name}
             uninstalling={uninstalling}
             progress={progress}
           />

--- a/src/renderer/screens/manager/AppsList/AppsList.js
+++ b/src/renderer/screens/manager/AppsList/AppsList.js
@@ -111,7 +111,7 @@ const AppsList = ({
     }
   }, [search]);
 
-  const { installed: installedApps, uninstallQueue } = state;
+  const { installed: installedApps, uninstallQueue, apps } = state;
 
   const addAccount = useCallback(
     currency => {
@@ -219,6 +219,7 @@ const AppsList = ({
                 addAccount={addAccount}
                 dispatch={dispatch}
                 installed={installedApps}
+                apps={apps}
               />
             )}
           </>

--- a/src/renderer/screens/manager/AppsList/Placeholder.js
+++ b/src/renderer/screens/manager/AppsList/Placeholder.js
@@ -2,7 +2,8 @@
 import React, { useMemo, useCallback } from "react";
 import { Trans } from "react-i18next";
 
-import type { Action, InstalledItem, App } from "@ledgerhq/live-common/lib/apps/types";
+import type { Action, InstalledItem } from "@ledgerhq/live-common/lib/apps/types";
+import type { App } from "@ledgerhq/live-common/lib/types/manager";
 
 import { listTokens } from "@ledgerhq/live-common/lib/currencies";
 import manager from "@ledgerhq/live-common/lib/manager";

--- a/src/renderer/screens/manager/AppsList/Progress.js
+++ b/src/renderer/screens/manager/AppsList/Progress.js
@@ -20,10 +20,11 @@ type Props = {
   installing?: boolean,
   uninstalling?: boolean,
   progress?: number,
+  isCurrent: boolean,
 };
 
 // we can forward appOp from state.currentAppOp if it matches the contextual app
-const Progress = ({ updating, installing, uninstalling, progress }: Props) => {
+const Progress = ({ updating, installing, uninstalling, progress, isCurrent }: Props) => {
   return (
     <Box flex="1" horizontal justifyContent="flex-end" overflow="hidden">
       <Box flex="0 0 auto" vertical alignItems="flex-end" justifyContent="center">
@@ -42,7 +43,7 @@ const Progress = ({ updating, installing, uninstalling, progress }: Props) => {
                   ? "manager.applist.item.updating"
                   : uninstalling
                   ? "manager.applist.item.uninstalling"
-                  : installing && progress !== 1
+                  : installing && isCurrent && progress !== 1
                   ? "manager.applist.item.installing"
                   : "manager.applist.item.scheduled"
               }
@@ -52,7 +53,7 @@ const Progress = ({ updating, installing, uninstalling, progress }: Props) => {
         <Holder>
           {uninstalling ? (
             <ProgressBar infinite timing={1200} />
-          ) : installing && progress !== 1 ? (
+          ) : installing && isCurrent && progress !== 1 ? (
             <ProgressBar infinite timing={1200} progress={progress || 0} />
           ) : (
             <ProgressBar color="palette.text.shade20" progress={-1} />

--- a/src/renderer/screens/manager/AppsList/index.js
+++ b/src/renderer/screens/manager/AppsList/index.js
@@ -101,8 +101,8 @@ const AppsList = ({ deviceInfo, result, exec, t }: Props) => {
           </>
         }
         desc={t(`errors.ManagerQuitPage.${installState}.description`)}
-        confirmText={t(`errors.ManagerQuitPage.quit`)}
-        cancelText={t(`errors.ManagerQuitPage.${installState}.stay`)}
+        confirmText={t(`errors.ManagerQuitPage.${installState}.stay`)}
+        cancelText={t(`errors.ManagerQuitPage.quit`)}
         centered
       />
       <DeviceStorage

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -420,6 +420,7 @@
         "learnMore": "Learn more",
         "learnMoreTooltip": "Learn more about {{appName}}",
         "removeTooltip": "Uninstall {{appName}}",
+        "useAppForToken": "{{tokenName}} tokens can be managed using the {{appName}} app",
         "noAppNeededForToken": "Install {{appName}} app for {{tokenName}}",
         "tokenAppDisclaimer": "{{tokenName}} is an {{tokenType}} token using the {{appName}} app. To manage {{tokenName}}, <1>install the {{appName}} app</1> and send the tokens <3>to your {{appName}} account</3>",
         "tokenAppDisclaimerInstalled": "{{tokenName}} is an {{tokenType}} token using the {{appName}} app. To manage {{tokenName}}, <1>open the {{appName}} app</1> and send the tokens <3>to your {{appName}} account</3>",


### PR DESCRIPTION
Manager v2 polish
* search tokens placeholder polish  on already installed wording and parent app icon
* progress bar glitch when several apps queued fixed
* quit manager modal actions inverted same as mobile

![localhost_8080_webpack_index html](https://user-images.githubusercontent.com/11752937/75348242-ba31e600-58a2-11ea-99ff-62a06b3e0b29.png)

![localhost_8080_webpack_index html](https://user-images.githubusercontent.com/11752937/75353788-3d0b6e80-58ac-11ea-9ccb-9008c060fdd4.png)


### Type

Bug Fix,  UI Polish

### Context
Manager v2

### Parts of the app affected / Test plan

Manager v2
