### PR TITLE
add version to export logs

### DIFF
--- a/tools/main.js
+++ b/tools/main.js
@@ -5,10 +5,16 @@ const WebpackBar = require("webpackbar");
 const webpack = require("webpack");
 const yargs = require("yargs");
 const nodeExternals = require("webpack-node-externals");
+const childProcess = require("child_process");
 
 const pkg = require("./../package.json");
 
-const { SENTRY_URL, GIT_REVISION } = process.env;
+const { SENTRY_URL } = process.env;
+
+const GIT_REVISION = childProcess
+  .execSync("git rev-parse --short HEAD")
+  .toString("utf8")
+  .trim();
 
 // TODO: ADD BUNDLE ANALYZER
 


### PR DESCRIPTION
Since upgrading to V2, exporting logs would yield a file named like this `ledgerlive-logs-2020.04.10-12.39.46-unversioned.json`  

Fixing this so now we have the short hash of the commit on which the app was built

### Type

Fix

### Context

@gre context

### Parts of the app affected / Test plan

Export logs
