### PR TITLE
show terms and conditions from the about settings page

### DIFF
--- a/src/renderer/modals/Terms/index.js
+++ b/src/renderer/modals/Terms/index.js
@@ -19,7 +19,7 @@ import Modal from "~/renderer/components/Modal";
 import ModalBody from "~/renderer/components/Modal/ModalBody";
 import { closeModal } from "~/renderer/actions/modals";
 
-const TermsModal = () => {
+const TermsModal = ({ showClose = false }: { showClose?: boolean }) => {
   const dispatch = useDispatch();
 
   const [markdown, error] = useTerms();
@@ -36,87 +36,80 @@ const TermsModal = () => {
   }, [onClickClose]);
 
   return (
-    <Modal
-      name="MODAL_TERMS"
-      preventBackdropClick
-      centered
-      render={(
-        { data }: { data?: { showClose: boolean } }, // Why u no get the correct type ?
-      ) => (
-        <ModalBody
-          title={<Trans i18nKey="Terms.title" />}
-          render={() => (
-            <>
-              <TrackPage category="Modal" name="Terms" />
+    <Modal name="MODAL_TERMS" preventBackdropClick centered>
+      <ModalBody
+        title={<Trans i18nKey="Terms.title" />}
+        render={() => (
+          <>
+            <TrackPage category="Modal" name="Terms" />
 
-              {markdown ? (
-                <Terms px={5} pb={8}>
-                  <Markdown>{markdown}</Markdown>
-                </Terms>
-              ) : error ? (
-                <Box grow alignItems="center" justifyContent="space-around">
-                  <Text ff="Inter|SemiBold" fontSize={3}>
-                    <TranslatedError error={error} />
+            {markdown ? (
+              <Terms px={5} pb={8}>
+                <Markdown>{markdown}</Markdown>
+              </Terms>
+            ) : error ? (
+              <Box grow alignItems="center" justifyContent="space-around">
+                <Text ff="Inter|SemiBold" fontSize={3}>
+                  <TranslatedError error={error} />
+                </Text>
+
+                <LinkWithExternalIcon onClick={() => openURL(url)}>
+                  <Trans i18nKey="Terms.read" />
+                </LinkWithExternalIcon>
+              </Box>
+            ) : (
+              <Box horizontal alignItems="center">
+                <Spinner
+                  size={32}
+                  style={{
+                    margin: "auto",
+                  }}
+                />
+              </Box>
+            )}
+          </>
+        )}
+        modalFooterStyle={{ justifyContent: "stretch" }}
+        renderFooter={() => (
+          <Box
+            style={{ position: "relative", width: "100%" }}
+            grow
+            horizontal
+            justifyContent={showClose ? "flex-end" : "space-between"}
+            alignItems="center"
+          >
+            {showClose ? (
+              <Button primary onClick={onClickClose}>
+                <Trans i18nKey="common.close" />
+              </Button>
+            ) : (
+              <>
+                <Box
+                  style={{ width: "75%" }}
+                  horizontal
+                  alignItems="center"
+                  onClick={onSwitchAccept}
+                >
+                  <CheckBox isChecked={accepted} id="terms-checkbox" />
+                  <Text ff="Inter|SemiBold" fontSize={4} style={{ marginLeft: 8, flex: 1 }}>
+                    <Trans i18nKey="Terms.switchLabel" />
                   </Text>
-
-                  <LinkWithExternalIcon onClick={() => openURL(url)}>
-                    <Trans i18nKey="Terms.read" />
-                  </LinkWithExternalIcon>
                 </Box>
-              ) : (
-                <Box horizontal alignItems="center">
-                  <Spinner
-                    size={32}
-                    style={{
-                      margin: "auto",
-                    }}
-                  />
-                </Box>
-              )}
-            </>
-          )}
-          modalFooterStyle={{ justifyContent: "stretch" }}
-          renderFooter={() => (
-            <Box
-              style={{ position: "relative", width: "100%" }}
-              grow
-              horizontal
-              justifyContent={data && data.showClose ? "flex-end" : "space-between"}
-              alignItems="center"
-            >
-              {data && data.showClose ? (
-                <Button primary onClick={onClickClose}>
-                  <Trans i18nKey="common.close" />
+                <Button
+                  style={{ position: "absolute", right: 0 /* flex and <Box> hell */ }}
+                  onClick={onClick}
+                  primary
+                  disabled={!accepted}
+                  id="terms-confirm-button"
+                >
+                  <Trans i18nKey="common.confirm" />
                 </Button>
-              ) : (
-                <>
-                  <Box
-                    style={{ width: "75%" }}
-                    horizontal
-                    alignItems="center"
-                    onClick={onSwitchAccept}
-                  >
-                    <CheckBox isChecked={accepted} id="terms-checkbox" />
-                    <Text ff="Inter|SemiBold" fontSize={4} style={{ marginLeft: 8, flex: 1 }}>
-                      <Trans i18nKey="Terms.switchLabel" />
-                    </Text>
-                  </Box>
-                  <Button
-                    style={{ position: "absolute", right: 0 /* flex and <Box> hell */ }}
-                    onClick={onClick}
-                    primary
-                    disabled={!accepted}
-                    id="terms-confirm-button"
-                  >
-                    <Trans i18nKey="common.confirm" />
-                  </Button>
-                </>
-              )}
-            </Box>
-          )}
-        />
-      )}
-    />
+              </>
+            )}
+          </Box>
+        )}
+      />
+    </Modal>
   );
 };
 

