### PR TITLE
Fixes device step to match exactly what happens on device

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@ledgerhq/hw-transport-http": "^5.12.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.12.0",
     "@ledgerhq/ledger-core": "^6.2.1",
-    "@ledgerhq/live-common": "^12.12.2",
+    "@ledgerhq/live-common": "^12.13.0",
     "@ledgerhq/logs": "^5.11.0",
     "@tippy.js/react": "^3.1.1",
     "@trust/keyto": "^1.0.1",

--- a/src/renderer/components/TransactionConfirm/TransactionConfirmField.js
+++ b/src/renderer/components/TransactionConfirm/TransactionConfirmField.js
@@ -8,7 +8,7 @@ const TransactionConfirmField = ({
   children,
   label,
 }: {
-  children: React$Node,
+  children?: React$Node,
   label: React$Node,
 }) => (
   <Box horizontal justifyContent="space-between" mb={2}>

--- a/src/renderer/components/TransactionConfirm/index.js
+++ b/src/renderer/components/TransactionConfirm/index.js
@@ -59,6 +59,7 @@ const TransactionConfirm = ({ t, device, account, parentAccount, transaction, st
   const Post = r && r.post;
   const Warning = r && r.warning;
   const Title = r && r.title;
+  const noFees = r && r.disableFees && r.disableFees(transaction);
 
   const recipientWording = t(`TransactionConfirm.recipientWording.${transaction.mode || "send"}`);
 
@@ -112,7 +113,7 @@ const TransactionConfirm = ({ t, device, account, parentAccount, transaction, st
             />
           </TransactionConfirmField>
         )}
-        {!estimatedFees.isZero() && (
+        {noFees ? null : (
           <TransactionConfirmField label={<Trans i18nKey="send.steps.details.fees" />}>
             <FormattedVal
               color={"palette.text.shade80"}

--- a/src/renderer/families/tron/TransactionConfirmFields.js
+++ b/src/renderer/families/tron/TransactionConfirmFields.js
@@ -49,50 +49,70 @@ const Pre = ({
 
   invariant(transaction.family === "tron", "tron transaction");
 
-  const from = account.type === "ChildAccount" ? account.address : mainAccount.freshAddress;
+  const { votes, resource } = transaction;
 
   return (
     <>
-      <TransactionConfirmField label={<Trans i18nKey="TransactionConfirm.fromAddress" />}>
-        <AddressText>{from}</AddressText>
-      </TransactionConfirmField>
-      {transaction.recipient && transaction.recipient !== from && (
-        <TransactionConfirmField label={<Trans i18nKey="TransactionConfirm.toAddress" />}>
-          <AddressText>{transaction.recipient}</AddressText>
+      {resource && (
+        <TransactionConfirmField label="Resource">
+          <AddressText ff="Inter|SemiBold">
+            {resource.slice(0, 1).toUpperCase() + resource.slice(1).toLowerCase()}
+          </AddressText>
         </TransactionConfirmField>
       )}
 
-      {transaction.resource && (
-        <TransactionConfirmField label={<Trans i18nKey="TransactionConfirm.resource" />}>
-          <AddressText ff="Inter|SemiBold">{transaction.resource}</AddressText>
-        </TransactionConfirmField>
-      )}
-      {transaction.votes && transaction.votes.length > 0 && (
+      {votes && votes.length > 0 && (
         <Box vertical justifyContent="space-between" mb={2}>
-          <TransactionConfirmField label={<Trans i18nKey="TransactionConfirm.votes" />}>
-            <AddressText ff="Inter|SemiBold">
+          <TransactionConfirmField
+            label={
               <Trans
-                i18nKey="TransactionConfirm.validators"
-                values={{ nbrVote: transaction.votes.length }}
+                i18nKey="TransactionConfirm.votes"
+                count={votes.length}
+                values={{ count: votes.length }}
               />
-            </AddressText>
-          </TransactionConfirmField>
-
-          <OperationDetailsVotes
-            votes={transaction.votes}
-            account={mainAccount}
-            isTransactionField
+            }
           />
+
+          <OperationDetailsVotes votes={votes} account={mainAccount} isTransactionField />
         </Box>
       )}
     </>
   );
 };
 
-const Post = ({ transaction }: { transaction: Transaction }) => {
+const Post = ({
+  transaction,
+  account,
+  parentAccount,
+}: {
+  account: AccountLike,
+  parentAccount: ?Account,
+  transaction: Transaction,
+}) => {
+  invariant(transaction.family === "tron", "tron transaction");
+  const mainAccount = getMainAccount(account, parentAccount);
+
   invariant(transaction.family === "tron", "tron transaction");
 
-  return null;
+  const from = mainAccount.freshAddress;
+
+  const { mode } = transaction;
+
+  return (
+    <>
+      {(mode === "freeze" || mode === "unfreeze") && (
+        <TransactionConfirmField label={mode === "freeze" ? "Freeze To" : "Delegate To"}>
+          <AddressText>{from}</AddressText>
+        </TransactionConfirmField>
+      )}
+
+      {mode !== "send" ? (
+        <TransactionConfirmField label="From Address">
+          <AddressText>{from}</AddressText>
+        </TransactionConfirmField>
+      ) : null}
+    </>
+  );
 };
 
 const Warning = ({
@@ -134,4 +154,5 @@ export default {
   post: Post,
   warning: Warning,
   title: Title,
+  disableFees: () => true,
 };

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -1377,12 +1377,7 @@
       "undelegate": "validator",
       "claimReward": "delegation rewards recipient"
     },
-    "fromAddress": "From",
-    "toAddress": "To",
-    "address": "Address",
-    "resource": "Resource",
-    "votes": "Votes",
-    "validators": "{{ nbrVote }} validators"
+    "votes": "Votes ({{count}})"
   },
   "RecipientField": {
     "placeholder": "Enter {{currencyName}} address"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,10 +1402,10 @@
     node-pre-gyp "^0.14.0"
     node-pre-gyp-github "^1.4.3"
 
-"@ledgerhq/live-common@^12.12.2":
-  version "12.12.2"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.12.2.tgz#fe01f6548c19361dc68601e76d03f2917ca1ddd0"
-  integrity sha512-3fXjyci2JGFTmspOTFoft3NZJk5IYbP4lkRrRrJ4dN1I8DQXKl8nZgPUgJ4SK3vLXt7evF+kCpsgXw04hHWsOw==
+"@ledgerhq/live-common@^12.13.0":
+  version "12.13.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.13.0.tgz#1014da7625c128bea6ce4ae9423be167582481ce"
+  integrity sha512-Osh0wjGkxdc4SZLdY6KJ3Bjq2OhIe5ZFZU1ePSZM+fITyyY7YRROMP/PAWxytT9WaLRiZgqs/ilUGZVeemCHQw==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.12.0"


### PR DESCRIPTION
- this fixes the device step to match exactly what is shown in device.
- as agreed, the exception is that the SEND should not display any address because you are supposed to verify against where you send to, and showing the "From" address would be confusing here.
- The text are hardcoded in English because we must reflect the device wording. in future, we will try to generalize this back in live-common as suggested in https://github.com/LedgerHQ/ledger-live-common/issues/596
- **Also includes fixes of https://github.com/LedgerHQ/ledger-live-common/releases/tag/v12.13.0**

### Type

ui polish / security

### Context

🌳 

### Parts of the app affected / Test plan

send

<img width="518" alt="Capture d’écran 2020-04-03 à 21 28 47" src="https://user-images.githubusercontent.com/211411/78398065-b2c4d180-75f2-11ea-8aa4-354ac4924205.png">

send token

<img width="521" alt="Capture d’écran 2020-04-03 à 21 35 20" src="https://user-images.githubusercontent.com/211411/78398244-09321000-75f3-11ea-92f9-6ff7de14f877.png">


freeze

<img width="523" alt="Capture d’écran 2020-04-03 à 21 28 07" src="https://user-images.githubusercontent.com/211411/78398068-b48e9500-75f2-11ea-8ae3-5d867ffeb240.png">

unfreeze

<img width="512" alt="Capture d’écran 2020-04-03 à 21 22 53" src="https://user-images.githubusercontent.com/211411/78398072-b5272b80-75f2-11ea-9471-5bd15ee3baae.png">

votes

<img width="513" alt="Capture d’écran 2020-04-03 à 21 33 36" src="https://user-images.githubusercontent.com/211411/78398123-cf610980-75f2-11ea-8875-fd4732d2531a.png">

