### PR TITLE
Fixes main logs to appear in exported logs + more db logs

### DIFF
--- a/src/live-common-setup-base.js
+++ b/src/live-common-setup-base.js
@@ -1,0 +1,10 @@
+// @flow
+import "./env";
+
+import { listen as listenLogs } from "@ledgerhq/logs";
+import logger from "./logger";
+
+listenLogs(({ id, date, ...log }) => {
+  if (log.type === "hid-frame") return;
+  logger.debug(log);
+});

--- a/src/live-common-setup.js
+++ b/src/live-common-setup.js
@@ -1,14 +1,7 @@
 // @flow
-import "./env";
 import "@ledgerhq/live-common/lib/load/tokens/ethereum/erc20";
 // import "@ledgerhq/live-common/lib/load/tokens/tron/trc10";
 // import "@ledgerhq/live-common/lib/load/tokens/tron/trc20";
 
-import { listen as listenLogs } from "@ledgerhq/logs";
-import logger from "./logger";
+import "./live-common-setup-base";
 import "./live-common-set-supported-currencies";
-
-listenLogs(({ id, date, ...log }) => {
-  if (log.type === "hid-frame") return;
-  logger.debug(log);
-});

--- a/src/main/db/crypto.js
+++ b/src/main/db/crypto.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { log } from "@ledgerhq/logs";
 import crypto from "crypto";
 
 // /!\ changing those presets would lock out users with already encrypted databases due to breaking changes.
@@ -30,6 +31,7 @@ export const encryptData = (data: string, encryptionKey: string) => {
 
 export const decryptData = (raw: string, encryptionKey: string) => {
   const data = Buffer.from(raw, "base64");
+  log("db/crypto", "decryptData. full data length = " + data.length);
 
   // We check if the data include an initialization vector
   if (data.slice(IV_LENGTH, IV_LENGTH + 1).toString() === ":") {
@@ -46,6 +48,9 @@ export const decryptData = (raw: string, encryptionKey: string) => {
       "utf8",
     );
   }
+
+  log("db/crypto", "fallback to deprecated API");
+
   // if not, then we fallback to the deprecated API
   // eslint-disable-next-line node/no-deprecated-api
   const decipher = crypto.createDecipher(ENCRYPTION_ALGORITHM, encryptionKey);

--- a/src/main/db/index.js
+++ b/src/main/db/index.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { log } from "@ledgerhq/logs";
 import path from "path";
 import cloneDeep from "lodash/cloneDeep";
 import get from "lodash/get";
@@ -154,6 +155,8 @@ async function setEncryptionKey(ns: string, keyPath: string, encryptionKey: stri
 
     return save(ns);
   } catch (err) {
+    log("db", "setEncryptionKey failure: " + String(err));
+    logger.error(err);
     throw new DBWrongPassword();
   }
 }

--- a/src/main/setup.js
+++ b/src/main/setup.js
@@ -1,6 +1,6 @@
 // @flow
 
-import "../env";
+import "../live-common-setup-base";
 import { ipcMain } from "electron";
 import contextMenu from "electron-context-menu";
 import logger, { enableDebugLogger } from "../logger";


### PR DESCRIPTION
if you input a wrong password and export logs, you will now see more info:

<img width="1080" alt="Capture d’écran 2020-03-09 à 14 36 44" src="https://user-images.githubusercontent.com/211411/76217825-6bc20700-6213-11ea-84ba-d10d7a76e97e.png">

not much to test and impact risk is low