### PR TITLE
Fix broken color for title/description EmptyStateAccount

### DIFF
--- a/src/renderer/screens/account/EmptyStateAccount.js
+++ b/src/renderer/screens/account/EmptyStateAccount.js
@@ -110,13 +110,13 @@ class EmptyStateAccount extends PureComponent<Props, *> {
 const Title: ThemedComponent<{}> = styled(Box).attrs(() => ({
   ff: "Inter|Regular",
   fontSize: 6,
-  color: p => p.theme.colors.palette.text.shade100,
+  color: "palette.text.shade100",
 }))``;
 
 const Description: ThemedComponent<{}> = styled(Box).attrs(() => ({
   ff: "Inter|Regular",
   fontSize: 4,
-  color: p => p.theme.colors.palette.text.shade80,
+  color: "palette.text.shade80",
   textAlign: "center",
 }))``;
 


### PR DESCRIPTION
Small polish I noticed while working on another issue, we had left an invalid color value for the `EmptyStateAccount` title and description resulting in a gray font regardless of the theme. This screen should probably do with a makeover, it looks bad compared to the new empty states.

### Before
![before](https://user-images.githubusercontent.com/4631227/79241111-e44f5f80-7e72-11ea-894a-575dd8d2c0ab.png)

### After
![after](https://user-images.githubusercontent.com/4631227/79241102-e0bbd880-7e72-11ea-9af5-9d8defe9f111.png)

### Type

UI Polish

### Context

n/a

### Parts of the app affected / Test plan

Just looking at the screenshots should suffice in this case.



