### PR TITLE
target develop branch instead of master for nightly builds

### DIFF
--- a/.github/workflows/tag-nightly.yml
+++ b/.github/workflows/tag-nightly.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+        with:
+          ref: develop
       - name: check if current commit is on tag
         run: |
           git describe --exact-match &>/dev/null \
@@ -37,6 +39,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: true
+          branch: develop
       - name: push tag
         run: |
           curl -s -X POST https://api.github.com/repos/LedgerHQ/${{ steps.config.outputs.repo }}/git/refs \


### PR DESCRIPTION
When we ported the code to the new repo, we haven't checked our current workflow for nightlies
As such we were still targeting the master branch for the nightlies, but this branch is protected, and we want to build from develop anyway

### Type

Improvement
