### PR TITLE
Prevent little jump in onboarding security check steps

### DIFF
--- a/src/renderer/screens/onboarding/sharedComponents.js
+++ b/src/renderer/screens/onboarding/sharedComponents.js
@@ -108,6 +108,7 @@ export const GenuineCheckCardWrapper: ThemedComponent<{}> = styled(Box).attrs(()
   borderRadius: "4px",
   justifyContent: "flex-start",
 }))`
+  min-height: 102px;
   width: 580px;
   transition: all ease-in-out 0.2s;
   color: ${p =>


### PR DESCRIPTION
Super minor polish but since I've been seeing the onboarding flow a lot lately I started to get triggered by it. The security steps grew a little bit between the initial state and the state with the YES/NO buttons. Increasing the minimum height of the component prevents this and, in my opinion, makes it look a lot smoother.

> Note that the before/after shots are overlays of the initial state and the end state of that step with a multiplying effect on the layers. All the artifacts we see in the UI for the screenshots are a consequence of demonstrating how the current develop version is a tiny bit offset. 


### Before
![image](https://user-images.githubusercontent.com/4631227/77806408-e77dd980-7084-11ea-9abe-b2d273df7cf5.png)


### After
![image](https://user-images.githubusercontent.com/4631227/77806479-1eec8600-7085-11ea-8417-0a457c2482c7.png)

### Gif
See how it doesn't jump when we select Yes and the next step gets enabled? Well, is used to and once you see it you can't unsee it. Did I take x20 times longer writing this than the code itself, obviously yes.

![fixed](https://user-images.githubusercontent.com/4631227/77806688-a89c5380-7085-11ea-832d-6eef17140fa9.gif)


### Type

UI Polish

### Parts of the app affected / Test plan

Onboarding security check step
