### PR TITLE
LL-2378 (TRX): percentage votes used flooring fixed

### DIFF
--- a/src/renderer/components/ProgressCircle.js
+++ b/src/renderer/components/ProgressCircle.js
@@ -67,7 +67,7 @@ const ProgressCircle = ({ size, progress }: Props) => {
           color={progress === 0 ? "palette.text.shade80" : "wallet"}
           fontSize={4}
         >
-          {`${Math.round(progress * 100)}%`}
+          {`${Math.floor(progress * 100)}%`}
         </Text>
       </TextContainer>
       <svg height={size} width={size}>

--- a/src/renderer/families/tron/Votes/Footer.js
+++ b/src/renderer/families/tron/Votes/Footer.js
@@ -41,7 +41,7 @@ type Props = {
 };
 
 const Footer = ({ total, used, onClick }: Props) => {
-  const percentVotesUsed = used / total;
+  const percentVotesUsed = Math.floor(100 * (used / total)) / 100;
 
   if (percentVotesUsed >= 1) return null;
 


### PR DESCRIPTION
Issue on votes used flooring

![localhost_8080_webpack_index html_theme=dusk](https://user-images.githubusercontent.com/11752937/78902483-22ffa700-7a7a-11ea-8737-a28d8ef9a900.png)

### Type

UI Polish

### Context

LL-2378

### Parts of the app affected / Test plan

Use almost all of your TRX votes
You will then see the banner telling you you used 99% of your votes at maximum

