### PR TITLE
(TRX): earn rewards info modal, legal warning added

### DIFF
--- a/src/renderer/modals/EarnRewardsInfoModal/index.js
+++ b/src/renderer/modals/EarnRewardsInfoModal/index.js
@@ -18,6 +18,7 @@ import LinkWithExternalIcon from "~/renderer/components/LinkWithExternalIcon";
 
 import Rewards from "~/renderer/images/rewards.svg";
 import Modal, { ModalBody } from "~/renderer/components/Modal/index";
+import WarnBox from "~/renderer/components/WarnBox";
 
 const RewardImg = styled.img.attrs(() => ({ src: Rewards }))`
   width: 130px;
@@ -123,6 +124,9 @@ const EarnRewardsInfoModal = ({ name, account, parentAccount }: Props) => {
                   />
                 </Box>
               </Box>
+              <WarnBox>
+                <Trans i18nKey="tron.voting.flow.steps.starter.termsAndPrivacy" />
+              </WarnBox>
             </Box>
           )}
           renderFooter={() => (

--- a/src/renderer/modals/EarnRewardsInfoModal/index.js
+++ b/src/renderer/modals/EarnRewardsInfoModal/index.js
@@ -117,12 +117,6 @@ const EarnRewardsInfoModal = ({ name, account, parentAccount }: Props) => {
                     </Text>
                   </Row>
                 </Box>
-                <Box my={4}>
-                  <LinkWithExternalIcon
-                    label={<Trans i18nKey="tron.voting.flow.steps.starter.help" />}
-                    onClick={() => openURL(urls.stakingTron)}
-                  />
-                </Box>
               </Box>
               <WarnBox>
                 <Trans i18nKey="tron.voting.flow.steps.starter.termsAndPrivacy" />
@@ -130,7 +124,13 @@ const EarnRewardsInfoModal = ({ name, account, parentAccount }: Props) => {
             </Box>
           )}
           renderFooter={() => (
-            <Box horizontal alignItems="right">
+            <Box horizontal grow>
+              <Box grow>
+                <LinkWithExternalIcon
+                  label={<Trans i18nKey="tron.voting.flow.steps.starter.help" />}
+                  onClick={() => openURL(urls.stakingTron)}
+                />
+              </Box>
               <Button secondary onClick={onClose}>
                 <Trans i18nKey="common.cancel" />
               </Button>

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -786,7 +786,7 @@
       "noRewards": "No rewards available",
       "remainingVotes": {
         "title": "You still have {{amount}} votes remaining",
-        "description": "Cast your remaining votes to earn more rewards",
+        "description": "You can cast your remaining votes to earn more rewards",
         "button": "Vote now"
       },
       "flow": {
@@ -802,7 +802,8 @@
             "help": "How voting works",
             "button": {
               "cta": "Continue"
-            }
+            },
+            "termsAndPrivacy": "Delegating your voting rights does not guarantee you will be paid any reward by your super representative."
           }
         }
       }


### PR DESCRIPTION
add legal warning to earn rewards info modal

![localhost_8080_webpack_index html_theme=dusk](https://user-images.githubusercontent.com/11752937/78672068-6b835d00-78e0-11ea-81e4-ea88679aa78e.png)


### Type

UI Polish

### Context
alpha test
### Parts of the app affected / Test plan

Create an account send fund to it and start the earn rewards flow to view the info modal
