### PR TITLE
LL-1118 Use user password to encrypt libcore db

### DIFF
--- a/src/internal/implement-libcore.js
+++ b/src/internal/implement-libcore.js
@@ -3,6 +3,10 @@ import invariant from "invariant";
 import implementLibcore from "@ledgerhq/live-common/lib/libcore/platforms/nodejs";
 import { withLibcore } from "@ledgerhq/live-common/lib/libcore/access";
 
+export const changePassword = async (currentPassword: string, newPassword: string) => {
+  withLibcore(async core => core.getPoolInstance().changePassword(currentPassword, newPassword));
+};
+
 export default async (dbPassword: string) => {
   const dbPath = process.env.LEDGER_LIVE_SQLITE_PATH;
   invariant(dbPath, "process.env.LEDGER_LIVE_SQLITE_PATH required");

--- a/src/internal/implement-libcore.js
+++ b/src/internal/implement-libcore.js
@@ -1,11 +1,23 @@
 // @flow
 import invariant from "invariant";
 import implementLibcore from "@ledgerhq/live-common/lib/libcore/platforms/nodejs";
+import { withLibcore } from "@ledgerhq/live-common/lib/libcore/access";
 
-const dbPath = process.env.LEDGER_LIVE_SQLITE_PATH;
-invariant(dbPath, "process.env.LEDGER_LIVE_SQLITE_PATH required");
+export default async (dbPassword: string) => {
+  const dbPath = process.env.LEDGER_LIVE_SQLITE_PATH;
+  invariant(dbPath, "process.env.LEDGER_LIVE_SQLITE_PATH required");
 
-implementLibcore({
-  lib: require("@ledgerhq/ledger-core"),
-  dbPath,
-});
+  implementLibcore({
+    lib: require("@ledgerhq/ledger-core"),
+    dbPath,
+    dbPassword,
+  });
+
+  console.log("----------------------");
+  console.log(`Libcore init with password: "${dbPassword}"`);
+  console.log("----------------------");
+
+  await withLibcore(async core => core.getPoolInstance().getName());
+  invariant(process.send, "Internal has no IPC channel! (process.send is missing)");
+  process.send({ type: "libcoreInitialized" });
+};

--- a/src/internal/implement-libcore.js
+++ b/src/internal/implement-libcore.js
@@ -13,11 +13,10 @@ export default async (dbPassword: string) => {
     dbPassword,
   });
 
-  console.log("----------------------");
-  console.log(`Libcore init with password: "${dbPassword}"`);
-  console.log("----------------------");
-
+  // The following line will consistently crash if the password is wrong.
+  // We rather crash now and know right away libcore is unusable (until the correct password is set)
   await withLibcore(async core => core.getPoolInstance().getName());
+
   invariant(process.send, "Internal has no IPC channel! (process.send is missing)");
-  process.send({ type: "libcoreInitialized" });
+  process.send({ type: "libcoreInitialized" }); // We didn't crash 🎉
 };

--- a/src/internal/index.js
+++ b/src/internal/index.js
@@ -8,6 +8,7 @@ import { getCryptoCurrencyById } from "@ledgerhq/live-common/lib/currencies";
 import { log } from "@ledgerhq/logs";
 import logger from "~/logger";
 import LoggerTransport from "~/logger/logger-transport-internal";
+import implementLibcore from "./implement-libcore";
 
 import { executeCommand, unsubscribeCommand, unsubscribeAllCommands } from "./commandHandler";
 
