### PR TITLE
(Managerv2): updated completion label

### DIFF
--- a/src/renderer/screens/manager/AppsList/AppActions.js
+++ b/src/renderer/screens/manager/AppsList/AppActions.js
@@ -43,6 +43,7 @@ const SuccessInstall = styled.div`
   color: ${p => p.theme.colors.positiveGreen};
   display: flex;
   flex-direction: row;
+  align-items: center;
   padding: 10px 20px;
   > svg {
     padding-right: 5px;
@@ -128,129 +129,136 @@ const AppActions: React$ComponentType<Props> = React.memo(
             uninstalling={uninstalling}
             progress={progress}
           />
-        ) : (
-          showActions && (
-            <>
-              {installed ? (
-                isLiveSupported ? (
-                  <Tooltip
-                    content={
-                      canAddAccount ? (
-                        <Trans
-                          i18nKey="manager.applist.item.addAccountTooltip"
-                          values={{ appName: name }}
-                        />
-                      ) : (
-                        <Trans i18nKey="manager.applist.item.addAccountWarn" />
-                      )
-                    }
-                  >
-                    <Button
-                      color={canAddAccount ? "palette.primary.main" : "palette.text.shade40"}
-                      inverted
-                      style={{ display: "flex", backgroundColor: "rgba(0,0,0,0)" }}
-                      fontSize={3}
-                      disabled={!canAddAccount}
-                      onClick={onAddAccount}
-                      event="Manager AddAccount Click"
-                      eventProperties={{
-                        appName: name,
-                        appVersion: app.version,
-                      }}
-                    >
-                      <AccountAdd size={16} />
-                      <Text style={{ marginLeft: 8 }}>
-                        <Trans i18nKey="manager.applist.item.addAccount" />
-                      </Text>
-                    </Button>
-                  </Tooltip>
-                ) : (
-                  <Tooltip
-                    content={
-                      <Trans
-                        i18nKey="manager.applist.item.learnMoreTooltip"
-                        values={{ appName: name }}
-                      />
-                    }
-                  >
-                    <Button
-                      inverted
-                      style={{ display: "flex" }}
-                      fontSize={3}
-                      onClick={onSupportLink}
-                      event="Manager SupportLink Click"
-                      eventProperties={{
-                        appName: name,
-                        appVersion: app.version,
-                      }}
-                    >
-                      <LinkIcon size={16} />
-                      <Text ff="Inter" style={{ marginLeft: 8 }}>
-                        <Trans i18nKey="manager.applist.item.learnMore" />
-                      </Text>
-                    </Button>
-                  </Tooltip>
-                )
-              ) : null}
-              {appStoreView && installed && (
-                <SuccessInstall>
-                  <IconCheck size={16} />
-                  <Text ff="Inter|SemiBold" fontSize={4}>
-                    <Trans i18nKey="manager.applist.item.installed" />
-                  </Text>
-                </SuccessInstall>
-              )}
-
-              {!installed && (
+        ) : showActions ? (
+          <>
+            {installed ? (
+              isLiveSupported ? (
                 <Tooltip
                   content={
-                    notEnoughMemoryToInstall ? (
-                      <Trans i18nKey="manager.applist.item.notEnoughSpace" />
-                    ) : null
+                    canAddAccount ? (
+                      <Trans
+                        i18nKey="manager.applist.item.addAccountTooltip"
+                        values={{ appName: name }}
+                      />
+                    ) : (
+                      <Trans i18nKey="manager.applist.item.addAccountWarn" />
+                    )
                   }
                 >
                   <Button
-                    style={{ display: "flex" }}
-                    lighterPrimary
-                    disabled={notEnoughMemoryToInstall}
-                    onClick={onInstall}
-                    event="Manager Install Click"
+                    color={canAddAccount ? "palette.primary.main" : "palette.text.shade40"}
+                    inverted
+                    style={{ display: "flex", backgroundColor: "rgba(0,0,0,0)" }}
+                    fontSize={3}
+                    disabled={!canAddAccount}
+                    onClick={onAddAccount}
+                    event="Manager AddAccount Click"
                     eventProperties={{
                       appName: name,
                       appVersion: app.version,
                     }}
                   >
-                    <IconArrowDown size={14} />
+                    <AccountAdd size={16} />
                     <Text style={{ marginLeft: 8 }}>
-                      <Trans i18nKey="manager.applist.item.install" />
+                      <Trans i18nKey="manager.applist.item.addAccount" />
                     </Text>
                   </Button>
                 </Tooltip>
-              )}
-              {(((installed || !installedAvailable) && !appStoreView && !onlyUpdate) ||
-                forceUninstall) && (
+              ) : (
                 <Tooltip
                   content={
                     <Trans
-                      i18nKey="manager.applist.item.removeTooltip"
+                      i18nKey="manager.applist.item.learnMoreTooltip"
                       values={{ appName: name }}
                     />
                   }
                 >
                   <Button
-                    style={{ padding: 13 }}
-                    onClick={onUninstall}
-                    event="Manager Uninstall Click"
+                    inverted
+                    style={{ display: "flex" }}
+                    fontSize={3}
+                    onClick={onSupportLink}
+                    event="Manager SupportLink Click"
                     eventProperties={{
                       appName: name,
                       appVersion: app.version,
                     }}
                   >
-                    <IconTrash color={colors.grey} size={14} />
+                    <LinkIcon size={16} />
+                    <Text ff="Inter" style={{ marginLeft: 8 }}>
+                      <Trans i18nKey="manager.applist.item.learnMore" />
+                    </Text>
                   </Button>
                 </Tooltip>
-              )}
-            </>
+              )
+            ) : null}
+            {appStoreView && installed && (
+              <SuccessInstall>
+                <IconCheck size={16} />
+                <Text ff="Inter|SemiBold" fontSize={4}>
+                  <Trans i18nKey="manager.applist.item.installed" />
+                </Text>
+              </SuccessInstall>
+            )}
+
+            {!installed && (
+              <Tooltip
+                content={
+                  notEnoughMemoryToInstall ? (
+                    <Trans i18nKey="manager.applist.item.notEnoughSpace" />
+                  ) : null
+                }
+              >
+                <Button
+                  style={{ display: "flex" }}
+                  lighterPrimary
+                  disabled={notEnoughMemoryToInstall}
+                  onClick={onInstall}
+                  event="Manager Install Click"
+                  eventProperties={{
+                    appName: name,
+                    appVersion: app.version,
+                  }}
+                >
+                  <IconArrowDown size={14} />
+                  <Text style={{ marginLeft: 8 }}>
+                    <Trans i18nKey="manager.applist.item.install" />
+                  </Text>
+                </Button>
+              </Tooltip>
+            )}
+            {(((installed || !installedAvailable) && !appStoreView && !onlyUpdate) ||
+              forceUninstall) && (
+              <Tooltip
+                content={
+                  <Trans i18nKey="manager.applist.item.removeTooltip" values={{ appName: name }} />
+                }
+              >
+                <Button
+                  style={{ padding: 13 }}
+                  onClick={onUninstall}
+                  event="Manager Uninstall Click"
+                  eventProperties={{
+                    appName: name,
+                    appVersion: app.version,
+                  }}
+                >
+                  <IconTrash color={colors.grey} size={14} />
+                </Button>
+              </Tooltip>
+            )}
+          </>
+        ) : (
+          onlyUpdate &&
+          updating &&
+          !uninstalling &&
+          installed && (
+            <SuccessInstall>
+              <IconCheck size={16} />
+              <Text ff="Inter|SemiBold" fontSize={4}>
+                <Trans i18nKey="manager.applist.item.updated" />
+              </Text>
+            </SuccessInstall>
           )
         )}
       </AppActionsWrapper>

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -411,6 +411,7 @@
         "updateAllOutOfMemory": "Not enough storage to update, please uninstall some apps",
         "install": "Install",
         "installed": "Installed",
+        "updated": "Updated",
         "uninstall": "Uninstall",
         "notEnoughSpace": "Not enough storage",
         "supported": "Ledger Live supported",


### PR DESCRIPTION
Manager v2

After a completed update the update list now shows an updated label

![localhost_8080_webpack_index html](https://user-images.githubusercontent.com/11752937/75464989-4bc75380-5988-11ea-8bb3-d932c5e5dae7.png)

### Type

UI Polish

### Parts of the app affected / Test plan

After a series of updates you should see a updated label on the succesfully updated apps

Make sure this label only shows in that case.
