### PR TITLE
use team-live as user to make the push to develop

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -12,15 +12,6 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 12.x
-      - name: get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: install dependencies
         run: yarn --ignore-scripts --frozen-lockfile
       - name: build the app

--- a/.github/workflows/bundle-app.yml
+++ b/.github/workflows/bundle-app.yml
@@ -17,15 +17,6 @@ jobs:
         run: |
           git config user.email "team-live@ledger.fr"
           git config user.name "Team Live"
-      - name: get yarn cache
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: install dependencies
         run: yarn --ignore-scripts --frozen-lockfile
       - uses: ledgerhq/actions/get-package-infos@v1.0.0

--- a/.github/workflows/tag-nightly.yml
+++ b/.github/workflows/tag-nightly.yml
@@ -37,16 +37,7 @@ jobs:
       - name: push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ACCESS_TOKEN_TEAM_LIVE }}
           branch: develop
           force: true
-      - name: push tag
-        run: |
-          curl -s -X POST https://api.github.com/repos/LedgerHQ/${{ steps.config.outputs.repo }}/git/refs \
-          -H "Authorization: token ${{ secrets.ACCESS_TOKEN_VAL }}" \
-          -d @- << EOF
-          {
-            "ref": "refs/tags/${{ steps.config.outputs.nightly }}",
-            "sha": "${{ steps.config.outputs.commit }}"
-          }
-          EOF
+          tags: true


### PR DESCRIPTION
Nightlies were not be triggered because the user creating the commit inside the action, was "github", and does not have rights to push to develop

We are switching to the "Team Live" user 

I had to create a secrets to give to the action to authenticate team-live

### Type

CI