### PR TITLE
Fallback to USD when the user selected fiat counterValue is not supported

### DIFF
--- a/src/renderer/screens/settings/sections/General/CounterValueSelect.js
+++ b/src/renderer/screens/settings/sections/General/CounterValueSelect.js
@@ -2,18 +2,10 @@
 
 import React, { useCallback, useMemo } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import { listSupportedFiats } from "@ledgerhq/live-common/lib/currencies";
 import { setCounterValue } from "~/renderer/actions/settings";
-import { counterValueCurrencySelector, possibleIntermediaries } from "~/renderer/reducers/settings";
+import { counterValueCurrencySelector, supportedCountervalues } from "~/renderer/reducers/settings";
 import Select from "~/renderer/components/Select";
 import Track from "~/renderer/analytics/Track";
-
-// TODO allow more cryptos as countervalues, then refactor this to common
-const currencies = [...listSupportedFiats(), ...possibleIntermediaries].map(currency => ({
-  value: currency.ticker,
-  label: `${currency.name} - ${currency.ticker}`,
-  currency,
-}));
 
 const CounterValueSelect = () => {
   const counterValueCurrency = useSelector(counterValueCurrencySelector);
@@ -26,9 +18,10 @@ const CounterValueSelect = () => {
     [dispatch],
   );
 
-  const cvOption = useMemo(() => currencies.find(f => f.value === counterValueCurrency.ticker), [
-    counterValueCurrency,
-  ]);
+  const cvOption = useMemo(
+    () => supportedCountervalues.find(f => f.value === counterValueCurrency.ticker),
+    [counterValueCurrency],
+  );
 
   return (
     <>
@@ -39,7 +32,7 @@ const CounterValueSelect = () => {
         onChange={handleChangeCounterValue}
         itemToString={item => (item ? item.name : "")}
         renderSelected={item => item && item.name}
-        options={currencies}
+        options={counterValueCurrency}
         value={cvOption}
       />
     </>


### PR DESCRIPTION
This pr introduces the automatic fallback to using USD as a counter value when the currently selected counter value is not reported as supported. Without this, users who have selected a non-supported fiat counter value will see their total balances and graphs as broken.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Feature

### Context

Slack conversation, no Jira task as far as I know

### Parts of the app affected / Test plan

With the application stopped, edit your `app.json` and set the counter value to something not supported (but contemplated in https://github.com/LedgerHQ/ledger-live-common/blob/1a29a3bc5f533ee29e0a47c577a1a7e068546e0b/src/data/fiat.js#L23-L73 and then launch the application. It should automagically start using USD instead of VND or whatever non-supported fiat you chose.