### PR TITLE
LL-2298 Refactor OnboardingFooterWrapper

### DIFF
--- a/src/renderer/screens/onboarding/OnboardingFooter.js
+++ b/src/renderer/screens/onboarding/OnboardingFooter.js
@@ -6,27 +6,54 @@ import Button from "~/renderer/components/Button";
 import { OnboardingFooterWrapper } from "./sharedComponents";
 
 type Props = {
-  nextStep: () => void,
-  prevStep: () => void,
+  nextStep?: () => void,
+  prevStep?: () => void,
   isContinueDisabled?: boolean,
+  isBackDisabled?: boolean,
+  left?: ?React$Node,
+  right?: ?React$Node,
 };
 
-const OnboardingFooter = ({ nextStep, prevStep, isContinueDisabled, ...props }: Props) => {
+const OnboardingFooter = ({
+  nextStep,
+  prevStep,
+  isBackDisabled,
+  isContinueDisabled,
+  left,
+  right,
+  ...props
+}: Props) => {
   const { t } = useTranslation();
+
   return (
     <OnboardingFooterWrapper {...props}>
-      <Button outlineGrey onClick={() => prevStep()} id="onboarding-back-button">
-        {t("common.back")}
-      </Button>
-      <Button
-        disabled={isContinueDisabled}
-        primary
-        onClick={() => nextStep()}
-        ml="auto"
-        id="onboarding-continue-button"
-      >
-        {t("common.continue")}
-      </Button>
+      {left ||
+        (prevStep ? (
+          <Button
+            disabled={isBackDisabled}
+            outlineGrey
+            onClick={prevStep}
+            id="onboarding-back-button"
+          >
+            {t("common.back")}
+          </Button>
+        ) : (
+          <div />
+        ))}
+      {right ||
+        (nextStep ? (
+          <Button
+            disabled={isContinueDisabled}
+            primary
+            onClick={() => nextStep()}
+            ml="auto"
+            id="onboarding-continue-button"
+          >
+            {t("common.continue")}
+          </Button>
+        ) : (
+          <div />
+        ))}
     </OnboardingFooterWrapper>
   );
 };

--- a/src/renderer/screens/onboarding/steps/GenuineCheck/GenuineCheckErrorPage.js
+++ b/src/renderer/screens/onboarding/steps/GenuineCheck/GenuineCheckErrorPage.js
@@ -11,11 +11,11 @@ import LedgerNanoX from "~/renderer/images/ledger-nano-x-error-onb.svg";
 import type { OnboardingState } from "~/renderer/reducers/onboarding";
 import InvertableImg from "~/renderer/components/InvertableImg";
 import Box from "~/renderer/components/Box";
-import Button from "~/renderer/components/Button";
 import ExternalLinkButton from "~/renderer/components/ExternalLinkButton";
 import TrackPage from "~/renderer/analytics/TrackPage";
 
-import { Title, Description, OnboardingFooterWrapper } from "../../sharedComponents";
+import { Title, Description } from "../../sharedComponents";
+import OnboardingFooter from "~/renderer/screens/onboarding/OnboardingFooter";
 
 const Img = ({ type }: { type: string }) => {
   switch (type) {
@@ -89,18 +89,18 @@ class GenuineCheckErrorPage extends PureComponent<Props, *> {
         <Box grow alignItems="center" justifyContent="center">
           {this.renderErrorPage()}
         </Box>
-        <OnboardingFooterWrapper>
-          <Button outlineGrey onClick={() => redoGenuineCheck()} id="onboarding-back-button">
-            <Trans i18nKey="common.back" />
-          </Button>
-          <ExternalLinkButton
-            danger
-            ml="auto"
-            label={<Trans i18nKey="onboarding.genuineCheck.buttons.contactSupport" />}
-            url={urls.contactSupport}
-            id="onboarding-contactus-button"
-          />
-        </OnboardingFooterWrapper>
+        <OnboardingFooter
+          prevStep={redoGenuineCheck}
+          right={
+            <ExternalLinkButton
+              danger
+              ml="auto"
+              label={<Trans i18nKey="onboarding.genuineCheck.buttons.contactSupport" />}
+              url={urls.contactSupport}
+              id="onboarding-contactus-button"
+            />
+          }
+        />
       </Box>
     );
   }

--- a/src/renderer/screens/onboarding/steps/NoDevice.js
+++ b/src/renderer/screens/onboarding/steps/NoDevice.js
@@ -11,10 +11,10 @@ import LedgerLiveLogo from "~/renderer/components/LedgerLiveLogo";
 import LedgerLiveImg from "~/renderer/images/ledgerlive-logo.svg";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { OptionFlowCard } from "~/renderer/screens/onboarding/steps/Init";
-import Button from "~/renderer/components/Button";
 import Image from "~/renderer/components/Image";
-import { Title, OnboardingFooterWrapper } from "../sharedComponents";
+import { Title } from "../sharedComponents";
 import type { StepProps } from "..";
+import OnboardingFooter from "~/renderer/screens/onboarding/OnboardingFooter";
 
 class NoDevice extends PureComponent<StepProps, *> {
   render() {
@@ -63,11 +63,7 @@ class NoDevice extends PureComponent<StepProps, *> {
             </Box>
           </Box>
         </GrowScroll>
-        <OnboardingFooterWrapper>
-          <Button outlineGrey onClick={() => prevStep()} mr="auto" id="onboarding-back-button">
-            <Trans i18nKey="common.back" />
-          </Button>
-        </OnboardingFooterWrapper>
+        <OnboardingFooter prevStep={prevStep} />
       </Box>
     );
   }

--- a/src/renderer/screens/onboarding/steps/SetPassword.js
+++ b/src/renderer/screens/onboarding/steps/SetPassword.js
@@ -9,7 +9,6 @@ import {
   Description,
   DisclaimerBox,
   FixedTopContainer,
-  OnboardingFooterWrapper,
   StepContainerInner,
   Title,
 } from "~/renderer/screens/onboarding/sharedComponents";
@@ -22,6 +21,7 @@ import type { StepProps } from "~/renderer/screens/onboarding";
 import { setHasPassword } from "~/renderer/actions/application";
 import { hasPasswordSelector } from "~/renderer/reducers/application";
 import { createStructuredSelector } from "reselect";
+import OnboardingFooter from "~/renderer/screens/onboarding/OnboardingFooter";
 
 type State = {
   currentPassword: string,
@@ -134,29 +134,30 @@ class SetPassword extends PureComponent<Props, State> {
           </>
         </StepContainerInner>
 
-        <OnboardingFooterWrapper>
-          <Button outlineGrey onClick={() => prevStep()}>
-            {t("common.back")}
-          </Button>
-          <Box horizontal ml="auto">
-            <Button
-              event="Onboarding Skip Password"
-              onClick={() => nextStep()}
-              disabled={false}
-              mx={2}
-            >
-              {t("common.skipThisStep")}
-            </Button>
-            <Button
-              onClick={this.handleSave}
-              disabled={!this.isValid() || !newPassword.length || !confirmPassword.length}
-              primary
-              id="modal-continue-button"
-            >
-              {t("common.continue")}
-            </Button>
-          </Box>
-        </OnboardingFooterWrapper>
+        <OnboardingFooter
+          prevStep={prevStep}
+          right={
+            <Box horizontal ml="auto">
+              <Button
+                event="Onboarding Skip Password"
+                id="onboarding-password-skip-button"
+                onClick={() => nextStep()}
+                disabled={false}
+                mx={2}
+              >
+                {t("common.skipThisStep")}
+              </Button>
+              <Button
+                id="onboarding-password-continue-button"
+                onClick={this.handleSave}
+                disabled={!this.isValid() || !newPassword.length || !confirmPassword.length}
+                primary
+              >
+                {t("common.continue")}
+              </Button>
+            </Box>
+          }
+        />
       </FixedTopContainer>
     );
   }


### PR DESCRIPTION
This should allow @nabil-brn to write cleaner tests for onboarding according to my understanding of the situation. Some screens such as the password one on onboarding do have custom ids that will need to be set manually since the buttons are different. Do take a look.

### Type

QA feature

### Context

https://ledgerhq.atlassian.net/browse/LL-2298

### Parts of the app affected / Test plan

Onboarding in general, all steps with a footer should now use the `OnboardingFooter` component