### PR TITLE
(Modals): refactor modals transition

### DIFF
--- a/src/renderer/ModalsLayer.js
+++ b/src/renderer/ModalsLayer.js
@@ -5,7 +5,7 @@ import { Transition } from "react-transition-group";
 import { connect } from "react-redux";
 import { createStructuredSelector, createSelector } from "reselect";
 
-import type { ThemedComponent } from "styled-components";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 
 import { modalsStateSelector } from "~/renderer/reducers/modals";
 import modals from "~/renderer/modals";
@@ -54,9 +54,9 @@ const ModalsLayer = ({ visibleModals }: *) => (
 );
 
 const visibleModalsSelector = createSelector(modalsStateSelector, state =>
-  Object.entries(state)
-    .filter(([name, { isOpened }]) => !!modals[name] && isOpened)
-    .map(([name, data]) => ({ name, ...data })),
+  Object.keys(state)
+    .filter((name: string) => !!modals[name] && state[name].isOpened)
+    .map((name: string) => ({ name, ...state[name].data })),
 );
 
 const mapStateToProps = createStructuredSelector({

--- a/src/renderer/ModalsLayer.js
+++ b/src/renderer/ModalsLayer.js
@@ -1,19 +1,62 @@
 // @flow
 import React from "react";
+import styled from "styled-components";
+import { Transition } from "react-transition-group";
 import { connect } from "react-redux";
 import { createStructuredSelector, createSelector } from "reselect";
+
+import type { ThemedComponent } from "styled-components";
+
 import { modalsStateSelector } from "~/renderer/reducers/modals";
 import modals from "~/renderer/modals";
 
-const ModalsLayer = ({ visibleModals }: *) =>
-  visibleModals.map(name => {
-    const ModalComponent = modals[name];
-    if (!ModalComponent) return null;
-    return <ModalComponent key={name} />;
-  });
+// TODO: SNOOOOOOOOWW
+// import Snow, { isSnowTime } from '~/renderer/components/extra/Snow'
+
+const BackDrop: ThemedComponent<{ state: string }> = styled.div.attrs(({ state }) => ({
+  style: { opacity: state === "entered" ? 1 : 0 },
+}))`
+  pointer-events: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  opacity: 0;
+  transition: opacity 200ms cubic-bezier(0.3, 1, 0.5, 0.8);
+`;
+
+const ModalsLayer = ({ visibleModals }: *) => (
+  <Transition
+    in={visibleModals.length > 0}
+    appear
+    mountOnEnter
+    unmountOnExit
+    timeout={{
+      appear: 100,
+      enter: 100,
+      exit: 200,
+    }}
+  >
+    {state => (
+      <BackDrop state={state}>
+        {/* {// Will only render at the end of december
+          isSnowTime() ? <Snow numFlakes={200} /> : null} */}
+        {visibleModals.map(({ name, data }, i) => {
+          const ModalComponent = modals[name];
+          return <ModalComponent key={name} name={name} {...data} />;
+        })}
+      </BackDrop>
+    )}
+  </Transition>
+);
 
 const visibleModalsSelector = createSelector(modalsStateSelector, state =>
-  Object.keys(modals).filter(name => state[name] && state[name].isOpened),
+  Object.entries(state)
+    .filter(([name, { isOpened }]) => !!modals[name] && isOpened)
+    .map(([name, data]) => ({ name, ...data })),
 );
 
 const mapStateToProps = createStructuredSelector({

--- a/src/renderer/components/Modal/index.js
+++ b/src/renderer/components/Modal/index.js
@@ -120,7 +120,7 @@ class Modal extends PureComponent<Props> {
     document.addEventListener("keydown", this.preventFocusEscape);
   }
 
-  componentDidUpdate({ isOpened, onHide }) {
+  componentDidUpdate({ isOpened, onHide }: Props) {
     if (!isOpened && onHide) onHide();
   }
 

--- a/src/renderer/components/Modal/index.js
+++ b/src/renderer/components/Modal/index.js
@@ -196,19 +196,17 @@ class Modal extends PureComponent<Props> {
       >
         {state => {
           return (
-            <>
-              <Container
-                state={state}
-                centered={centered}
-                isOpened={isOpened}
-                onClick={this.handleClickOnBackdrop}
-              >
-                <BodyWrapper state={state} width={width} onClick={this.swallowClick}>
-                  {render && render(renderProps)}
-                  {children}
-                </BodyWrapper>
-              </Container>
-            </>
+            <Container
+              state={state}
+              centered={centered}
+              isOpened={isOpened}
+              onClick={this.handleClickOnBackdrop}
+            >
+              <BodyWrapper state={state} width={width} onClick={this.swallowClick}>
+                {render && render(renderProps)}
+                {children}
+              </BodyWrapper>
+            </Container>
           );
         }}
       </Transition>


### PR DESCRIPTION
Modals now use react-transition-group in order to appear and exit with same animation as before

This refactor was needed for smoother transitions between modals ie: go from a modal step to another modal without the backdrop blinking.

They should animate same as before. the backdrop giving the color is now unique to the modal layer and activated when there are modals to be shown

### Type

 UI Polish

### Parts of the app affected / Test plan

Test out that send receive and other modals are showing correctly and closes with an animation now.

The data layer of the modals should remain the same.
