### PR TITLE
LL-2324 TOU modal enable keyboard navigation

### DIFF
--- a/src/renderer/components/CheckBox.js
+++ b/src/renderer/components/CheckBox.js
@@ -51,7 +51,10 @@ function CheckBox(props: Props) {
       isRadio={isRadio}
       isChecked={isChecked}
       disabled={disabled}
-      onClick={() => onChange && onChange(!isChecked)}
+      onClick={e => {
+        e.stopPropagation();
+        onChange && onChange(!isChecked);
+      }}
     >
       <Check size={12} />
     </Base>

--- a/src/renderer/modals/DisclaimerModal/index.js
+++ b/src/renderer/modals/DisclaimerModal/index.js
@@ -82,6 +82,8 @@ class DisclaimerModal extends PureComponent<Props, State> {
     this.props.onClose();
   }
 
+  onSeedReady = () => this.setState(state => ({ seedReady: !state.seedReady }));
+
   render(): React$Node {
     const { status, firmware, onClose, t, goToNextStep } = this.props;
     const { showUninsWarning } = this.state;
@@ -184,13 +186,8 @@ class DisclaimerModal extends PureComponent<Props, State> {
           renderFooter={() => (
             <Box horizontal justifyContent="flex-end" alignItems="center" style={{ flex: 1 }}>
               {!showUninsWarning ? (
-                <Box
-                  horizontal
-                  alignItems="center"
-                  onClick={() => this.setState(state => ({ seedReady: !state.seedReady }))}
-                  style={{ flex: 1 }}
-                >
-                  <CheckBox isChecked={this.state.seedReady} />
+                <Box horizontal alignItems="center" onClick={this.onSeedReady} style={{ flex: 1 }}>
+                  <CheckBox isChecked={this.state.seedReady} onChange={this.onSeedReady} />
                   <Text
                     ff="Inter|SemiBold"
                     fontSize={4}

--- a/src/renderer/modals/Terms/index.js
+++ b/src/renderer/modals/Terms/index.js
@@ -90,7 +90,7 @@ const TermsModal = ({ showClose = false }: { showClose?: boolean }) => {
                   alignItems="center"
                   onClick={onSwitchAccept}
                 >
-                  <CheckBox isChecked={accepted} id="terms-checkbox" />
+                  <CheckBox isChecked={accepted} onChange={onSwitchAccept} id="terms-checkbox" />
                   <Text ff="Inter|SemiBold" fontSize={4} style={{ marginLeft: 8, flex: 1 }}>
                     <Trans i18nKey="Terms.switchLabel" />
                   </Text>


### PR DESCRIPTION
The checkbox was working because it triggered the wrapper box click handler not a click on the checkbox itself, that's why space / enter did nothing. In fixing this I noticed that the firmware update also suffered from this issue and some others (https://ledgerhq.atlassian.net/browse/LL-2339). In order to not go out of the scope of the linked jira task I've limited my fix to only the checkbox keyboard actions.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2324

### Parts of the app affected / Test plan
Terms of use modal should be able to be navigated only by tab+enter/space
Firmware update disclaimer modal should be able to be accepted only with keyboard.