### PR TITLE
going back to ledger-live-desktop repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Ledger Live - Desktop",
   "version": "1.106.0",
   "author": "Ledger Live Team <team-live@ledger.fr>",
-  "repository": "https://github.com/LedgerHQ/lld-v2",
+  "repository": "https://github.com/LedgerHQ/ledger-live-desktop",
   "license": "MIT",
   "private": true,
   "main": "./.webpack/main.bundle.js",


### PR DESCRIPTION
do not merge until we are good for a v2 (we'll probably do a last 1.107.0 before that)

is https://github.com/LedgerHQ/ledger-live-desktop/commit/811fa557107d3db8aa04eb2a23fc7938f0e98987 the only change we need to get this v2 in prod?