### PR TITLE
Fixes optimistic op update on tron flows

### DIFF
--- a/src/renderer/modals/ClaimRewards/Body.js
+++ b/src/renderer/modals/ClaimRewards/Body.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { useState, useCallback } from "react";
 import { compose } from "redux";
-import { connect } from "react-redux";
+import { connect, useDispatch } from "react-redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/lib/bridge/react";
@@ -96,6 +96,7 @@ const Body = ({
   const [optimisticOperation, setOptimisticOperation] = useState(null);
   const [transactionError, setTransactionError] = useState(null);
   const [signed, setSigned] = useState(false);
+  const dispatch = useDispatch();
 
   const { transaction, account, parentAccount, status, bridgeError } = useBridgeTransaction(() => {
     const { account, parentAccount } = params;
@@ -131,13 +132,15 @@ const Body = ({
   const handleOperationBroadcasted = useCallback(
     (optimisticOperation: Operation) => {
       if (!account) return;
-      updateAccountWithUpdater(account.id, account =>
-        addPendingOperation(account, optimisticOperation),
+      dispatch(
+        updateAccountWithUpdater(account.id, account =>
+          addPendingOperation(account, optimisticOperation),
+        ),
       );
       setOptimisticOperation(optimisticOperation);
       setTransactionError(null);
     },
-    [account],
+    [account, dispatch],
   );
 
   const error = transactionError || bridgeError;

--- a/src/renderer/modals/Freeze/Body.js
+++ b/src/renderer/modals/Freeze/Body.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { useState, useCallback } from "react";
 import { compose } from "redux";
-import { connect } from "react-redux";
+import { connect, useDispatch } from "react-redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import Track from "~/renderer/analytics/Track";
@@ -95,6 +95,7 @@ const Body = ({
   const [optimisticOperation, setOptimisticOperation] = useState(null);
   const [transactionError, setTransactionError] = useState(null);
   const [signed, setSigned] = useState(false);
+  const dispatch = useDispatch();
 
   const {
     transaction,
@@ -139,13 +140,15 @@ const Body = ({
   const handleOperationBroadcasted = useCallback(
     (optimisticOperation: Operation) => {
       if (!account) return;
-      updateAccountWithUpdater(account.id, account =>
-        addPendingOperation(account, optimisticOperation),
+      dispatch(
+        updateAccountWithUpdater(account.id, account =>
+          addPendingOperation(account, optimisticOperation),
+        ),
       );
       setOptimisticOperation(optimisticOperation);
       setTransactionError(null);
     },
-    [account],
+    [account, dispatch],
   );
 
   const error = transactionError || bridgeError;

--- a/src/renderer/modals/Send/Body.js
+++ b/src/renderer/modals/Send/Body.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { useCallback, useEffect, useState } from "react";
-import { connect } from "react-redux";
+import { connect, useDispatch } from "react-redux";
 import { compose } from "redux";
 import type { TFunction } from "react-i18next";
 import { createStructuredSelector } from "reselect";
@@ -123,6 +123,8 @@ const Body = ({
 }: Props) => {
   const openedFromAccount = !!params.account;
   const [steps] = useState(createSteps);
+  const dispatch = useDispatch();
+
   const {
     transaction,
     setTransaction,
@@ -178,13 +180,15 @@ const Body = ({
     (optimisticOperation: Operation) => {
       if (!account) return;
       const mainAccount = getMainAccount(account, parentAccount);
-      updateAccountWithUpdater(mainAccount.id, account =>
-        addPendingOperation(account, optimisticOperation),
+      dispatch(
+        updateAccountWithUpdater(mainAccount.id, account =>
+          addPendingOperation(account, optimisticOperation),
+        ),
       );
       setOptimisticOperation(optimisticOperation);
       setTransactionError(null);
     },
-    [account, parentAccount, updateAccountWithUpdater],
+    [account, parentAccount, updateAccountWithUpdater, dispatch],
   );
 
   const handleStepChange = useCallback(e => onChangeStepId(e.id), [onChangeStepId]);

--- a/src/renderer/modals/Unfreeze/Body.js
+++ b/src/renderer/modals/Unfreeze/Body.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { useState, useCallback, useMemo } from "react";
 import { compose } from "redux";
-import { connect } from "react-redux";
+import { connect, useDispatch } from "react-redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { BigNumber } from "bignumber.js";
@@ -135,6 +135,7 @@ const Body = ({
   const [optimisticOperation, setOptimisticOperation] = useState(null);
   const [transactionError, setTransactionError] = useState(null);
   const [signed, setSigned] = useState(false);
+  const dispatch = useDispatch();
 
   const {
     transaction,
@@ -181,13 +182,15 @@ const Body = ({
   const handleOperationBroadcasted = useCallback(
     (optimisticOperation: Operation) => {
       if (!account) return;
-      updateAccountWithUpdater(account.id, account =>
-        addPendingOperation(account, optimisticOperation),
+      dispatch(
+        updateAccountWithUpdater(account.id, account =>
+          addPendingOperation(account, optimisticOperation),
+        ),
       );
       setOptimisticOperation(optimisticOperation);
       setTransactionError(null);
     },
-    [account],
+    [account, dispatch],
   );
 
   const statusError = useMemo(() => status.errors && Object.values(status.errors)[0], [

--- a/src/renderer/modals/VoteTron/Body.js
+++ b/src/renderer/modals/VoteTron/Body.js
@@ -2,7 +2,7 @@
 import invariant from "invariant";
 import React, { useState, useCallback } from "react";
 import { compose } from "redux";
-import { connect } from "react-redux";
+import { connect, useDispatch } from "react-redux";
 import { Trans, withTranslation } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/lib/bridge/react";
@@ -97,6 +97,7 @@ const Body = ({
   const [optimisticOperation, setOptimisticOperation] = useState(null);
   const [transactionError, setTransactionError] = useState(null);
   const [signed, setSigned] = useState(false);
+  const dispatch = useDispatch();
 
   const {
     transaction,
@@ -148,13 +149,15 @@ const Body = ({
   const handleOperationBroadcasted = useCallback(
     (optimisticOperation: Operation) => {
       if (!account) return;
-      updateAccountWithUpdater(account.id, account =>
-        addPendingOperation(account, optimisticOperation),
+      dispatch(
+        updateAccountWithUpdater(account.id, account =>
+          addPendingOperation(account, optimisticOperation),
+        ),
       );
       setOptimisticOperation(optimisticOperation);
       setTransactionError(null);
     },
-    [account],
+    [account, dispatch],
   );
 
   const error = transactionError || bridgeError;


### PR DESCRIPTION
- if you were doing a unfreeze, claim rewards, votes and quickly would open the "Operation Detail" (view detail), it would not appear.
- make sure a freeze also properly work ok. it was affected too but we don't offer the view detail feature so it's ok, the optimistic op shall appear in the account properly now.