### PR TITLE
LL-2366 Introduce shallowAccountSelector to fix multiple selectors

### DIFF
--- a/src/renderer/components/SelectAccount.js
+++ b/src/renderer/components/SelectAccount.js
@@ -15,7 +15,7 @@ import { withTranslation } from "react-i18next";
 import { connect } from "react-redux";
 import { createFilter } from "react-select";
 import { createStructuredSelector } from "reselect";
-import { accountsSelector } from "~/renderer/reducers/accounts";
+import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
 import Box from "~/renderer/components/Box";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import Select from "~/renderer/components/Select";
@@ -23,7 +23,7 @@ import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
 import Ellipsis from "~/renderer/components/Ellipsis";
 
 const mapStateToProps = createStructuredSelector({
-  accounts: accountsSelector,
+  accounts: shallowAccountsSelector,
 });
 
 const Tick = styled.div`

--- a/src/renderer/screens/settings/index.js
+++ b/src/renderer/screens/settings/index.js
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Switch, Route } from "react-router-dom";
 import type { RouterHistory, Match, Location } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { accountsSelector } from "~/renderer/reducers/accounts";
+import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
 import Pills from "~/renderer/components/Pills";
 import type { Item } from "~/renderer/components/Pills";
 import Box from "~/renderer/components/Box";
@@ -57,7 +57,7 @@ type Props = {
 // Props are passed from the <Route /> component in <Default />
 const Settings = ({ history, location, match }: Props) => {
   const { t } = useTranslation();
-  const accounts = useSelector(accountsSelector);
+  const accounts = useSelector(shallowAccountsSelector);
   const accountsCount = accounts.length;
 
   const items = useMemo(() => getItems(t), [t]);


### PR DESCRIPTION
This introduces a new selector for accounts for components that need access to the accounts but don't care about the changes made to that state in some cases. The original case for this is the account selector component, we care about the list of accounts and we should be able to reflect changes in things like the account name, an account suddenly not existing anymore, or a balance change, but we should not have to render again (losing the scroll position) when the `lastSyncDate` changes, for example.

By the usage of a custom selector creator that compares a hash from the accounts (a string containing some relevant fields), we can prevent the render and loss of the scroll position. This was not only affecting the select account from the send flow, of course, but it also affected several other places:

- Send flow account selector
- Receive flow account selector
- Currency selector in settings > crypto assets
- Countervalue currency selector in settings > general

I was unable to fix the rate provider exchange selector, it still scrolls to the top while accounts are being synced. I will create a separate task for this one so @gre or someone with a better understanding of [what's going on here](https://github.com/LedgerHQ/ledger-live-desktop/blob/19b092792100ec2944e2f55569054b91d8c30192/src/renderer/countervalues.js#L17) can take care of it.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2366

### Parts of the app affected / Test plan

While accounts are being synced in the background, test the above-mentioned selectors and see if they scroll to top every time accounts are synced or if they now respect the user scroll position.