### PR TITLE
Remove clip-path from CryptoCurrencyIconWithCount

### DIFF
--- a/src/renderer/components/CryptoCurrencyIconWithCount.js
+++ b/src/renderer/components/CryptoCurrencyIconWithCount.js
@@ -25,11 +25,7 @@ const Wrapper: ThemedComponent<{
   ${p =>
     p.doubleIcon
       ? `
-  margin-right: -12px;
-
-  > :nth-child(1) {
-    clip-path: polygon(0% 0%, 100% 0%, 100% 50%, 81% 50%, 68% 54%, 58% 63%, 52% 74%, 50% 86%, 50% 100%, 0% 100%);
-  }`
+  margin-right: -12px;`
       : `
   display: flex;
   align-items: center;`}
@@ -38,7 +34,7 @@ const Wrapper: ThemedComponent<{
   font-size: ${p => (p.bigger ? "12px" : "12px")};
 
   > :nth-child(2) {
-    margin-top: ${p => (p.bigger ? "-10px" : "-8px")};
+    margin-top: ${p => (p.bigger ? "-14px" : "-12px")};
     margin-left: ${p => (p.bigger ? "10px" : "8px")};
 
     border: 2px solid transparent;


### PR DESCRIPTION
Same UI bug that was fixed on other parts like the token icon, this one is for when adding accounts and exporting operations. There are two versions with different sizes so to test this we need to add an accounts with tokens and also try to export their operations.

### Type

UI Polish

It should **not** look like this
![image](https://user-images.githubusercontent.com/4631227/75363951-2fa9b080-58bb-11ea-893b-963300be4a2b.png)

It **should** look something like this, note that since we are removing the `clip-path` thing the Ethereum icon looks whole and not clipped.
![image](https://user-images.githubusercontent.com/4631227/75364098-6f709800-58bb-11ea-8bba-ebe7f944da86.png)

