### PR TITLE
[Mac] Fix notarization failing for Apple IDs with more than 1 provider

### DIFF
--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -32,6 +32,7 @@ async function notarizeApp(context) {
   await notarize({
     appBundleId: "com.ledger.live",
     appPath: path,
+    ascProvider: "EpicDreamSAS",
     appleId: APPLEID,
     appleIdPassword: APPLEID_PASSWORD,
   });


### PR DESCRIPTION
As pointed out by @valpinkman, `yarn release` will fail on Mac at the notarization part if the Apple ID used is a member of multiple teams or organizations.

This fix that by hardcoding the provider to use Ledger's one (which, for historical reasons, has `EpicDreamSAS` as a shortname. It's _totally_ not a hack attempt on my part, promise 😇)

### Type

Bug Fix

### Parts of the app affected / Test plan

Doing in a release.
On Valentin's Mac.
