### PR TITLE
LL-2286 enforce a minimum max for the yAxes of the chart

### DIFF
--- a/src/renderer/components/Chart2/index.js
+++ b/src/renderer/components/Chart2/index.js
@@ -47,6 +47,7 @@ import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 
 export type Props = {
   data: Data,
+  magnitude: number,
   id?: string,
   height?: number,
   tickXScale: string,
@@ -67,7 +68,15 @@ const ChartContainer: ThemedComponent<{}> = styled.div.attrs(({ height }) => ({
   position: relative;
 `;
 
-const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "value" }: Props) => {
+const Chart = ({
+  magnitude,
+  height,
+  data,
+  color,
+  renderTickY,
+  renderTooltip,
+  valueKey = "value",
+}: Props) => {
   const canvasRef = useRef(null);
   const chartRef = useRef(null);
   const theme = useTheme("colors.palette");
@@ -150,6 +159,7 @@ const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "va
             },
             ticks: {
               beginAtZero: true,
+              suggestedMax: 10 ** Math.max(magnitude - 4, 1),
               maxTicksLimit: 4,
               fontColor: theme.text.shade60,
               fontFamily: "Inter",
@@ -160,7 +170,7 @@ const Chart = ({ height, data, color, renderTickY, renderTooltip, valueKey = "va
         ],
       },
     }),
-    [renderTickY, theme],
+    [renderTickY, theme, magnitude],
   );
 
   useLayoutEffect(() => {

--- a/src/renderer/screens/account/BalanceSummary.js
+++ b/src/renderer/screens/account/BalanceSummary.js
@@ -103,6 +103,10 @@ class AccountBalanceSummary extends PureComponent<Props> {
       ? perFamilyAccountBalanceSummaryFooter[mainAccount.currency.family]
       : null;
 
+    const chartMagnitude = displayCountervalue
+      ? counterValue.units[0].magnitude
+      : getAccountUnit(account).magnitude;
+
     return (
       <Card p={0} py={5}>
         <Box px={6}>
@@ -122,6 +126,7 @@ class AccountBalanceSummary extends PureComponent<Props> {
         <Box px={5} ff="Inter" fontSize={4} color="palette.text.shade80" pt={5}>
           <Chart
             id={chartId}
+            magnitude={chartMagnitude}
             color={chartColor}
             data={history}
             height={200}

--- a/src/renderer/screens/asset/BalanceSummary.js
+++ b/src/renderer/screens/asset/BalanceSummary.js
@@ -91,6 +91,9 @@ class BalanceSummary extends PureComponent<Props> {
       discreetMode,
     } = this.props;
     const displayCountervalue = countervalueFirst && portfolio.countervalueAvailable;
+
+    const chartMagnitude = displayCountervalue ? counterValue.units[0].magnitude : unit.magnitude;
+
     return (
       <Card p={0} py={5}>
         <Box px={6}>
@@ -111,6 +114,7 @@ class BalanceSummary extends PureComponent<Props> {
           <Chart
             key={chartId}
             id={chartId}
+            magnitude={chartMagnitude}
             color={chartColor}
             data={portfolio.history}
             height={200}

--- a/src/renderer/screens/dashboard/GlobalSummary.js
+++ b/src/renderer/screens/dashboard/GlobalSummary.js
@@ -92,6 +92,7 @@ class PortfolioBalanceSummary extends PureComponent<Props> {
             <Chart
               onlyUpdateIfLastPointChanges
               id={chartId}
+              magnitude={counterValue.units[0].magnitude}
               color={chartColor}
               data={portfolio.balanceHistory}
               height={250}


### PR DESCRIPTION
Passing the magnitude of the displayed unit to the chart we can enforce what's called the `suggestedMax` of the Y-axis to be a fraction of the complete unit of that currency. This will be `10 ** Math.max(magnitude - 4, 1)` (the max is needed for fiat for instance) and seems to do the trick just fine. without any major complications.

![samples](https://user-images.githubusercontent.com/4631227/78841666-3d943a80-79fe-11ea-832b-823e92479082.png)
> **Note** the number of decimal points shown in the screenshot is one less than the number of decimal points that you will see in the implementation because I increased it after taking the screenshots and I'm not doing them again.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2286

### Parts of the app affected / Test plan

Check charts of accounts with no balance in the selected range and make sure that the Y-axis values are not repeated. Also, make sure accounts with normal balance don't suddenly regress and have broken charts either.