### PR TITLE
(Modal): backdrop blur filter

### DIFF
--- a/src/renderer/ModalsLayer.js
+++ b/src/renderer/ModalsLayer.js
@@ -22,7 +22,7 @@ const BackDrop: ThemedComponent<{ state: string }> = styled.div.attrs(({ state }
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background-color: rgba(0, 0, 0, 0.65);
   z-index: 100;
   opacity: 0;
   transition: opacity 200ms cubic-bezier(0.3, 1, 0.5, 0.8);


### PR DESCRIPTION
Added backdrop filter blur on modals as a solution for better contrast between content and backdrop.

![localhost_8080_webpack_index html_theme=dusk](https://user-images.githubusercontent.com/11752937/78688154-41886580-78f5-11ea-984d-186df0f886bb.png)
![localhost_8080_webpack_index html_theme=light](https://user-images.githubusercontent.com/11752937/78688161-43522900-78f5-11ea-9259-a9a97cc66eef.png)


### Type

UI Polish

### Parts of the app affected / Test plan

Open a modal
