### PR TITLE
Add hidden inputs to checkbox/switch components for better QA

### DIFF
--- a/src/renderer/components/CheckBox.js
+++ b/src/renderer/components/CheckBox.js
@@ -15,6 +15,9 @@ const Base: ThemedComponent<{
   alignItems: "center",
   justifyContent: "center",
 }))`
+  & input[type="checkbox"] {
+    display: none;
+  }
   outline: none;
   border-radius: ${p => (p.isRadio ? 24 : 4)}px;
   cursor: pointer;
@@ -53,6 +56,7 @@ function CheckBox(props: Props) {
       disabled={disabled}
       onClick={() => onChange && onChange(!isChecked)}
     >
+      <input type="checkbox" disabled={disabled || null} checked={isChecked || null} />
       <Check size={12} />
     </Base>
   );

--- a/src/renderer/components/Switch.js
+++ b/src/renderer/components/Switch.js
@@ -15,6 +15,9 @@ const Base: ThemedComponent<{
   horizontal: true,
   alignItems: "center",
 }))`
+  & input[type="checkbox"] {
+    display: none;
+  }
   width: ${p => (p.small ? 25 : 40)}px;
   height: ${p => (p.small ? 13 : 24)}px;
   border-radius: 13px;
@@ -42,19 +45,22 @@ const Ball = styled.div`
 
 type Props = {
   isChecked: boolean,
+  disabled?: boolean,
   onChange?: Function,
   small?: boolean,
 };
 
 function Switch(props: Props) {
-  const { isChecked, onChange, small, ...p } = props;
+  const { isChecked, onChange, small, disabled, ...p } = props;
   return (
     <Base
       {...p}
+      disabled={disabled}
       small={small}
       isChecked={isChecked}
       onClick={() => onChange && onChange(!isChecked)}
     >
+      <input type="checkbox" disabled={disabled || null} checked={isChecked || null} />
       <Ball small={small} isChecked={isChecked} />
     </Base>
   );


### PR DESCRIPTION
In order to allow automation and testing libraries to work properly, we need to maintain the standard input dom elements (hidden in our case even if it's not ideal) so as to have access to things like `.checked` which wouldn't be available on a normal div element.

### Type

QA related improvements