### PR TITLE
disable firm update button while installing apps + remount after update

### DIFF
--- a/src/renderer/screens/manager/AppsList/index.js
+++ b/src/renderer/screens/manager/AppsList/index.js
@@ -51,9 +51,10 @@ type Props = {
   result: ListAppsResult,
   exec: Exec,
   t: TFunction,
+  render?: boolean => React$Node,
 };
 
-const AppsList = ({ deviceInfo, result, exec, t }: Props) => {
+const AppsList = ({ deviceInfo, result, exec, t, render }: Props) => {
   const [state, dispatch] = useAppsRunner(result, exec);
   const [appInstallDep, setAppInstallDep] = useState(undefined);
   const [appUninstallDep, setAppUninstallDep] = useState(undefined);
@@ -93,62 +94,67 @@ const AppsList = ({ deviceInfo, result, exec, t }: Props) => {
     }
   }, [state.installed.length, reduxDispatch, hasInstalledApps]);
 
+  const disableFirmwareUpdate = state.installQueue.length > 0 || state.uninstallQueue.length > 0;
+
   return (
-    <Container>
-      {currentError && (
-        <ErrorModal isOpened={!!currentError} error={currentError.error} onClose={onCloseError} />
-      )}
-      <NavigationGuard
-        analyticsName="ManagerGuardModal"
-        when={jobInProgress}
-        subTitle={
-          <>
-            <QuitIconWrapper>
-              <Quit size={30} />
-            </QuitIconWrapper>
-            {t(`errors.ManagerQuitPage.${installState}.title`)}
-          </>
-        }
-        desc={t(`errors.ManagerQuitPage.${installState}.description`)}
-        confirmText={t(`errors.ManagerQuitPage.${installState}.stay`)}
-        cancelText={t(`errors.ManagerQuitPage.quit`)}
-        centered
-      />
-      <DeviceStorage
-        jobInProgress={jobInProgress}
-        uninstallQueue={uninstallQueue}
-        installQueue={installQueue}
-        distribution={distribution}
-        deviceModel={state.deviceModel}
-        deviceInfo={deviceInfo}
-        isIncomplete={isIncomplete}
-      />
-      <AppList
-        deviceInfo={deviceInfo}
-        state={state}
-        dispatch={dispatch}
-        isIncomplete={isIncomplete}
-        setAppInstallDep={setAppInstallDep}
-        setAppUninstallDep={setAppUninstallDep}
-        t={t}
-        distribution={distribution}
-      />
-      <AppDepsInstallModal
-        app={appInstallDep && appInstallDep.app}
-        dependencies={appInstallDep && appInstallDep.dependencies}
-        appList={state.apps}
-        dispatch={dispatch}
-        onClose={onCloseDepsInstallModal}
-      />
-      <AppDepsUnInstallModal
-        app={appUninstallDep && appUninstallDep.app}
-        dependents={appUninstallDep && appUninstallDep.dependents}
-        appList={state.apps}
-        installed={state.installed}
-        dispatch={dispatch}
-        onClose={onCloseDepsUninstallModal}
-      />
-    </Container>
+    <>
+      {render ? render(disableFirmwareUpdate) : null}
+      <Container>
+        {currentError && (
+          <ErrorModal isOpened={!!currentError} error={currentError.error} onClose={onCloseError} />
+        )}
+        <NavigationGuard
+          analyticsName="ManagerGuardModal"
+          when={jobInProgress}
+          subTitle={
+            <>
+              <QuitIconWrapper>
+                <Quit size={30} />
+              </QuitIconWrapper>
+              {t(`errors.ManagerQuitPage.${installState}.title`)}
+            </>
+          }
+          desc={t(`errors.ManagerQuitPage.${installState}.description`)}
+          confirmText={t(`errors.ManagerQuitPage.${installState}.stay`)}
+          cancelText={t(`errors.ManagerQuitPage.quit`)}
+          centered
+        />
+        <DeviceStorage
+          jobInProgress={jobInProgress}
+          uninstallQueue={uninstallQueue}
+          installQueue={installQueue}
+          distribution={distribution}
+          deviceModel={state.deviceModel}
+          deviceInfo={deviceInfo}
+          isIncomplete={isIncomplete}
+        />
+        <AppList
+          deviceInfo={deviceInfo}
+          state={state}
+          dispatch={dispatch}
+          isIncomplete={isIncomplete}
+          setAppInstallDep={setAppInstallDep}
+          setAppUninstallDep={setAppUninstallDep}
+          t={t}
+          distribution={distribution}
+        />
+        <AppDepsInstallModal
+          app={appInstallDep && appInstallDep.app}
+          dependencies={appInstallDep && appInstallDep.dependencies}
+          appList={state.apps}
+          dispatch={dispatch}
+          onClose={onCloseDepsInstallModal}
+        />
+        <AppDepsUnInstallModal
+          app={appUninstallDep && appUninstallDep.app}
+          dependents={appUninstallDep && appUninstallDep.dependents}
+          appList={state.apps}
+          installed={state.installed}
+          dispatch={dispatch}
+          onClose={onCloseDepsUninstallModal}
+        />
+      </Container>
+    </>
   );
 };
 

