### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/bundle-app.yml
+++ b/.github/workflows/bundle-app.yml
@@ -78,7 +78,6 @@ jobs:
         with:
           name: ${{ steps.post-version.outputs.version }}-linux-x86_64.AppImage
           path: dist/${{ steps.post-version.outputs.name }}-${{ steps.post-version.outputs.version }}-linux-x86_64.AppImage
-
   bundle-windows:
     runs-on: windows-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "install-deps": "electron-builder install-app-deps",
     "prepublish": "bash ./scripts/sync-families-dispatch.sh",
     "postinstall": "node ./scripts/post-install.js",
-    "dist:internal": "cross-env NODE_ENV=production electron-builder",
+    "dist:internal": "cross-env NODE_ENV=production DEBUG=electron-builder electron-builder",
     "dist": "node ./tools/dist",
     "dist:dirty": "node ./tools/dist --dirty",
     "dist:dir": "node ./tools/dist --dir",

--- a/tools/dist/index.js
+++ b/tools/dist/index.js
@@ -60,7 +60,7 @@ const buildTasks = args => [
   {
     title: "Compiling assets",
     task: async () => {
-      await exec("yarn", ["-s", "--frozen-lockfile", "build"]);
+      await exec("yarn", ["build"]);
     },
   },
   {
@@ -68,12 +68,13 @@ const buildTasks = args => [
       ? "Bundling and publishing the electron application"
       : "Bundling the electron application",
     task: async () => {
-      const commands = ["-s", "--frozen-lockfile", "dist:internal"];
+      const commands = ["dist:internal"];
       if (args.dir) commands.push("--dir");
       if (args.publish) {
         commands.push("--publish", "always");
       } else {
         commands.push("-c.afterSign='lodash/noop'");
+        commands.push("--publish", "never");
       }
       if (args.n) {
         commands.push("--config");


### PR DESCRIPTION
It seems that now, electron-builder detects Github Actions as a CI environment. 
As we did not pass a `--publish` option to the bundle-app script, it would check the environment, guess we are on a CI, and since we tag the build, it would automatically try to publish to Github.
Passing a `--publish never` actually fixes the bundle-app script
