### PR TITLE
(ManagerV2): fixed update version text + warning on fadeInOutBox

### DIFF
--- a/src/renderer/components/FadeInOutBox.js
+++ b/src/renderer/components/FadeInOutBox.js
@@ -28,10 +28,16 @@ type Props = {
   ...
 };
 
-const UpdateAllApps = ({ timing = 400, unmountOnExit = true, children, ...rest }: Props) => {
+const UpdateAllApps = ({
+  timing = 400,
+  unmountOnExit = true,
+  children,
+  in: _in,
+  ...rest
+}: Props) => {
   return (
     <Transition
-      in={rest.in}
+      in={_in}
       unmountOnExit
       timeout={{
         appear: 0,

--- a/src/renderer/screens/manager/AppsList/Item.js
+++ b/src/renderer/screens/manager/AppsList/Item.js
@@ -27,8 +27,10 @@ const AppRow = styled.div`
 `;
 
 const AppName = styled.div`
+  flex: 1;
   flex-direction: column;
   padding-left: 15px;
+  max-height: 40px;
   & > * {
     display: block;
   }
@@ -98,14 +100,9 @@ const Item: React$ComponentType<Props> = ({
           }`}</Text>
           <Text ff="Inter|Regular" color="palette.text.shade60" fontSize={3}>
             <Trans
-              i18nKey={
-                installed && !installed.updated
-                  ? "manager.applist.item.versionNew"
-                  : "manager.applist.item.version"
-              }
+              i18nKey="manager.applist.item.version"
               values={{
-                version,
-                newVersion: newVersion && newVersion !== version ? ` ${newVersion}` : null,
+                version: onlyUpdate && newVersion && newVersion !== version ? newVersion : version,
               }}
             />
           </Text>
@@ -120,7 +117,7 @@ const Item: React$ComponentType<Props> = ({
       <Box flex="0.6" horizontal alignContent="center" justifyContent="center">
         {isLiveSupported && (
           <>
-            <Box mr={2}>
+            <Box pr={2}>
               <IconCheckFull size={16} />
             </Box>
             <Text ml={1} ff="Inter|Regular" color="palette.text.shade60" fontSize={3}>

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -401,7 +401,6 @@
       },
       "item": {
         "version": "Version {{version}}",
-        "versionNew": "Version {{version}} (NEW{{newVersion}})",
         "installing": "Installing...",
         "uninstalling": "Uninstalling...",
         "updating": "Updating...",


### PR DESCRIPTION
Managerv2 
wording issue on update version label 
now the new version shows on the update list and the device version on the catalog and installed list

![localhost_8080_webpack_index html](https://user-images.githubusercontent.com/11752937/75425123-5d860800-5942-11ea-9094-9027a312fa46.png)


### Type

UI Polish

### Context

Manager v2

### Parts of the app affected / Test plan

Try install an app that can pdate or switch provider to trigger the update list showing
