### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,27 @@ Ledger Live is an hybrid desktop application built with Electron, React, Redux, 
  <img src="/docs/architecture.png" width="550"/>
 </p>
 
+## Download
+
+The latest stable release is available on [ledger.com/ledger-live](https://www.ledger.com/ledger-live/).
+
+Previous versions and pre-releases can be downloaded on here from the [Releases](https://github.com/LedgerHQ/ledger-live-desktop/releases) section.
+
+### Compatibility
+- macOS 10.10+
+- Windows 8+ (x64)
+- Linux (x64)
+
+# Development
+
 ## Setup
 
 ### Requirements
 
-- [NodeJS](https://nodejs.org) lts/erbium (Node 12.x)
-- [Yarn](https://yarnpkg.com) lts
-- [Python](https://www.python.org/) v2.7.10 (used by [node-gyp](https://github.com/nodejs/node-gyp) to build native addons)
-- You will also need a C++ compiler
+- [NodeJS](https://nodejs.org) LTS/erbium (Node 12.x)
+- [Yarn 1.x](https://classic.yarnpkg.com/) (Classic)
+- [Python](https://www.python.org/) 2.7 or 3.5+
+- A C/C++ toolchain (see [node-gyp documentation](https://github.com/nodejs/node-gyp#on-unix))
 
 ## Install
 


### PR DESCRIPTION
Updated the requirements which were out of date:
- Yarn must be Classic™️ to work
- `node-gyp` finally added support for Python3
- Added a link to `node-gyp` documentation regarding C/C++ toolchain, as it can be tricky to get right

I realized the landing page of the repo was only focused on developers wanting to contribute, so I added a part about downloads and compatibility for lost average Joes stumbling on our GitHub.

### Type

Documentation update


