### PR TITLE
Ll 2152/enable sentry again

### DIFF
--- a/src/internal/index.js
+++ b/src/internal/index.js
@@ -10,15 +10,14 @@ import logger from "~/logger";
 import LoggerTransport from "~/logger/logger-transport-internal";
 
 import { executeCommand, unsubscribeCommand, unsubscribeAllCommands } from "./commandHandler";
+import sentry from "~/sentry/node";
+// import uuid from 'uuid/v4'
 
 process.on("exit", () => {
   logger.debug("exiting process, unsubscribing all...");
   unsubscribeSetup();
   unsubscribeAllCommands();
 });
-
-// import uuid from 'uuid/v4'
-// import sentry from '~/sentry/node'
 
 logger.add(new LoggerTransport());
 
@@ -39,8 +38,10 @@ process.on("uncaughtException", err => {
 const defers = {};
 
 // eslint-disable-next-line no-unused-vars
-let sentryEnabled = process.env.INITIAL_SENTRY_ENABLED || false;
-// sentry(() => sentryEnabled, process.env.SENTRY_USER_ID)
+let sentryEnabled = !!process.env.INITIAL_SENTRY_ENABLED || false;
+if (process.env.SENTRY_USER_ID) {
+  sentry(() => sentryEnabled, process.env.SENTRY_USER_ID);
+}
 
 process.on("message", m => {
   switch (m.type) {

--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -73,37 +73,31 @@ export function enableDebugLogger() {
 }
 
 const captureBreadcrumb = (breadcrumb: any) => {
-  // FIXME
-  /*
   if (!process.env.STORYBOOK_ENV) {
     try {
-      if (typeof window !== 'undefined') {
-        require('sentry/browser').captureBreadcrumb(breadcrumb)
+      if (typeof window !== "undefined") {
+        require("~/sentry/browser").captureBreadcrumb(breadcrumb);
       } else {
-        require('sentry/node').captureBreadcrumb(breadcrumb)
+        require("~/sentry/node").captureBreadcrumb(breadcrumb);
       }
     } catch (e) {
-      logger.log('warn', "Can't captureBreadcrumb", e)
+      logger.log("warn", "Can't captureBreadcrumb", e);
     }
   }
-  */
 };
 
-const captureException = (_error: Error) => {
-  // FIXME
-  /*
+const captureException = (error: Error) => {
   if (!process.env.STORYBOOK_ENV) {
     try {
-      if (typeof window !== 'undefined') {
-        require('sentry/browser').captureException(error)
+      if (typeof window !== "undefined") {
+        require("~/sentry/browser").captureException(error);
       } else {
-        require('sentry/node').captureException(error)
+        require("~/sentry/node").captureException(error);
       }
     } catch (e) {
-      logger.log('warn', "Can't send to sentry", error, e)
+      logger.log("warn", "Can't send to sentry", error, e);
     }
   }
-  */
 };
 
 const logCmds = !process.env.NO_DEBUG_COMMANDS;


### PR DESCRIPTION
This PR should enable sentry again. It use the old (deprecated) implementation called "raven" (we should update that someday).

We need to ensure that we build the app with the SENTRY_URL envvar set or sentry won't work.