### PR TITLE
Added a simple countermeasure against clipboard hijacking attacks

### DIFF
--- a/src/renderer/components/ReadOnlyAddressField.js
+++ b/src/renderer/components/ReadOnlyAddressField.js
@@ -35,6 +35,14 @@ const CopyFeedback = styled(Box).attrs(() => ({
   border-left: 1px solid ${p => p.theme.colors.palette.divider};
 `;
 
+const ClipboardSuspicious = styled.div`
+  font-family: Inter;
+  font-weight: 400;
+  font-style: normal;
+  font-size: 12px;
+  color: ${p => p.theme.colors.alertRed};
+`;
+
 const CopyBtn = styled(Box).attrs(() => ({
   bg: "palette.background.paper",
   color: "palette.text.shade100",
@@ -58,6 +66,7 @@ type Props = {
 
 function ReadOnlyAddressField({ address }: Props) {
   const [copyFeedback, setCopyFeedback] = useState(false);
+  const [clibboardChanged, setClipboardChanged] = useState(false);
 
   const copyTimeout = useRef();
 
@@ -65,6 +74,12 @@ function ReadOnlyAddressField({ address }: Props) {
     clipboard.writeText(address);
     setCopyFeedback(true);
     clearTimeout(copyTimeout.current);
+    setTimeout(() => {
+      const copiedAddress = clipboard.readText();
+      if (copiedAddress !== address) {
+        setClipboardChanged(true);
+      }
+    }, 300);
     copyTimeout.current = setTimeout(() => setCopyFeedback(false), 1e3);
   }, [address]);
 
@@ -75,19 +90,25 @@ function ReadOnlyAddressField({ address }: Props) {
   }, []);
 
   return (
-    <Box horizontal alignItems="stretch">
-      <Address>
-        {!copyFeedback ? null : (
-          <CopyFeedback>
-            <Trans i18nKey="common.addressCopied" />
-          </CopyFeedback>
-        )}
-        {address}
-      </Address>
-
-      <CopyBtn onClick={onCopy}>
-        <IconCopy size={16} />
-      </CopyBtn>
+    <Box vertical alignItems="center">
+      {clibboardChanged ? (
+        <ClipboardSuspicious>
+          <Trans i18nKey="common.addressCopiedSuspicious" />
+        </ClipboardSuspicious>
+      ) : null}
+      <Box horizontal alignItems="stretch">
+        <Address>
+          {!copyFeedback ? null : (
+            <CopyFeedback>
+              <Trans i18nKey="common.addressCopied" />
+            </CopyFeedback>
+          )}
+          {address}
+        </Address>
+        <CopyBtn onClick={onCopy}>
+          <IconCopy size={16} />
+        </CopyBtn>
+      </Box>
     </Box>
   );
 }

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -41,6 +41,7 @@
     "copy": "Copy",
     "copied": "Copied",
     "addressCopied": "Address copied",
+    "addressCopiedSuspicious": "Mismatch between the copied address and the one in the clipboard.",
     "experimentalFeature": "Experimental",
     "dismiss": "Dismiss",
     "information": "Information",


### PR DESCRIPTION
A few milliseconds after copying an address, we now verify the clipboard and match its content to the original address. If it doesn't match, we display an error for the user to see.

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
![image](https://user-images.githubusercontent.com/9251185/78227978-65e7da80-74ce-11ea-8942-50671a3cd89c.png)

QA: You can actually trigger it if you copy the address and then copy something else within the 300 ms 😄 I was able to do it with a clever alt tab