### PR TITLE
(DeviceAction): disconnect glitch after opening app

### DIFF
--- a/src/renderer/components/DeviceAction/actions/app.js
+++ b/src/renderer/components/DeviceAction/actions/app.js
@@ -195,6 +195,10 @@ const useHook = (device: ?Device, appRequest: AppRequest): AppState => {
             // no debounce for allow event
             return empty();
           }
+          if (!s.device) {
+            // extra debounce for the disconnect event
+            return interval(2000);
+          }
           // default debounce (to be tweak)
           return interval(1500);
         }),

--- a/src/renderer/components/DeviceAction/actions/app.js
+++ b/src/renderer/components/DeviceAction/actions/app.js
@@ -195,12 +195,8 @@ const useHook = (device: ?Device, appRequest: AppRequest): AppState => {
             // no debounce for allow event
             return empty();
           }
-          if (!s.device) {
-            // extra debounce for the disconnect event
-            return interval(2000);
-          }
           // default debounce (to be tweak)
-          return interval(1500);
+          return interval(2000);
         }),
       )
       // the state simply goes into a React state


### PR DESCRIPTION
**DeviceAction**

Added .5s extra debounce when device disconnect after opening an app.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type
Bug Fix

### Parts of the app affected / Test plan

Device connection modals and manager as well
It should not have side effect since this just adds extra debounce time on reducer state change in case of device disconnection.

try adding an account select the app.
connect your device following the instructions and check if after opening the app the modal goes to step 3 instead of showing the "connect your device animation"
