### PR TITLE
Fix: The date on the tooltip on the price chart is one day off

### DIFF
--- a/src/renderer/components/Chart2/index.js
+++ b/src/renderer/components/Chart2/index.js
@@ -37,6 +37,7 @@ import React, { useRef, useLayoutEffect, useState, useMemo } from "react";
 import ChartJs from "chart.js";
 import styled from "styled-components";
 import Color from "color";
+import moment from "moment";
 
 import useTheme from "~/renderer/hooks/useTheme";
 import Tooltip from "./Tooltip";
@@ -67,7 +68,15 @@ const ChartContainer: ThemedComponent<{}> = styled.div.attrs(({ height }) => ({
   position: relative;
 `;
 
-const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "value" }: Props) => {
+const Chart = ({
+  height,
+  data,
+  color,
+  renderTickY,
+  renderTooltip,
+  valueKey = "value",
+  dateFormat = "MMM D",
+}: Props) => {
   const canvasRef = useRef(null);
   const chartRef = useRef(null);
   const theme = useTheme("colors.palette");
@@ -76,6 +85,7 @@ const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "va
 
   const generatedData = useMemo(
     () => ({
+      labels: data.map(d => moment(d.date).format(dateFormat)),
       datasets: [
         {
           label: "all accounts",
@@ -95,7 +105,7 @@ const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "va
         },
       ],
     }),
-    [color, data, valueKey],
+    [color, data, valueKey, dateFormat],
   );
 
   const generateOptions = useMemo(
@@ -115,28 +125,6 @@ const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "va
         display: false,
       },
       scales: {
-        xAxes: [
-          {
-            type: "time",
-            gridLines: {
-              display: false,
-              color: theme.text.shade10,
-            },
-            ticks: {
-              fontColor: theme.text.shade60,
-              fontFamily: "Inter",
-              maxTicksLimit: 7,
-              maxRotation: 0,
-              minRotation: 0,
-            },
-            time: {
-              minUnit: "day",
-              displayFormats: {
-                quarter: "MMM YYYY",
-              },
-            },
-          },
-        ],
         yAxes: [
           {
             gridLines: {

--- a/src/renderer/components/Chart2/index.js
+++ b/src/renderer/components/Chart2/index.js
@@ -37,6 +37,7 @@ import React, { useRef, useLayoutEffect, useState, useMemo } from "react";
 import ChartJs from "chart.js";
 import styled from "styled-components";
 import Color from "color";
+import moment from "moment";
 
 import useTheme from "~/renderer/hooks/useTheme";
 import Tooltip from "./Tooltip";
@@ -97,7 +98,9 @@ const Chart = ({
           pointRadius: 0,
           borderWidth: 2,
           data: data.map(d => ({
-            x: new Date(d.date).toLocaleDateString(),
+            x: moment(new Date(d.date))
+              .startOf("day")
+              .toDate(),
             y: d[valueKey].toNumber(),
           })),
         },

--- a/src/renderer/components/Chart2/index.js
+++ b/src/renderer/components/Chart2/index.js
@@ -52,7 +52,6 @@ export type Props = {
   tickXScale: string,
   color?: string,
   hideAxis?: boolean,
-  dateFormat?: string,
   isInteractive?: boolean,
   renderTooltip?: Function,
   renderTickY: (t: number) => string | number,
@@ -68,15 +67,7 @@ const ChartContainer: ThemedComponent<{}> = styled.div.attrs(({ height }) => ({
   position: relative;
 `;
 
-const Chart = ({
-  height,
-  data,
-  color,
-  renderTickY,
-  renderTooltip,
-  valueKey = "value",
-  dateFormat = "MMM D",
-}: Props) => {
+const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "value" }: Props) => {
   const canvasRef = useRef(null);
   const chartRef = useRef(null);
   const theme = useTheme("colors.palette");

--- a/src/renderer/components/Chart2/index.js
+++ b/src/renderer/components/Chart2/index.js
@@ -37,7 +37,6 @@ import React, { useRef, useLayoutEffect, useState, useMemo } from "react";
 import ChartJs from "chart.js";
 import styled from "styled-components";
 import Color from "color";
-import moment from "moment";
 
 import useTheme from "~/renderer/hooks/useTheme";
 import Tooltip from "./Tooltip";
@@ -85,7 +84,6 @@ const Chart = ({
 
   const generatedData = useMemo(
     () => ({
-      labels: data.map(d => moment(d.date).format(dateFormat)),
       datasets: [
         {
           label: "all accounts",
@@ -99,13 +97,13 @@ const Chart = ({
           pointRadius: 0,
           borderWidth: 2,
           data: data.map(d => ({
-            x: new Date(d.date),
+            x: new Date(d.date).toLocaleDateString(),
             y: d[valueKey].toNumber(),
           })),
         },
       ],
     }),
-    [color, data, valueKey, dateFormat],
+    [color, data, valueKey],
   );
 
   const generateOptions = useMemo(
@@ -125,6 +123,28 @@ const Chart = ({
         display: false,
       },
       scales: {
+        xAxes: [
+          {
+            type: "time",
+            gridLines: {
+              display: false,
+              color: theme.text.shade10,
+            },
+            ticks: {
+              fontColor: theme.text.shade60,
+              fontFamily: "Inter",
+              maxTicksLimit: 7,
+              maxRotation: 0,
+              minRotation: 0,
+            },
+            time: {
+              minUnit: "day",
+              displayFormats: {
+                quarter: "MMM YYYY",
+              },
+            },
+          },
+        ],
         yAxes: [
           {
             gridLines: {


### PR DESCRIPTION
### Outcome

<img width="1552" alt="Screen Shot 2020-02-27 at 12 04 46 PM" src="https://user-images.githubusercontent.com/8398372/75439049-5e766400-5959-11ea-875c-d8a134d2bf68.png">