--- a/src/renderer/modals/Terms/index.js
+++ b/src/renderer/modals/Terms/index.js
@@ -26,73 +26,97 @@ const TermsModal = () => {
   const [accepted, setAccepted] = useState(false);
   const onSwitchAccept = useCallback(() => setAccepted(!accepted), [accepted]);
 
-  const onClick = useCallback(() => {
-    acceptTerms();
+  const onClickClose = useCallback(() => {
     dispatch(closeModal("MODAL_TERMS"));
   }, [dispatch]);
 
+  const onClick = useCallback(() => {
+    acceptTerms();
+    onClickClose();
+  }, [onClickClose]);
+
   return (
-    <Modal name="MODAL_TERMS" preventBackdropClick centered>
-      <ModalBody
-        title={<Trans i18nKey="Terms.title" />}
-        render={() => (
-          <>
-            <TrackPage category="Modal" name="Terms" />
+    <Modal
+      name="MODAL_TERMS"
+      preventBackdropClick
+      centered
+      render={(
+        { data }: { data?: { showClose: boolean } }, // Why u no get the correct type ?
+      ) => (
+        <ModalBody
+          title={<Trans i18nKey="Terms.title" />}
+          render={() => (
+            <>
+              <TrackPage category="Modal" name="Terms" />
 
-            {markdown ? (
-              <Terms px={5} pb={8}>
-                <Markdown>{markdown}</Markdown>
-              </Terms>
-            ) : error ? (
-              <Box grow alignItems="center" justifyContent="space-around">
-                <Text ff="Inter|SemiBold" fontSize={3}>
-                  <TranslatedError error={error} />
-                </Text>
+              {markdown ? (
+                <Terms px={5} pb={8}>
+                  <Markdown>{markdown}</Markdown>
+                </Terms>
+              ) : error ? (
+                <Box grow alignItems="center" justifyContent="space-around">
+                  <Text ff="Inter|SemiBold" fontSize={3}>
+                    <TranslatedError error={error} />
+                  </Text>
 
-                <LinkWithExternalIcon onClick={() => openURL(url)}>
-                  <Trans i18nKey="Terms.read" />
-                </LinkWithExternalIcon>
-              </Box>
-            ) : (
-              <Box horizontal alignItems="center">
-                <Spinner
-                  size={32}
-                  style={{
-                    margin: "auto",
-                  }}
-                />
-              </Box>
-            )}
-          </>
-        )}
-        modalFooterStyle={{ justifyContent: "stretch" }}
-        renderFooter={() => (
-          <Box
-            style={{ position: "relative", width: "100%" }}
-            grow
-            horizontal
-            justifyContent="space-between"
-            alignItems="center"
-          >
-            <Box style={{ width: "75%" }} horizontal alignItems="center" onClick={onSwitchAccept}>
-              <CheckBox isChecked={accepted} id="terms-checkbox" />
-              <Text ff="Inter|SemiBold" fontSize={4} style={{ marginLeft: 8, flex: 1 }}>
-                <Trans i18nKey="Terms.switchLabel" />
-              </Text>
-            </Box>
-            <Button
-              style={{ position: "absolute", right: 0 /* flex and <Box> hell */ }}
-              onClick={onClick}
-              primary
-              disabled={!accepted}
-              id="terms-confirm-button"
+                  <LinkWithExternalIcon onClick={() => openURL(url)}>
+                    <Trans i18nKey="Terms.read" />
+                  </LinkWithExternalIcon>
+                </Box>
+              ) : (
+                <Box horizontal alignItems="center">
+                  <Spinner
+                    size={32}
+                    style={{
+                      margin: "auto",
+                    }}
+                  />
+                </Box>
+              )}
+            </>
+          )}
+          modalFooterStyle={{ justifyContent: "stretch" }}
+          renderFooter={() => (
+            <Box
+              style={{ position: "relative", width: "100%" }}
+              grow
+              horizontal
+              justifyContent={data && data.showClose ? "flex-end" : "space-between"}
+              alignItems="center"
             >
-              <Trans i18nKey="common.confirm" />
-            </Button>
-          </Box>
-        )}
-      />
-    </Modal>
+              {data && data.showClose ? (
+                <Button primary onClick={onClickClose}>
+                  <Trans i18nKey="common.close" />
+                </Button>
+              ) : (
+                <>
+                  <Box
+                    style={{ width: "75%" }}
+                    horizontal
+                    alignItems="center"
+                    onClick={onSwitchAccept}
+                  >
+                    <CheckBox isChecked={accepted} id="terms-checkbox" />
+                    <Text ff="Inter|SemiBold" fontSize={4} style={{ marginLeft: 8, flex: 1 }}>
+                      <Trans i18nKey="Terms.switchLabel" />
+                    </Text>
+                  </Box>
+                  <Button
+                    style={{ position: "absolute", right: 0 /* flex and <Box> hell */ }}
+                    onClick={onClick}
+                    primary
+                    disabled={!accepted}
+                    id="terms-confirm-button"
+                  >
+                    <Trans i18nKey="common.confirm" />
+                  </Button>
+                </>
+              )}
+            </Box>
+          )}
+        />
+      )}
+    />
   );
 };
 

--- a/src/renderer/screens/settings/sections/About/TermsButton.js
+++ b/src/renderer/screens/settings/sections/About/TermsButton.js
@@ -1,0 +1,27 @@
+// @flow
+
+import React, { useCallback } from "react";
+import { useDispatch } from "react-redux";
+import { useTranslation } from "react-i18next";
+import { openModal } from "~/renderer/actions/modals";
+import Button from "~/renderer/components/Button";
+
+const TermsButton = () => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+  const onClick = useCallback(
+    (e: SyntheticEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      dispatch(openModal("MODAL_TERMS", { showClose: true }));
+    },
+    [dispatch],
+  );
+
+  return (
+    <Button small primary onClick={onClick}>
+      {t("settings.help.termsBtn")}
+    </Button>
+  );
+};
+
+export default TermsButton;

--- a/src/renderer/screens/settings/sections/About/index.js
+++ b/src/renderer/screens/settings/sections/About/index.js
@@ -13,6 +13,7 @@ import {
 } from "../../SettingsSection";
 import RowItem from "../../RowItem";
 import ReleaseNotesButton from "./ReleaseNotesButton";
+import TermsButton from "./TermsButton";
 
 const SectionHelp = () => {
   const { t } = useTranslation();
@@ -33,11 +34,9 @@ const SectionHelp = () => {
           <ReleaseNotesButton />
         </Row>
 
-        <RowItem
-          title={t("settings.help.terms")}
-          desc={t("settings.help.termsDesc")}
-          url={urls.terms}
-        />
+        <Row title={t("settings.help.terms")} desc={t("settings.help.termsDesc")}>
+          <TermsButton />
+        </Row>
 
         <RowItem
           title={t("settings.help.privacy")}

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -923,6 +923,7 @@
       "desc": "Learn more about Ledger Live or get help.",
       "version": "Version",
       "releaseNotesBtn": "Details",
+      "termsBtn": "Read",
       "faq": "Ledger Support",
       "faqDesc": "A problem? Get help using Ledger Live with your hardware wallet.",
       "terms": "Terms of Use",


### PR DESCRIPTION
Adds the Terms and Condition Modal to the Settings > About page

### Type

Feat

### Context

LL-2311 

### Parts of the app affected / Test plan

Settings > About > Terms and Conditions

![image](https://user-images.githubusercontent.com/671786/77085047-11d5f400-6a00-11ea-86f3-f91a23785365.png)

![image](https://user-images.githubusercontent.com/671786/77085083-1e5a4c80-6a00-11ea-8177-b4389a1dc4d8.png)

