### PR TITLE
Fixes broken countervalue selector

### DIFF
--- a/src/renderer/screens/settings/sections/General/CounterValueSelect.js
+++ b/src/renderer/screens/settings/sections/General/CounterValueSelect.js
@@ -32,7 +32,7 @@ const CounterValueSelect = () => {
         onChange={handleChangeCounterValue}
         itemToString={item => (item ? item.name : "")}
         renderSelected={item => item && item.name}
-        options={counterValueCurrency}
+        options={supportedCountervalues}
         value={cvOption}
       />
     </>


### PR DESCRIPTION
The current develop branch would crash instantly when trying to type in the counter value selector. We never caught this because I tested the fallback to USD PR by changing the app.json directly and directed QA to test that way too. The moral of the story for QA is not to only test like I say because I'm a moron and might do things like this.

### Type

Bug fix

### Parts of the app affected / Test plan

Try to change the counter value, try to type in the input, do the app.json approach too and make sure it still fallback to USD if it's not supported.