### PR TITLE
(ManagerV2): learn more link supportURL

### DIFF
--- a/src/renderer/screens/manager/AppsList/AppActions.js
+++ b/src/renderer/screens/manager/AppsList/AppActions.js
@@ -84,7 +84,7 @@ const AppActions: React$ComponentType<Props> = React.memo(
     isLiveSupported,
     addAccount,
   }: Props) => {
-    const { name } = app;
+    const { name, supportURL } = app;
     const { installedAvailable, installQueue, uninstallQueue, updateAllQueue } = state;
 
     const needsInstallDeps = useAppInstallNeedsDeps(state, app);
@@ -106,8 +106,8 @@ const AppActions: React$ComponentType<Props> = React.memo(
     }, [addAccount]);
 
     const onSupportLink = useCallback(() => {
-      openURL(urls.appSupport);
-    }, []);
+      openURL(supportURL || urls.appSupport);
+    }, [supportURL]);
 
     const updating = useMemo(() => updateAllQueue.includes(name), [updateAllQueue, name]);
     const installing = useMemo(() => installQueue.includes(name), [installQueue, name]);


### PR DESCRIPTION
ManagerV2

learn more link when we have an installed and not live supported app now links to the app.suppportURL provided by our API and fallback to the regular support apps page.

### Type

UI Polish

### Context

Manager v2

### Parts of the app affected / Test plan

Once the support URL field is filled we can test it but this should work out of the box without any problem.
