### PR TITLE
LL-2282 [Windows] Download and install Visual C++ Redistributable

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,11 @@
+!macro customInstall
+  NSISdl::download "https://aka.ms/vs/16/release/vc_redist.x64.exe" "vc_redist.x64.exe"
+
+  Pop $0
+
+  ${If} $0 == "success"
+    ExecWait '"vc_redist.x64.exe"  /passive /norestart'	
+  ${Else}
+    MessageBox mb_iconstop "Error: $0"
+  ${EndIf}
+!macroend


### PR DESCRIPTION
Download and install the latest Visual C++ Redistributable package from Microsoft at the end of Ledger Live install on Windows.

This should fix the issue for users experiencing a crash at launch.

### Caveats

- Blindly installs the the package, w/o checking if it's needed.
- Probably useless as soon as libcore is compiled with static linking to VC++ libs.

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2282
https://ledgerhq.atlassian.net/browse/LLC-596

### Parts of the app affected / Test plan

- Test if installing still works on Windows, even on computers not showing the crash at start
- Test if it fixes the issue for affected users
