### PR TITLE
LL-2267 Images: prevent right clicks

### DIFF
--- a/src/renderer/components/IsUnlocked.js
+++ b/src/renderer/components/IsUnlocked.js
@@ -22,6 +22,7 @@ import ConfirmModal from "~/renderer/modals/ConfirmModal";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import IconArrowRight from "~/renderer/icons/ArrowRight";
 import LedgerLiveImg from "~/renderer/images/ledgerlive-logo.svg";
+import Image from "./Image";
 
 type InputValue = {
   password: string,
@@ -130,7 +131,9 @@ const IsUnlocked = ({ children }: Props) => {
           <Box alignItems="center">
             <LedgerLiveLogo
               style={{ marginBottom: 40 }}
-              icon={<img src={LedgerLiveImg} alt="" draggable="false" width={50} height={50} />}
+              icon={
+                <Image resource={LedgerLiveImg} alt="" draggable="false" width={50} height={50} />
+              }
             />
             <PageTitle>{t("common.lockScreen.title")}</PageTitle>
             <LockScreenDesc>

--- a/src/renderer/families/tezos/BakerImage.js
+++ b/src/renderer/families/tezos/BakerImage.js
@@ -5,6 +5,7 @@ import type { Baker } from "@ledgerhq/live-common/lib/families/tezos/bakers";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import Box from "~/renderer/components/Box";
 import CustomValidator from "~/renderer/icons/CustomValidator";
+import Image from "~/renderer/components/Image";
 
 const Circle: ThemedComponent<{ size: number }> = styled(Box).attrs(props => ({
   style: {
@@ -16,13 +17,6 @@ const Circle: ThemedComponent<{ size: number }> = styled(Box).attrs(props => ({
   overflow: hidden;
 `;
 
-const Img = styled.img.attrs(props => ({
-  style: {
-    width: props.size,
-    height: props.size,
-  },
-}))``;
-
 type Props = {
   size?: number,
   baker: ?Baker,
@@ -30,7 +24,11 @@ type Props = {
 
 const BakerImage = ({ size = 24, baker }: Props) => (
   <Circle size={size}>
-    {baker ? <Img src={baker.logoURL} size={size} /> : <CustomValidator size={size} />}
+    {baker ? (
+      <Image resource={baker.logoURL} alt="" width={size} height={size} />
+    ) : (
+      <CustomValidator size={size} />
+    )}
   </Circle>
 );
 

--- a/src/renderer/icons/BigSpinner/index.js
+++ b/src/renderer/icons/BigSpinner/index.js
@@ -2,14 +2,15 @@
 
 import React from "react";
 import png from "./bigspinner.png";
+import Image from "~/renderer/components/Image";
 
 type Props = {
   size?: number,
 };
 
-function BigSpinner({ size }: Props) {
+function BigSpinner({ size = 44 }: Props) {
   const defaultedSize = size || 44;
-  return <img style={{ width: defaultedSize, height: defaultedSize }} src={png} alt="" />;
+  return <Image style={{ width: defaultedSize, height: defaultedSize }} resource={png} alt="" />;
 }
 
 export default BigSpinner;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,97 +1,96 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8" />
-    <title><%= htmlWebpackPlugin.options.title %></title>
-    <script
-      async
-      src="https://resources.live.ledger.app/public_resources/analytics.min.js"
-    ></script>
-    <style>
-      html {
-        overflow: hidden;
+
+<head>
+  <meta charset="utf-8" />
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <script async src="https://resources.live.ledger.app/public_resources/analytics.min.js"></script>
+  <style>
+    html {
+      overflow: hidden;
+    }
+
+    @keyframes loaded-anim {
+      0% {
+        transform: translateZ(1px);
       }
 
-      @keyframes loaded-anim {
-        0% {
-          transform: translateZ(1px);
-        }
+      100% {
+        transform: translateZ(2000px);
+      }
+    }
 
-        100% {
-          transform: translateZ(2000px);
-        }
+    @keyframes logo-anim {
+      0% {
+        transform: rotate(0);
+        animation-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
       }
 
-      @keyframes logo-anim {
-        0% {
-          transform: rotate(0);
-          animation-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
-        }
-
-        50% {
-          transform: rotate(-360deg);
-          animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
-        }
-
-        100% {
-          transform: rotate(-1080deg);
-        }
+      50% {
+        transform: rotate(-360deg);
+        animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
       }
 
-      #react-root {
-        visibility: hidden;
+      100% {
+        transform: rotate(-1080deg);
       }
+    }
 
-      #loader-container {
-        z-index: 99;
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        perspective: 2000px;
-        transition: opacity 0.8s ease-out;
-        opacity: 0;
-        pointer-events: none;
-      }
+    #react-root {
+      visibility: hidden;
+    }
 
-      #loader-container.loading {
-        opacity: 1;
-      }
+    #loader-container {
+      z-index: 99;
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      perspective: 2000px;
+      transition: opacity 0.8s ease-out;
+      opacity: 0;
+      pointer-events: none;
+    }
 
-      #loader {
-        width: 70px;
-        height: 70px;
-        background-color: white;
-        border-radius: 50%;
-        padding: 12px;
-        box-sizing: content-box;
-      }
+    #loader-container.loading {
+      opacity: 1;
+    }
 
-      #loader.loaded {
-        animation: loaded-anim 0.7s cubic-bezier(0.55, 0.085, 0.68, 0.53) both;
-      }
+    #loader {
+      width: 70px;
+      height: 70px;
+      background-color: white;
+      border-radius: 50%;
+      padding: 12px;
+      box-sizing: content-box;
+    }
 
-      #logo {
-        animation: logo-anim 1.8s infinite;
-        height: 100%;
-        width: 100%;
-        user-select: none;
-        pointer-events: none;
-      }
-    </style>
-  </head>
+    #loader.loaded {
+      animation: loaded-anim 0.7s cubic-bezier(0.55, 0.085, 0.68, 0.53) both;
+    }
 
-  <body>
-    <div id="react-root"></div>
-    <div id="loader-container">
-      <div id="loader">
-        <img id="logo" />
-      </div>
+    #logo {
+      animation: logo-anim 1.8s infinite;
+      height: 100%;
+      width: 100%;
+      user-select: none;
+      pointer-events: none;
+    }
+  </style>
+</head>
+
+<body>
+  <div id="react-root"></div>
+  <div id="loader-container">
+    <div id="loader">
+      <img id="logo" />
     </div>
-    <div id="modals"></div>
-  </body>
+  </div>
+  <div id="modals"></div>
+</body>
+
 </html>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -1,94 +1,97 @@
-<!doctype html>
+<!DOCTYPE html>
 <html>
-
-<head>
-  <meta charset="utf-8" />
-  <title><%= htmlWebpackPlugin.options.title %></title>
-  <script async src="https://resources.live.ledger.app/public_resources/analytics.min.js"></script>
-  <style>
-    html {
-      overflow: hidden;
-    }
-
-    @keyframes loaded-anim {
-      0% {
-        transform: translateZ(1px);
+  <head>
+    <meta charset="utf-8" />
+    <title><%= htmlWebpackPlugin.options.title %></title>
+    <script
+      async
+      src="https://resources.live.ledger.app/public_resources/analytics.min.js"
+    ></script>
+    <style>
+      html {
+        overflow: hidden;
       }
 
-      100% {
-        transform: translateZ(2000px);
-      }
-    }
+      @keyframes loaded-anim {
+        0% {
+          transform: translateZ(1px);
+        }
 
-    @keyframes logo-anim {
-      0% {
-        transform: rotate(0);
-        animation-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
-      }
-
-      50% {
-        transform: rotate(-360deg);
-        animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+        100% {
+          transform: translateZ(2000px);
+        }
       }
 
-      100% {
-        transform: rotate(-1080deg);
+      @keyframes logo-anim {
+        0% {
+          transform: rotate(0);
+          animation-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+        }
+
+        50% {
+          transform: rotate(-360deg);
+          animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+        }
+
+        100% {
+          transform: rotate(-1080deg);
+        }
       }
-    }
 
-    #react-root {
-      visibility: hidden;
-    }
+      #react-root {
+        visibility: hidden;
+      }
 
-    #loader-container {
-      z-index: 99;
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      perspective: 2000px;
-      transition: opacity 0.8s ease-out;
-      opacity: 0;
-      pointer-events: none;
-    }
+      #loader-container {
+        z-index: 99;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        perspective: 2000px;
+        transition: opacity 0.8s ease-out;
+        opacity: 0;
+        pointer-events: none;
+      }
 
-    #loader-container.loading {
-      opacity: 1;
-    }
+      #loader-container.loading {
+        opacity: 1;
+      }
 
-    #loader {
-      width: 70px;
-      height: 70px;
-      background-color: white;
-      border-radius: 50%;
-      padding: 12px;
-      box-sizing: content-box;
-    }
+      #loader {
+        width: 70px;
+        height: 70px;
+        background-color: white;
+        border-radius: 50%;
+        padding: 12px;
+        box-sizing: content-box;
+      }
 
-    #loader.loaded {
-      animation: loaded-anim 0.7s cubic-bezier(0.55, 0.085, 0.68, 0.53) both;
-    }
+      #loader.loaded {
+        animation: loaded-anim 0.7s cubic-bezier(0.55, 0.085, 0.68, 0.53) both;
+      }
 
-    #logo {
-      animation: logo-anim 1.8s infinite;
-      height: 100%;
-      width: 100%;
-    }
-  </style>
-</head>
+      #logo {
+        animation: logo-anim 1.8s infinite;
+        height: 100%;
+        width: 100%;
+        user-select: none;
+        pointer-events: none;
+      }
+    </style>
+  </head>
 
-<body>
-  <div id="react-root"></div>
-  <div id="loader-container">
-    <div id="loader">
-      <img id="logo" />
+  <body>
+    <div id="react-root"></div>
+    <div id="loader-container">
+      <div id="loader">
+        <img id="logo" />
+      </div>
     </div>
-  </div>
-  <div id="modals"></div>
-</body>
-
+    <div id="modals"></div>
+  </body>
 </html>

--- a/src/renderer/modals/MigrateAccounts/steps/StepOverview.js
+++ b/src/renderer/modals/MigrateAccounts/steps/StepOverview.js
@@ -22,6 +22,7 @@ import type { StepProps } from "~/renderer/modals/MigrateAccounts";
 
 import LedgerLiveImg from "~/renderer/images/ledgerlive-logo.svg";
 import MobileExport from "~/renderer/images/mobile-export.svg";
+import Image from "~/renderer/components/Image";
 
 const getAllImportedAccounts = accountsByAsset =>
   reduce(accountsByAsset, (acc, accounts) => [...acc, ...accounts], []);
@@ -186,7 +187,7 @@ const StepOverview = ({
           <LedgerLiveLogo
             width="58px"
             height="58px"
-            icon={<img src={LedgerLiveImg} alt="" width={35} height={35} />}
+            icon={<Image resource={LedgerLiveImg} alt="" width={35} height={35} />}
           />
         ) : (
           <SuccessAnimatedIcon width={70} height={70} />

--- a/src/renderer/screens/manager/AppsList/AppDepsInstallModal.js
+++ b/src/renderer/screens/manager/AppsList/AppDepsInstallModal.js
@@ -10,6 +10,7 @@ import manager from "@ledgerhq/live-common/lib/manager";
 
 import ConfirmModal from "~/renderer/modals/ConfirmModal/index";
 import LinkIcon from "~/renderer/icons/LinkIcon";
+import Image from "~/renderer/components/Image";
 
 const IconsSection = styled.div`
   height: ${p => p.theme.space[7]}px;
@@ -68,13 +69,20 @@ const AppDepsInstallModal = ({ app, dependencies, appList, dispatch, onClose }: 
       subTitle={
         <>
           <IconsSection>
-            <img alt="" src={manager.getIconUrl(app.icon)} width={40} height={40} />
+            <Image alt="" resource={manager.getIconUrl(app.icon)} width={40} height={40} />
             <Separator />
             <LinkIconWrapper>
               <LinkIcon size={20} />
             </LinkIconWrapper>
             <Separator />
-            {<img alt="" src={manager.getIconUrl(dependencies[0].icon)} width={40} height={40} />}
+            {
+              <Image
+                alt=""
+                resource={manager.getIconUrl(dependencies[0].icon)}
+                width={40}
+                height={40}
+              />
+            }
           </IconsSection>
           <Trans
             i18nKey="manager.apps.dependencyInstall.title"

--- a/src/renderer/screens/manager/AppsList/AppDepsUnInstallModal.js
+++ b/src/renderer/screens/manager/AppsList/AppDepsUnInstallModal.js
@@ -15,6 +15,7 @@ import ListTreeLine from "~/renderer/icons/ListTreeLine";
 import CollapsibleCard from "~/renderer/components/CollapsibleCard";
 import Text from "~/renderer/components/Text";
 import Box from "~/renderer/components/Box/Box";
+import Image from "~/renderer/components/Image";
 
 const IconsSection = styled.div`
   display: flex;
@@ -113,7 +114,7 @@ const AppDepsUninstallModal = ({
               <ListTreeLine size={55} />
             </ListIcon>
             <Box ml={4} mr={2}>
-              <img alt="" src={manager.getIconUrl(a.icon)} width={22} height={22} />
+              <Image alt="" resource={manager.getIconUrl(a.icon)} width={22} height={22} />
             </Box>
             <Text ff="Inter|SemiBold" color="palette.text.shade100" fontSize={4}>
               {a.name}

--- a/src/renderer/screens/manager/AppsList/Item.js
+++ b/src/renderer/screens/manager/AppsList/Item.js
@@ -16,6 +16,7 @@ import Box from "~/renderer/components/Box";
 
 import IconCheckFull from "~/renderer/icons/CheckFull";
 import AppActions from "./AppActions";
+import Image from "~/renderer/components/Image";
 
 const AppRow = styled.div`
   display: flex;
@@ -91,7 +92,7 @@ const Item: React$ComponentType<Props> = ({
   return (
     <AppRow>
       <Box flex="0.7" horizontal>
-        <img alt="" src={manager.getIconUrl(app.icon)} width={40} height={40} />
+        <Image alt="" resource={manager.getIconUrl(app.icon)} width={40} height={40} />
         <AppName>
           <Text ff="Inter|Bold" color="palette.text.shade100" fontSize={3}>{`${app.name}${
             currency ? ` (${currency.ticker})` : ""

--- a/src/renderer/screens/manager/AppsList/Placeholder.js
+++ b/src/renderer/screens/manager/AppsList/Placeholder.js
@@ -12,6 +12,7 @@ import Text from "~/renderer/components/Text";
 import NoResults from "~/renderer/icons/NoResults";
 import Box from "~/renderer/components/Box/Box";
 import Button from "~/renderer/components/Button";
+import Image from "~/renderer/components/Image";
 
 const tokens = listTokens();
 
@@ -57,7 +58,7 @@ const Placeholder = ({ query, addAccount, dispatch, installed, apps }: Props) =>
 
   return found && parent ? (
     <Box alignItems="center" pt={5} py={6}>
-      <img alt="" src={manager.getIconUrl(parent.icon)} width={40} height={40} />
+      <Image alt="" resource={manager.getIconUrl(parent.icon)} width={40} height={40} />
       <Box mt={2} ff="Inter|Regular" fontSize={5} color="palette.text.shade100">
         <Trans
           i18nKey={

--- a/src/renderer/screens/manager/DeviceStorage/index.js
+++ b/src/renderer/screens/manager/DeviceStorage/index.js
@@ -39,6 +39,8 @@ export const DeviceIllustration: ThemedComponent<{}> = styled.img.attrs(p => ({
   max-height: 100%;
   filter: drop-shadow(0px 5px 7px ${p => p.theme.colors.palette.text.shade10});
   transform: translateX(-50%);
+  user-select: none;
+  pointer-events: none;
 `;
 
 const Separator = styled.div`

--- a/src/renderer/screens/onboarding/steps/Finish.js
+++ b/src/renderer/screens/onboarding/steps/Finish.js
@@ -18,6 +18,8 @@ import IconSocialReddit from "~/renderer/icons/Reddit";
 import IconSocialGithub from "~/renderer/icons/Github";
 import ConfettiParty from "~/renderer/components/ConfettiParty";
 import LedgerLiveLogo from "~/renderer/components/LedgerLiveLogo";
+import Image from "~/renderer/components/Image";
+
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import type { StepProps } from "~/renderer/screens/onboarding";
 
@@ -91,7 +93,9 @@ export default class Finish extends Component<StepProps, *> {
             <LedgerLiveLogo
               width="64px"
               height="64px"
-              icon={<img src={LedgerLiveImg} alt="" draggable="false" width={40} height={40} />}
+              icon={
+                <Image resource={LedgerLiveImg} alt="" draggable="false" width={40} height={40} />
+              }
             />
             <Box color="positiveGreen" style={{ position: "absolute", right: 0, bottom: 0 }}>
               <IconCheckFull size={18} />

--- a/src/renderer/screens/onboarding/steps/Init.js
+++ b/src/renderer/screens/onboarding/steps/Init.js
@@ -16,6 +16,7 @@ import IconCheck from "~/renderer/icons/Check";
 import IconChevronRight from "~/renderer/icons/ChevronRight";
 import IconExternalLink from "~/renderer/icons/ExternalLink";
 import { Title } from "../sharedComponents";
+import Image from "~/renderer/components/Image";
 import type { StepProps } from "..";
 
 const mapDispatchToProps = { flowType };
@@ -70,7 +71,9 @@ class InitC extends PureComponent<StepProps, *> {
           <LedgerLiveLogo
             width="64px"
             height="64px"
-            icon={<img src={LedgerLiveImg} alt="" draggable="false" width={40} height={40} />}
+            icon={
+              <Image resource={LedgerLiveImg} alt="" draggable="false" width={40} height={40} />
+            }
           />
           <Box m={5} style={{ maxWidth: 480 }}>
             <Title>{t("onboarding.init.title")}</Title>

--- a/src/renderer/screens/onboarding/steps/NoDevice.js
+++ b/src/renderer/screens/onboarding/steps/NoDevice.js
@@ -13,6 +13,7 @@ import LedgerLiveImg from "~/renderer/images/ledgerlive-logo.svg";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { OptionFlowCard } from "~/renderer/screens/onboarding/steps/Init";
 import Button from "~/renderer/components/Button";
+import Image from "~/renderer/components/Image";
 import { Title, OnboardingFooterWrapper } from "../sharedComponents";
 import type { StepProps } from "..";
 
@@ -55,7 +56,9 @@ class NoDevice extends PureComponent<StepProps, *> {
             <LedgerLiveLogo
               width="64px"
               height="64px"
-              icon={<img src={LedgerLiveImg} alt="" draggable="false" width={40} height={40} />}
+              icon={
+                <Image resource={LedgerLiveImg} alt="" draggable="false" width={40} height={40} />
+              }
             />
             <Box m={5} style={{ maxWidth: 480 }}>
               <Title>

--- a/src/renderer/screens/onboarding/steps/Start.js
+++ b/src/renderer/screens/onboarding/steps/Start.js
@@ -9,6 +9,7 @@ import Button from "~/renderer/components/Button";
 import { Description, Title } from "../sharedComponents";
 import type { StepProps } from "..";
 import ThemeSelector from "./ThemeSelector";
+import Image from "~/renderer/components/Image";
 
 const Start = (props: StepProps) => {
   const { jumpStep } = props;
@@ -17,7 +18,7 @@ const Start = (props: StepProps) => {
       <TrackPage category="Onboarding" name="Start" />
       <Box alignItems="center">
         <LedgerLiveLogo
-          icon={<img src={LedgerLiveImg} alt="" draggable="false" width={50} height={50} />}
+          icon={<Image resource={LedgerLiveImg} alt="" draggable="false" width={50} height={50} />}
         />
         <Box>
           <Title>


### PR DESCRIPTION
prevent right click on images

This should fix the issue where users could right click image resources and save them.

### Type

Bug Fix

### Context

LL-2267

### Parts of the app affected / Test plan

Try right clicking on the logo in the password page or any logo on the manager catalog list or any baker image on a Tezos validator selection.
