### PR TITLE
LL-2269 Fixes bug in add account internal logic

### DIFF
--- a/src/renderer/modals/AddAccounts/steps/StepImport.js
+++ b/src/renderer/modals/AddAccounts/steps/StepImport.js
@@ -138,7 +138,9 @@ class StepImport extends PureComponent<StepProps> {
               setScannedAccounts({
                 scannedAccounts: [...scannedAccounts, account],
                 checkedAccountsIds: onlyNewAccounts
-                  ? [account.id]
+                  ? hasAlreadyBeenImported
+                    ? []
+                    : [account.id]
                   : !hasAlreadyBeenImported && !isNewAccount
                   ? uniq([...checkedAccountsIds, account.id])
                   : checkedAccountsIds,


### PR DESCRIPTION
With the introduction of some logic that was in charge of preselecting the first new account scanned when all others had already been added we introduced a bug that would mark as _checked_ the last account that was scanned regardless of whether it was added or not already. This resulted in the flow for add accounts being changed and showing the `Add Account` (because internally there was this **one** account to be added).

This fixes that internal counter and should show "Close" as the CTA when we will effectively add/create no accounts.

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2269

### Parts of the app affected / Test plan

On the add account flow, when adding accounts 
- If any account will be created/added, the CTA should say add account/s.
- If no checkmarks are visible & selected, the CTA should say "Close" and end the flow.
- If all accounts have been added before & the last one is not empty, it should list it **and auto-select it**
- If all accounts have been added before & the last one **is empty** it should tell the user to receive funds on that account before creating a new one.


### Screenshot 
![image](https://user-images.githubusercontent.com/4631227/76024611-b6016a80-5f2b-11ea-85f2-34f7cf2555f1.png)

Example of a case where we'll kill the flow since we won't create more accounts.