### PR TITLE
add tooltip on vote button after freeze flow

### DIFF
--- a/src/renderer/modals/Freeze/steps/StepConfirmation.js
+++ b/src/renderer/modals/Freeze/steps/StepConfirmation.js
@@ -17,6 +17,8 @@ import RetryButton from "~/renderer/components/RetryButton";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
 import SuccessDisplay from "~/renderer/components/SuccessDisplay";
 import BroadcastErrorDisclaimer from "~/renderer/components/BroadcastErrorDisclaimer";
+import ToolTip from "~/renderer/components/Tooltip";
+import Text from "~/renderer/components/Text";
 
 import type { StepProps } from "../types";
 
@@ -28,6 +30,17 @@ const Container: ThemedComponent<{ shouldSpace?: boolean }> = styled(Box).attrs(
   justify-content: ${p => (p.shouldSpace ? "space-between" : "center")};
   min-height: 220px;
 `;
+
+const TooltipContent = () => (
+  <Box style={{ padding: 4 }}>
+    <Text color="palette.primary.contrastText" style={{ marginBottom: 5 }}>
+      <Trans i18nKey="freeze.steps.confirmation.tooltip.title" />
+    </Text>
+    <Text color="palette.primary.contrastText">
+      <Trans i18nKey="freeze.steps.confirmation.tooltip.desc" />
+    </Text>
+  </Box>
+);
 
 function StepConfirmation({
   account,
@@ -107,19 +120,23 @@ export function StepConfirmationFooter({
       <Button ml={2} event="Freeze Flow Step 3 View OpD Clicked" onClick={onClose} secondary>
         <Trans i18nKey="freeze.steps.confirmation.success.later" />
       </Button>
-      <Button
-        ml={2}
-        isLoading={isLoading && time === 0}
-        disabled={isLoading}
-        primary
-        onClick={openVote}
-      >
-        {time > 0 && isLoading ? (
-          <Trans i18nKey="freeze.steps.confirmation.success.votePending" values={{ time }} />
-        ) : (
+      {time > 0 && isLoading ? (
+        <ToolTip content={<TooltipContent />}>
+          <Button
+            ml={2}
+            isLoading={isLoading && time === 0}
+            disabled={isLoading}
+            primary
+            onClick={openVote}
+          >
+            <Trans i18nKey="freeze.steps.confirmation.success.votePending" values={{ time }} />
+          </Button>
+        </ToolTip>
+      ) : (
+        <Button ml={2} primary onClick={openVote}>
           <Trans i18nKey="freeze.steps.confirmation.success.vote" />
-        )}
-      </Button>
+        </Button>
+      )}
     </Box>
   );
 }

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -581,6 +581,10 @@
         "title": "Device"
       },
       "confirmation": {
+        "tooltip": {
+          "title": "Transaction is under validation",
+          "desc": "You have to wait a minute before being able to vote"
+        },
         "title": "Confirmation",
         "success": {
           "title": "",


### PR DESCRIPTION
Adds a tooltip to explain why the vote button is disabled for a minute

### Type

Fix

### Context

LL-2370

### Parts of the app affected / Test plan

![image](https://user-images.githubusercontent.com/671786/78907950-acff3e00-7a81-11ea-9ee3-89e27633df61.png)
