### PR TITLE
Use white as text color for blue buttons on dark themes

### DIFF
--- a/src/renderer/components/StepperNumber.js
+++ b/src/renderer/components/StepperNumber.js
@@ -26,7 +26,7 @@ const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({
 
 const Btn = styled(Box).attrs(p => ({
   bg: p.disabled ? "rgba(100, 144, 241, 0.5)" : "wallet",
-  color: "palette.background.paper",
+  color: "white",
   alignItems: "center",
   justifyContent: "center",
 }))`

--- a/src/renderer/screens/manager/AppsList/UpdateAllApps.js
+++ b/src/renderer/screens/manager/AppsList/UpdateAllApps.js
@@ -40,7 +40,7 @@ const UpdatableHeader = styled.div`
 const Badge = styled(Text)`
   border-radius: 29px;
   background-color: ${p => p.theme.colors.palette.primary.main};
-  color: ${p => p.theme.colors.palette.background.paper};
+  color: ${p => p.color || p.theme.colors.palette.background.paper};
   height: 18px;
   display: flex;
   align-items: center;
@@ -123,7 +123,7 @@ const UpdateAllApps = ({ update, state, dispatch, isIncomplete, progress }: Prop
         <Text ff="Inter|SemiBold" fontSize={4} color="palette.primary.main">
           <Trans i18nKey="manager.applist.updatable.title" />
         </Text>
-        <Badge ff="Inter|Bold" fontSize={3} color="palette.text.shade100">
+        <Badge ff="Inter|Bold" fontSize={3} color="white">
           {update.length}
         </Badge>
         <Box flex={1} />


### PR DESCRIPTION
Dark themes should still use white for the text color on wallet blue buttons/CTAs.
This addresses the updates pill and the +- buttons for the currency number of confirmations in settings.

### Type

UI Polish

### Context

https://docs.google.com/spreadsheets/d/1IsuT6FQNaLrVZa_dViiTKp5NL1_lpqe8U9gM2s9k2Ns/edit#gid=228270868&range=A143
https://docs.google.com/spreadsheets/d/1IsuT6FQNaLrVZa_dViiTKp5NL1_lpqe8U9gM2s9k2Ns/edit#gid=228270868&range=A104

### Before
![image](https://user-images.githubusercontent.com/4631227/75354401-35989500-58ad-11ea-9e01-a55c5693aa88.png)

### After
![image](https://user-images.githubusercontent.com/4631227/75354327-1437a900-58ad-11ea-982a-ba504cf3825f.png)
![image](https://user-images.githubusercontent.com/4631227/75354488-53fe9080-58ad-11ea-81a2-258860622b1c.png)

