### PR TITLE
Skip genuine check for dev with MOCK flag

### DIFF
--- a/src/renderer/screens/onboarding/steps/GenuineCheck/index.js
+++ b/src/renderer/screens/onboarding/steps/GenuineCheck/index.js
@@ -86,7 +86,7 @@ const GenuineCheck = (props: StepProps) => {
       setTimeout(() => {
         handleCloseGenuineCheckModal();
         handleGenuineCheckPass();
-      }, 5000);
+      }, 2000);
     }
   }, [handleCloseGenuineCheckModal, handleGenuineCheckPass]);
 

--- a/src/renderer/screens/onboarding/steps/GenuineCheck/index.js
+++ b/src/renderer/screens/onboarding/steps/GenuineCheck/index.js
@@ -2,6 +2,7 @@
 
 import React, { useState, useCallback } from "react";
 import { Trans } from "react-i18next";
+import { getEnv } from "@ledgerhq/live-common/lib/env";
 import { getDeviceModel } from "@ledgerhq/devices";
 import styled from "styled-components";
 import IconCheck from "~/renderer/icons/Check";
@@ -68,10 +69,6 @@ const GenuineCheck = (props: StepProps) => {
     [updateGenuineCheck],
   );
 
-  const handleOpenGenuineCheckModal = useCallback(() => {
-    setGenuineCheckModalOpened(true);
-  }, []);
-
   const handleCloseGenuineCheckModal = useCallback(() => {
     setGenuineCheckModalOpened(false);
   }, []);
@@ -82,6 +79,16 @@ const GenuineCheck = (props: StepProps) => {
     });
     setGenuineCheckModalOpened(false);
   }, [updateGenuineCheck]);
+
+  const handleOpenGenuineCheckModal = useCallback(() => {
+    setGenuineCheckModalOpened(true);
+    if (__DEV__ && process.env.SKIP_GENUINE_CHECK) {
+      setTimeout(() => {
+        handleCloseGenuineCheckModal();
+        handleGenuineCheckPass();
+      }, 5000);
+    }
+  }, [handleCloseGenuineCheckModal, handleGenuineCheckPass]);
 
   const redoGenuineCheck = useCallback(() => {
     setRecovery(undefined);

--- a/src/renderer/screens/onboarding/steps/GenuineCheck/index.js
+++ b/src/renderer/screens/onboarding/steps/GenuineCheck/index.js
@@ -82,7 +82,7 @@ const GenuineCheck = (props: StepProps) => {
 
   const handleOpenGenuineCheckModal = useCallback(() => {
     setGenuineCheckModalOpened(true);
-    if (__DEV__ && process.env.SKIP_GENUINE_CHECK) {
+    if (getEnv("MOCK")) {
       setTimeout(() => {
         handleCloseGenuineCheckModal();
         handleGenuineCheckPass();


### PR DESCRIPTION
Not sure I understood completely, but with this, adding the `MOCK` flag and being in dev mode will skip the genuine check from onboarding in order to allow @nabil-brn to write further automation tests. If someone else wants to take over further be my guest.