### PR TITLE
(Managerv2): add account banner pixel polish

### DIFF
--- a/src/renderer/screens/manager/AppsList/InstallSuccessBanner.js
+++ b/src/renderer/screens/manager/AppsList/InstallSuccessBanner.js
@@ -99,7 +99,7 @@ const InstallSuccessBanner = ({ state, isIncomplete, dispatch, addAccount, disab
   return (
     <Container ref={cardRef}>
       <FadeInOutBox in={visible} timing={800} color="palette.primary.contrastText">
-        <Box horizontal pt={1} overflow="hidden">
+        <Box horizontal pt={2} overflow="hidden">
           <Box
             borderRadius={1}
             flex="1"


### PR DESCRIPTION
Issue on add accounts banner on Manager v2 needed some extra padding top

before:
![image (1)](https://user-images.githubusercontent.com/11752937/75467239-a910d400-598b-11ea-9549-16e1232700ca.png)


after:
![localhost_8080_webpack_index html](https://user-images.githubusercontent.com/11752937/75467133-87175180-598b-11ea-86ac-3725bb46ccef.png)


### Type

UI Polish

### Context

Manager v2
