### PR TITLE
LL-2373 Export the black list of token ids on LiveQr

### DIFF
--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -337,11 +337,19 @@ export const exportSettingsSelector: OutputSelector<State, void, *> = createSele
   state => state.settings.currenciesSettings,
   state => state.settings.pairExchanges,
   developerModeSelector,
-  (counterValueCurrency, currenciesSettings, pairExchanges, developerModeEnabled) => ({
+  blacklistedTokenIdsSelector,
+  (
+    counterValueCurrency,
+    currenciesSettings,
+    pairExchanges,
+    developerModeEnabled,
+    blacklistedTokenIds,
+  ) => ({
     counterValue: counterValueCurrency.ticker,
     currenciesSettings,
     pairExchanges,
     developerModeEnabled,
+    blacklistedTokenIds,
   }),
 );
 


### PR DESCRIPTION
Add the setting when exporting accounts/settings

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-2373

### Parts of the app affected / Test plan

Once both PRs for blacklisting tokens are available on desktop and mobile, blacklist some on desktop, export the settings and see if they're blacklisted on mobile.