@@ -101,6 +102,12 @@ process.on("message", m => {
     case "setEnv": {
       const { name, value } = m.env;
       setEnvUnsafe(name, value);
+      break;
+    }
+
+    case "initLibcore": {
+      const { password } = m;
+      implementLibcore(password);
       break;
     }
 

--- a/src/internal/index.js
+++ b/src/internal/index.js
@@ -8,7 +8,7 @@ import { getCryptoCurrencyById } from "@ledgerhq/live-common/lib/currencies";
 import { log } from "@ledgerhq/logs";
 import logger from "~/logger";
 import LoggerTransport from "~/logger/logger-transport-internal";
-import implementLibcore from "./implement-libcore";
+import implementLibcore, { changePassword } from "./implement-libcore";
 
 import { executeCommand, unsubscribeCommand, unsubscribeAllCommands } from "./commandHandler";
 
@@ -108,6 +108,12 @@ process.on("message", m => {
     case "initLibcore": {
       const { password } = m;
       implementLibcore(password);
+      break;
+    }
+
+    case "changeLibcorePassword": {
+      const { currentPassword, newPassword } = m;
+      changePassword(currentPassword, newPassword);
       break;
     }
 

--- a/src/internal/index.js
+++ b/src/internal/index.js
@@ -112,7 +112,7 @@ process.on("message", m => {
     }
 
     default:
-      log("error", `internal thread: '${m.type}' event not supported`);
+      log("internal-message", `'${m.type}' event not supported`);
   }
 });
 

--- a/src/internal/live-common-setup.js
+++ b/src/internal/live-common-setup.js
@@ -1,6 +1,6 @@
 // @flow
 import "~/live-common-setup";
-import "./implement-libcore";
+// import "./implement-libcore";
 
 import { throwError } from "rxjs";
 import usbDetect from "usb-detection";

--- a/src/internal/live-common-setup.js
+++ b/src/internal/live-common-setup.js
@@ -1,6 +1,5 @@
 // @flow
 import "~/live-common-setup";
-// import "./implement-libcore";
 
 import { throwError } from "rxjs";
 import usbDetect from "usb-detection";

--- a/src/main/InternalProcess.js
+++ b/src/main/InternalProcess.js
@@ -89,6 +89,23 @@ class InternalProcess {
     }
   }
 
+  changePassword(newPassword: string) {
+    logger.info("Changing Libcore password", logType);
+
+    if (!this.libcoreInitialized) {
+      throw new Error("Can't change password if libcore is not unlocked first!");
+    }
+
+    this.process &&
+      this.process.send({
+        type: "changeLibcorePassword",
+        currentPassword: this.password,
+        newPassword,
+      });
+
+    this.password = newPassword;
+  }
+
   start() {
     logger.info("Started internal process", logType);
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -3,7 +3,7 @@ import "./setup";
 import { app, Menu, ipcMain } from "electron";
 import menu from "./menu";
 import { createMainWindow, getMainWindow, loadWindow } from "./window-lifecycle";
-import "./internal-lifecycle";
+import internal from "./internal-lifecycle";
 import resolveUserDataDirectory from "~/helpers/resolveUserDataDirectory";
 import db from "./db";
 import debounce from "lodash/debounce";
@@ -53,7 +53,15 @@ app.on("ready", async () => {
     return db.hasEncryptionKey(ns, keyPath);
   });
 
-  ipcMain.handle("setEncryptionKey", (event, { ns, keyPath, encryptionKey }) => {
+  ipcMain.handle("setEncryptionKey", async (event, { ns, keyPath, encryptionKey }) => {
+    console.log("encryptionKey", encryptionKey);
+    try {
+      await internal.setPassword(encryptionKey);
+      console.log("setPassword success");
+    } catch (error) {
+      console.log("--- set password failed ---");
+      console.log(error);
+    }
     return db.setEncryptionKey(ns, keyPath, encryptionKey);
   });
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -53,15 +53,7 @@ app.on("ready", async () => {
     return db.hasEncryptionKey(ns, keyPath);
   });
 
-  ipcMain.handle("setEncryptionKey", async (event, { ns, keyPath, encryptionKey }) => {
-    console.log("encryptionKey", encryptionKey);
-    try {
-      await internal.setPassword(encryptionKey);
-      console.log("setPassword success");
-    } catch (error) {
-      console.log("--- set password failed ---");
-      console.log(error);
-    }
+  ipcMain.handle("setEncryptionKey", (event, { ns, keyPath, encryptionKey }) => {
     return db.setEncryptionKey(ns, keyPath, encryptionKey);
   });
 
@@ -92,6 +84,17 @@ app.on("ready", async () => {
   ipcMain.handle("reloadRenderer", () => {
     console.log("reloading renderer ...");
     loadWindow();
+  });
+
+  ipcMain.handle("setLibcorePassword", async (event, { password }) => {
+    try {
+      await internal.setPassword(password);
+      if (!internal.process) {
+        await internal.start();
+      }
+    } catch (e) {
+      throw new Error("wrong password");
+    }
   });
 
   Menu.setApplicationMenu(menu);

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -97,6 +97,10 @@ app.on("ready", async () => {
     }
   });
 
+  ipcMain.handle("changeLibcorePassword", async (event, { password }) =>
+    internal.changePassword(password),
+  );
+
   Menu.setApplicationMenu(menu);
 
   const windowParams = await db.getKey("windowParams", "MainWindow", {});

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -93,7 +93,9 @@ app.on("ready", async () => {
         await internal.start();
       }
     } catch (e) {
-      throw new Error("wrong password");
+      // If we don't catch here then throw ourself, the error is not sent to renderer
+      // Also `error` is always undefined, so let's throw something more useful
+      throw new Error("setLibcorePasswordFailed");
     }
   });
 

--- a/src/renderer/components/IsUnlocked.js
+++ b/src/renderer/components/IsUnlocked.js
@@ -96,11 +96,19 @@ const IsUnlocked = ({ children }: Props) => {
           try {
             // The password worked for db, it should be the same for libcore
             await setLibcorePassword(inputValue.password);
-          } catch (e) {
-            // db password didn't work for libcore, this shouldn't happen
-            // let's wipe libcore database and start again
-            await removeSQLite();
-            await setLibcorePassword(inputValue.password);
+          } catch (error) {
+            if (
+              error &&
+              error.message &&
+              error.message.indexOf("setLibcorePasswordFailed") !== -1
+            ) {
+              // db password didn't work for libcore, this shouldn't happen
+              // let's wipe libcore database and start again
+              await removeSQLite();
+              await setLibcorePassword(inputValue.password);
+            } else {
+              throw error;
+            }
           }
           await dispatch(fetchAccounts());
         } else if (!(await isEncryptionKeyCorrect("app", "accounts", inputValue.password))) {

--- a/src/renderer/components/IsUnlocked.js
+++ b/src/renderer/components/IsUnlocked.js
@@ -1,11 +1,12 @@
 // @flow
-import { ipcRenderer } from "electron";
+
 import React, { useCallback, useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import { PasswordIncorrectError } from "@ledgerhq/errors";
 import { setEncryptionKey, isEncryptionKeyCorrect, hasBeenDecrypted } from "~/renderer/storage";
+import { setLibcorePassword } from "~/renderer/libcoreEncryption";
 
 import IconTriangleWarning from "~/renderer/icons/TriangleWarning";
 
@@ -48,9 +49,6 @@ export const LockScreenDesc: ThemedComponent<{}> = styled(Box).attrs(() => ({
 }))`
   margin: 10px auto 25px;
 `;
-
-const setLibcorePassword = (password: string) =>
-  ipcRenderer.invoke("setLibcorePassword", { password });
 
 const IconWrapperCircle = styled(Box)`
   width: 50px;

--- a/src/renderer/libcoreEncryption.js
+++ b/src/renderer/libcoreEncryption.js
@@ -1,0 +1,9 @@
+// @flow
+
+import { ipcRenderer } from "electron";
+
+export const setLibcorePassword = (password: string) =>
+  ipcRenderer.invoke("setLibcorePassword", { password });
+
+export const changeLibcorePassword = (password: string) =>
+  ipcRenderer.invoke("changeLibcorePassword", { password });

--- a/src/renderer/modals/DisablePasswordModal/index.js
+++ b/src/renderer/modals/DisablePasswordModal/index.js
@@ -5,6 +5,7 @@ import { useDispatch } from "react-redux";
 import { PasswordIncorrectError } from "@ledgerhq/errors";
 import { useTranslation } from "react-i18next";
 import { setEncryptionKey, removeEncryptionKey, isEncryptionKeyCorrect } from "~/renderer/storage";
+import { changeLibcorePassword } from "~/renderer/libcoreEncryption";
 import { closeModal } from "~/renderer/actions/modals";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -35,9 +36,11 @@ const DisablePasswordModal = () => {
       if (password) {
         dispatch(setHasPassword(true));
         await setEncryptionKey("app", "accounts", password);
+        await changeLibcorePassword(password);
       } else {
         dispatch(setHasPassword(false));
         await removeEncryptionKey("app", "accounts");
+        await changeLibcorePassword("");
       }
     },
     [dispatch],

--- a/src/renderer/modals/PasswordModal/index.js
+++ b/src/renderer/modals/PasswordModal/index.js
@@ -10,6 +10,7 @@ import Button from "~/renderer/components/Button";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
 import PasswordForm from "./PasswordForm";
 import { setEncryptionKey, removeEncryptionKey, isEncryptionKeyCorrect } from "~/renderer/storage";
+import { changeLibcorePassword } from "~/renderer/libcoreEncryption";
 import { hasPasswordSelector } from "~/renderer/reducers/application";
 import { setHasPassword } from "~/renderer/actions/application";
 
@@ -34,9 +35,11 @@ const PasswordModal = () => {
       if (password) {
         dispatch(setHasPassword(true));
         await setEncryptionKey("app", "accounts", password);
+        await changeLibcorePassword(password);
       } else {
         dispatch(setHasPassword(false));
         await removeEncryptionKey("app", "accounts");
+        await changeLibcorePassword("");
       }
     },
     [dispatch],

--- a/src/renderer/reset.js
+++ b/src/renderer/reset.js
@@ -8,6 +8,7 @@ import rimraf from "rimraf";
 import resolveUserDataDirectory from "~/helpers/resolveUserDataDirectory";
 import { delay } from "@ledgerhq/live-common/lib/promise";
 import { resetAll, cleanCache } from "~/renderer/storage";
+import { setLibcorePassword } from "~/renderer/libcoreEncryption";
 import { disable as disableDBMiddleware } from "./middlewares/db";
 import { clearBridgeCache } from "./bridge/cache";
 
@@ -60,6 +61,7 @@ export async function hardReset() {
   resetAll();
   window.localStorage.clear();
   await delay(500);
+  await setLibcorePassword("");
   await resetLibcore();
   log("clear-cache", "reload()");
   reload();

--- a/src/renderer/reset.js
+++ b/src/renderer/reset.js
@@ -23,7 +23,7 @@ export async function killInternalProcess() {
   return delay(1000);
 }
 
-const removeSQLite = () =>
+export const removeSQLite: () => Promise<any> = () =>
   new Promise((resolve, reject) =>
     rimraf(path.resolve(resolveUserDataDirectory(), "sqlite/"), e => {
       if (e) reject(e);


### PR DESCRIPTION
Done by extending our brand new `InternalProcess` singleton to keep track of the state of libcore and feed it the password when needed.

- [x] Encrypt an unencrypted db
- [x] Work with an encrypted db with the user provided password
- [x] Remove password encryption (decrypt db)
- [x] Change encryption password
- [x] Fallback for the case the app password doesn't match libcore one, by dropping libcore db and start a new one encrypted with the app password.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1118
(reimplementation of #2142)

### Parts of the app affected

- Setting/changing a password: it now additionally affects libcore.
- Unlocking the app: it now also send the password to libcore for decryption.

#### Test plan

- Setting a password in the app should encrypt libcore db
- Disabling password should decrypt libcore db
- Changing the password should also be reflected in libcore db
- Unlocking the app should also unlock libcore
- Updating from an older version of Ledger Live with a password should encrypt libcore db with the password on first unlock

To check the current status of the libcore db encryption, just open the sqlite file with [DB Browser for SQLite](https://sqlitebrowser.org/), and use the defaults encryption settings (SQLCipher 4 defaults)