--- a/src/renderer/screens/manager/FirmwareUpdate/UpdateFirmwareButton.js
+++ b/src/renderer/screens/manager/FirmwareUpdate/UpdateFirmwareButton.js
@@ -12,9 +12,10 @@ type Props = {
   firmware: { osu: OsuFirmware, final: FinalFirmware },
   onClick: () => void,
   deviceInfo: DeviceInfo,
+  disabled?: boolean,
 };
 
-const UpdateFirmwareButton = ({ firmware, onClick, deviceInfo }: Props) => {
+const UpdateFirmwareButton = ({ firmware, onClick, deviceInfo, disabled = false }: Props) => {
   const { t } = useTranslation();
 
   return (
@@ -25,6 +26,7 @@ const UpdateFirmwareButton = ({ firmware, onClick, deviceInfo }: Props) => {
       eventProperties={{
         firmwareName: firmware.final.name,
       }}
+      disabled={disabled}
     >
       {t("manager.firmware.updateBtn")}
     </Button>

--- a/src/renderer/screens/manager/FirmwareUpdate/index.js
+++ b/src/renderer/screens/manager/FirmwareUpdate/index.js
@@ -21,6 +21,7 @@ type Props = {
   deviceInfo: DeviceInfo,
   device: Device,
   setFirmwareUpdateOpened: boolean => void,
+  disableFirmwareUpdate?: boolean,
 };
 
 type State = {
@@ -47,6 +48,10 @@ const initializeState = (props: Props): State => ({
 });
 
 class FirmwareUpdate extends PureComponent<Props, State> {
+  static defaultProps = {
+    disableFirmwareUpdate: false,
+  };
+
   state = initializeState(this.props);
 
   async componentDidMount() {
@@ -88,7 +93,7 @@ class FirmwareUpdate extends PureComponent<Props, State> {
   handleDisclaimerNext = () => this.setState({ modal: "install" });
 
   render() {
-    const { deviceInfo, device, setFirmwareUpdateOpened } = this.props;
+    const { deviceInfo, device, setFirmwareUpdateOpened, disableFirmwareUpdate } = this.props;
     const { firmware, modal, stepId, ready, error } = this.state;
 
     if (!firmware) return null;
@@ -126,6 +131,7 @@ class FirmwareUpdate extends PureComponent<Props, State> {
           deviceInfo={deviceInfo}
           firmware={firmware}
           onClick={this.handleDisclaimerModal}
+          disabled={disableFirmwareUpdate}
         />
 
         {ready ? (


### PR DESCRIPTION
Disable firmware update button if user is installing/uninstalling apps
Remount manager after a firmware update

### Type

Feature

### Context

LL-2321

### Parts of the app affected / Test plan

Manager
