### PR TITLE
fixed visual glitch on breadcrumb

### DIFF
--- a/src/renderer/components/Stepper/Breadcrumb.js
+++ b/src/renderer/components/Stepper/Breadcrumb.js
@@ -31,6 +31,7 @@ const Bar: ThemedComponent<{
   height: 1px;
   left: ${p => p.start}%;
   position: absolute;
+  overflow: hidden;
   right: ${p => p.end}%;
   top: 8px;
   z-index: 1;


### PR DESCRIPTION
Repro: Receive flow => I don't have my device => Breadcrumb stepper has a visual glitch as described here: https://docs.google.com/spreadsheets/d/1IsuT6FQNaLrVZa_dViiTKp5NL1_lpqe8U9gM2s9k2Ns/edit#gid=228270868&range=A1