### PR TITLE
LL-2339 (Modals): tab navigation enabled 

### DIFF
--- a/src/renderer/components/Modal/index.js
+++ b/src/renderer/components/Modal/index.js
@@ -170,6 +170,11 @@ class Modal extends PureComponent<Props> {
     }
   };
 
+  /** combined with tab-index 0 this will allow tab navigation into the modal disabling tab navigation behind it */
+  setFocus = (r: HTMLElement) => {
+    r && r.focus();
+  };
+
   swallowClick = (e: Event) => {
     e.preventDefault();
     e.stopPropagation();
@@ -214,6 +219,8 @@ class Modal extends PureComponent<Props> {
               backdropColor={backdropColor}
             >
               <BodyWrapper
+                tabIndex="0"
+                ref={this.setFocus}
                 state={state}
                 width={width}
                 onClick={this.swallowClick}


### PR DESCRIPTION
Tab navigation should be enabled on all modals and not only redux driven ones


### Type

UX Polish

### Context

LL-2339

### Parts of the app affected / Test plan

Open a modal ie: Firmware update modal and you should be able to navigate inside using tab.
