### PR TITLE
reverted renderer process reuse to false

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -8,7 +8,7 @@ import resolveUserDataDirectory from "~/helpers/resolveUserDataDirectory";
 import db from "./db";
 import debounce from "lodash/debounce";
 
-app.allowRendererProcessReuse = true;
+app.allowRendererProcessReuse = false;
 
 const gotLock = app.requestSingleInstanceLock();
 const userDataDirectory = resolveUserDataDirectory();


### PR DESCRIPTION
Electron's allowRendererProcessReuse flag got its default value (false) deprecated in the V8. Turning it to true seems to change a lot of low level behaviors. As it doesn't really benefit us at the moment, I propose we turn it false (that will get rid of the deprecation warnings) and reconsider turning it on after the release.