### PR TITLE
LL-2237 (Manager): progress update hooked on observable

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@ledgerhq/hw-transport-http": "^5.9.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.10.0",
     "@ledgerhq/ledger-core": "^6.0.1",
-    "@ledgerhq/live-common": "^12.0.3",
+    "@ledgerhq/live-common": "^12.2.1",
     "@ledgerhq/logs": "^5.9.0",
     "@tippy.js/react": "^3.1.1",
     "@trust/keyto": "^1.0.0",

--- a/src/renderer/screens/manager/AppsList/AppActions.js
+++ b/src/renderer/screens/manager/AppsList/AppActions.js
@@ -59,7 +59,6 @@ type Props = {
   forceUninstall?: boolean,
   notEnoughMemoryToInstall: boolean,
   showActions?: boolean,
-  progress: number,
   setAppInstallDep?: (*) => void,
   setAppUninstallDep?: (*) => void,
   isLiveSupported: boolean,
@@ -78,7 +77,6 @@ const AppActions: React$ComponentType<Props> = React.memo(
     onlyUpdate,
     notEnoughMemoryToInstall,
     showActions = true,
-    progress,
     setAppInstallDep,
     setAppUninstallDep,
     isLiveSupported,
@@ -122,11 +120,12 @@ const AppActions: React$ComponentType<Props> = React.memo(
       <AppActionsWrapper>
         {installing || uninstalling ? (
           <Progress
+            state={state}
+            name={name}
             updating={updating}
             installing={installing}
             isCurrent={installQueue.length > 0 && installQueue[0] === name}
             uninstalling={uninstalling}
-            progress={progress}
           />
         ) : (
           showActions && (

--- a/src/renderer/screens/manager/AppsList/AppsList.js
+++ b/src/renderer/screens/manager/AppsList/AppsList.js
@@ -63,7 +63,6 @@ type Props = {
   state: State,
   dispatch: Action => void,
   isIncomplete: boolean,
-  progress?: number,
   setAppInstallDep: (*) => void,
   setAppUninstallDep: (*) => void,
   t: TFunction,
@@ -75,7 +74,6 @@ const AppsList = ({
   state,
   dispatch,
   isIncomplete,
-  progress = {},
   setAppInstallDep,
   setAppUninstallDep,
   t,
@@ -140,13 +138,12 @@ const AppsList = ({
         appStoreView={appStoreView}
         onlyUpdate={onlyUpdate}
         showActions={showActions}
-        progress={progress}
         setAppInstallDep={setAppInstallDep}
         setAppUninstallDep={setAppUninstallDep}
         addAccount={addAccount}
       />
     ),
-    [state, dispatch, isIncomplete, progress, setAppInstallDep, setAppUninstallDep, addAccount],
+    [state, dispatch, isIncomplete, setAppInstallDep, setAppUninstallDep, addAccount],
   );
 
   return (
@@ -163,7 +160,6 @@ const AppsList = ({
         state={state}
         dispatch={dispatch}
         isIncomplete={isIncomplete}
-        progress={progress}
       />
       {isIncomplete ? null : (
         <StickyTabBar>

--- a/src/renderer/screens/manager/AppsList/Item.js
+++ b/src/renderer/screens/manager/AppsList/Item.js
@@ -51,7 +51,6 @@ type Props = {
   onlyUpdate?: boolean,
   forceUninstall?: boolean,
   showActions?: boolean,
-  progress: number,
   setAppInstallDep?: (*) => void,
   setAppUninstallDep?: (*) => void,
   addAccount?: (*) => void,
@@ -67,7 +66,6 @@ const Item: React$ComponentType<Props> = ({
   onlyUpdate,
   forceUninstall,
   showActions = true,
-  progress,
   setAppInstallDep,
   setAppUninstallDep,
   addAccount,
@@ -136,7 +134,6 @@ const Item: React$ComponentType<Props> = ({
         onlyUpdate={onlyUpdate}
         showActions={showActions}
         notEnoughMemoryToInstall={notEnoughMemoryToInstall}
-        progress={progress}
         setAppInstallDep={setAppInstallDep}
         setAppUninstallDep={setAppUninstallDep}
         isLiveSupported={isLiveSupported}
@@ -146,17 +143,4 @@ const Item: React$ComponentType<Props> = ({
   );
 };
 
-export default memo<Props>(
-  Item,
-  (
-    { state: { installQueue: _installQueue, uninstallQueue: _uninstallQueue } },
-    { state: { installQueue, uninstallQueue }, progress, app: { name } },
-  ) => {
-    /** compare _prev to next props that if different should trigger a rerender */
-    return (
-      !(progress !== 1 && installQueue.length > 0 && installQueue[0] === name) &&
-      installQueue.length === _installQueue.length &&
-      uninstallQueue.length === _uninstallQueue.length
-    );
-  },
-);
+export default memo<Props>(Item);

--- a/src/renderer/screens/manager/AppsList/Progress.js
+++ b/src/renderer/screens/manager/AppsList/Progress.js
@@ -3,6 +3,10 @@ import React from "react";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
 
+import type { State } from "@ledgerhq/live-common/lib/apps/types";
+
+import { useAppInstallProgress } from "@ledgerhq/live-common/lib/apps/react";
+
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
 import ProgressBar from "~/renderer/components/Progress";
@@ -16,15 +20,18 @@ const Holder = styled.div`
 `;
 
 type Props = {
+  state: State,
+  name: string,
   updating?: boolean,
   installing?: boolean,
   uninstalling?: boolean,
-  progress?: number,
   isCurrent: boolean,
 };
 
 // we can forward appOp from state.currentAppOp if it matches the contextual app
-const Progress = ({ updating, installing, uninstalling, progress, isCurrent }: Props) => {
+const Progress = ({ state, name, updating, installing, uninstalling, isCurrent }: Props) => {
+  const progress = useAppInstallProgress(state, name);
+
   return (
     <Box flex="1" horizontal justifyContent="flex-end" overflow="hidden">
       <Box flex="0 0 auto" vertical alignItems="flex-end" justifyContent="center">

--- a/src/renderer/screens/manager/AppsList/UpdateAllApps.js
+++ b/src/renderer/screens/manager/AppsList/UpdateAllApps.js
@@ -61,10 +61,9 @@ type Props = {
   state: State,
   dispatch: Action => void,
   isIncomplete: boolean,
-  progress: number,
 };
 
-const UpdateAllApps = ({ update, state, dispatch, isIncomplete, progress }: Props) => {
+const UpdateAllApps = ({ update, state, dispatch, isIncomplete }: Props) => {
   const [open, setIsOpen] = useState();
   const { updateAllQueue } = state;
 
@@ -160,10 +159,9 @@ const UpdateAllApps = ({ update, state, dispatch, isIncomplete, progress }: Prop
         appStoreView={false}
         onlyUpdate={true}
         showActions={false}
-        progress={progress}
       />
     ),
-    [state, dispatch, isIncomplete, progress],
+    [state, dispatch, isIncomplete],
   );
 
   return (

--- a/src/renderer/screens/manager/AppsList/index.js
+++ b/src/renderer/screens/manager/AppsList/index.js
@@ -11,7 +11,7 @@ import {
   isIncompleteState,
   distribute,
 } from "@ledgerhq/live-common/lib/apps";
-import { useAppsRunner, useAppInstallProgress } from "@ledgerhq/live-common/lib/apps/react";
+import { useAppsRunner } from "@ledgerhq/live-common/lib/apps/react";
 
 import NavigationGuard from "~/renderer/components/NavigationGuard";
 import Quit from "~/renderer/icons/Quit";

--- a/src/renderer/screens/manager/AppsList/index.js
+++ b/src/renderer/screens/manager/AppsList/index.js
@@ -58,8 +58,6 @@ const AppsList = ({ deviceInfo, result, exec, t }: Props) => {
 
   const { installQueue, uninstallQueue, currentError } = state;
 
-  const progress = useAppInstallProgress(state, installQueue[0]);
-
   const jobInProgress = installQueue.length > 0 || uninstallQueue.length > 0;
 
   const distribution = useMemo(() => {
@@ -119,7 +117,6 @@ const AppsList = ({ deviceInfo, result, exec, t }: Props) => {
         state={state}
         dispatch={dispatch}
         isIncomplete={isIncomplete}
-        progress={progress}
         setAppInstallDep={setAppInstallDep}
         setAppUninstallDep={setAppUninstallDep}
         t={t}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1290,10 +1290,10 @@
     node-pre-gyp "^0.14.0"
     node-pre-gyp-github "^1.4.3"
 
-"@ledgerhq/live-common@^12.0.3":
-  version "12.0.3"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.0.3.tgz#f030e14e3d3026d487514484925f15e8c33048d1"
-  integrity sha512-/z9LN4FPQHE77teAQxkTritNHXxFN+7aUkbW2n8VlYhA74jAAgrza3ZEBGSMAhIlSwLVFEdvlpV65ifoQeKZdQ==
+"@ledgerhq/live-common@^12.2.1":
+  version "12.2.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.2.1.tgz#6680d1a4390f85c16af201aeca0da41ec0aa22a9"
+  integrity sha512-+w4Camz9UZuEvzejeAn6+B6JPIxh94y08UEEyFxEOTcFkC/4007twDFMhUWpeGtOhh3du9l3NetBvW6FjwsbPw==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.9.0"


### PR DESCRIPTION
Manager:

progress bar for installs now uses the new observable synced hook from live-common
introduced here:

https://github.com/LedgerHQ/ledger-live-common/pull/540

### Type

Polish

### Context

LL-2237

### Parts of the app affected / Test plan

Manager

Try an install or many and check that the progress bar updates correctly
