### PR TITLE
(UI-Polish): fix stars account select and deselect layout jump

### DIFF
--- a/src/renderer/components/MainSideBar/index.js
+++ b/src/renderer/components/MainSideBar/index.js
@@ -293,15 +293,15 @@ const MainSideBar = () => {
               />
               <Space of={30} />
             </SideBarList>
-
+            <Space grow of={30} />
             <Hide visible={secondAnim && hasStarredAccounts} mb={"-8px"}>
               <Separator />
             </Hide>
 
-            <SideBarList scroll title={t("sidebar.stars")} collapsed={secondAnim}>
+            <SideBarList scroll flex="1 1 40%" title={t("sidebar.stars")} collapsed={secondAnim}>
               <Stars pathname={location.pathname} collapsed={secondAnim} />
             </SideBarList>
-            <Space grow />
+            <Space of={30} grow />
             <TagContainer collapsed={!secondAnim} />
           </SideBar>
         );

--- a/src/renderer/components/SideBar/SideBarList.js
+++ b/src/renderer/components/SideBar/SideBarList.js
@@ -15,7 +15,6 @@ const ListWrapper = styled(Box)`
   ${p => (p.scroll ? p.theme.overflow.y : "")};
   ${p => (p.scroll ? "padding-right: 2px" : "")};
   will-change: unset;
-  flex: auto;
   ${p =>
     p.collapsed
       ? `
@@ -33,11 +32,20 @@ type Props = {
   titleRight?: any,
   emptyState?: any,
   collapsed?: boolean,
+  flex?: string,
 };
 
 class SideBarList extends Component<Props> {
   render() {
-    const { children, title, scroll, titleRight, emptyState, collapsed } = this.props;
+    const {
+      children,
+      title,
+      scroll,
+      titleRight,
+      emptyState,
+      collapsed,
+      flex = "auto",
+    } = this.props;
 
     return (
       <>
@@ -51,7 +59,14 @@ class SideBarList extends Component<Props> {
           </>
         )}
         {children ? (
-          <ListWrapper collapsed={collapsed} scroll={scroll} flow={2} px={3} fontSize={3}>
+          <ListWrapper
+            collapsed={collapsed}
+            scroll={scroll}
+            flow={2}
+            px={3}
+            fontSize={3}
+            flex={flex}
+          >
             {children}
           </ListWrapper>
         ) : emptyState ? (


### PR DESCRIPTION
Ui jumped when we selected and unselected starred account
should be fixed now.

![ezgif-7-d584d9413f69](https://user-images.githubusercontent.com/11752937/75703334-8d713a80-5cb7-11ea-96f6-17eb835c91c0.gif)


### Type

UI polish

### Parts of the app affected / Test plan

Sidebar stars section
try adding and removing starred accounts to make sure the layout doesn't jump anymore.
