### PR TITLE
Automatically hide/show empty token accounts when toggling the setting

### DIFF
--- a/src/renderer/actions/settings.js
+++ b/src/renderer/actions/settings.js
@@ -7,6 +7,7 @@ import type { Currency } from "@ledgerhq/live-common/lib/types";
 
 import { setEnvOnAllThreads } from "./../../helpers/env";
 import type { SettingsState as Settings } from "./../reducers/settings";
+import { refreshAccountsOrdering } from "~/renderer/actions/general";
 
 export type SaveSettings = ($Shape<Settings>) => { type: string, payload: $Shape<Settings> };
 
@@ -39,6 +40,7 @@ export const setHideEmptyTokenAccounts = (hideEmptyTokenAccounts: boolean) => as
 ) => {
   if (setEnvOnAllThreads("HIDE_EMPTY_TOKEN_ACCOUNTS", hideEmptyTokenAccounts)) {
     dispatch(saveSettings({ hideEmptyTokenAccounts }));
+    dispatch(refreshAccountsOrdering());
   }
 };
 export const setSidebarCollapsed = (sidebarCollapsed: boolean) =>

--- a/src/renderer/screens/accounts/AccountRowItem/index.js
+++ b/src/renderer/screens/accounts/AccountRowItem/index.js
@@ -23,6 +23,9 @@ import Delta from "./Delta";
 import Header from "./Header";
 
 import Star from "~/renderer/components/Stars/Star";
+import { connect } from "react-redux";
+import { createStructuredSelector } from "reselect";
+import { hideEmptyTokenAccountsSelector } from "~/renderer/reducers/settings";
 
 const Row: ThemedComponent<{}> = styled(Box)`
   background: ${p => p.theme.colors.palette.background.paper};
@@ -112,6 +115,7 @@ type Props = {
   account: TokenAccount | Account,
   parentAccount?: ?Account,
   disableRounding?: boolean,
+  hideEmptyTokens?: boolean,
   onClick: (AccountLike, ?Account) => void,
   hidden?: boolean,
   range: PortfolioRange,
@@ -169,7 +173,16 @@ class AccountRowItem extends PureComponent<Props, State> {
   };
 
   render() {
-    const { account, parentAccount, range, hidden, onClick, disableRounding, search } = this.props;
+    const {
+      account,
+      parentAccount,
+      range,
+      hidden,
+      onClick,
+      disableRounding,
+      search,
+      hideEmptyTokens,
+    } = this.props;
     const { expanded } = this.state;
 
     let currency;
@@ -208,8 +221,10 @@ class AccountRowItem extends PureComponent<Props, State> {
           hide: "subAccounts.hideSubAccounts",
         };
 
+    const key = `${account.id}_${hideEmptyTokens ? "hide_empty_tokens" : ""}`;
+
     return (
-      <div style={{ position: "relative" }} hidden={hidden}>
+      <div style={{ position: "relative" }} key={key} hidden={hidden}>
         <span style={{ position: "absolute", top: -70 }} ref={this.scrollTopFocusRef} />
         <Row expanded={expanded} tokens={showTokensIndicator} key={mainAccount.id}>
           <AccountContextMenu account={account}>
@@ -266,5 +281,12 @@ class AccountRowItem extends PureComponent<Props, State> {
     );
   }
 }
+const mapStateToProps = createStructuredSelector({
+  hideEmptyTokenAccounts: hideEmptyTokenAccountsSelector,
+});
 
-export default AccountRowItem;
+const ConnectedAccountRowItem: React$ComponentType<{}> = connect(
+  mapStateToProps,
+  null,
+)(AccountRowItem);
+export default ConnectedAccountRowItem;


### PR DESCRIPTION

![instahide](https://user-images.githubusercontent.com/4631227/76102772-cfa8bd80-5fd0-11ea-968e-c5baecc40b65.gif)

We had a regression where toggling the setting for hiding/showing empty token accounts didn't reflect the changes without exiting the screen and coming back/refreshing. This triggers a reorder of accounts and therefor shows the changes instantly.


<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Regression fix
