### PR TITLE
Spectron testing with mocked device events

### DIFF
--- a/MOCK.md
+++ b/MOCK.md
@@ -1,0 +1,44 @@
+# Event mocking for dev & QA
+
+In order to be able to complete all OK/KO cases of all flows for testing and development, we expose a way to mock events that require interaction with a real device. When running with the env variable `MOCK` you'll have access to `mockDeviceEvent` which receives one or more events that will be emitted to the subscribed observers triggering the associated actions.
+
+### Dev
+Simply open the console, `mockDeviceEvent` is available as a global window variable. Pass the snippet below or any event of your liking to that method.
+
+### QA
+As it's done in the `onboarding.spec.js` file, we need to get access to that method via a call to `const mockeDeviceEvent = getMockDeviceEvent(app)` afterward the functionality of the method is the same as for dev with the exception of having to `await` the result to not break the tests.
+
+## What is this useful for?
+It allows us to interact with all parts of the application without the need for a real device or real accounts. 
+
+## Snippets per-flow
+These are a series of snippets that allow you to reach the OK and KO ends of a device interaction for each of the flows. For the KOs, we can essentially use the name of any error and it will throw it, depending on the flow ones make more sense than others.
+
+### Receive
+- OK `{ type: "opened" }`
+- KO `{ type: "error", error: { name: "WrongDeviceForAccount" } }`
+- KO `{ type: "error", error: { name: "DisconnectedDevice" } }`
+
+### Send
+- OK `{ type: "opened" }`
+- KO `{ type: "error", error: { name: "WrongDeviceForAccount" } }`
+- KO `{ type: "error", error: { name: "UserRefusedOnDevice" } }`
+
+### Add accounts
+- OK `{ type: "opened" }`
+- KO `{ type: "error", error: { name: "DisconnectedDevice" } }`
+
+### Genuine Check / Manager
+- OK (note it's not an array) We could make other profiles for devices available and fix the sizes of the apps returned by `mockListAppsResult` to test things like the storage breakdown in the manager. **Note** for devs in the console you will be able to run this snippet only because we've exposed the dependencies as globals when in mock.
+
+  Refer to the signature of `mockListAppsResult` to see the doors it opens. But a tldr is the first parameter are the apps available in the catalog, the second is the list of installed apps.
+    ```
+    { type: "listingApps", deviceInfo: deviceInfo155 },  
+    {  
+      type: "result",  
+      result: mockListAppsResult("Bitcoin", "Bitcoin", deviceInfo155),  
+    }
+   ```
+
+- KO `{ type: "error", error: { name: "GenuineCheckFailed" } }`
+- KO `{ type: "error", error: { name: "WrongDeviceForAccount" } }`

--- a/src/renderer/Default.js
+++ b/src/renderer/Default.js
@@ -34,6 +34,7 @@ import ContextMenuWrapper from "~/renderer/components/ContextMenu/ContextMenuWra
 import DebugUpdater from "~/renderer/components/Updater/DebugUpdater";
 import Page from "~/renderer/components/Page";
 import ModalsLayer from "./ModalsLayer";
+import DebugMock from "~/renderer/components/DebugMock";
 
 const reloadApp = event => {
   if ((event.ctrlKey || event.metaKey) && event.key === "r") {
@@ -107,7 +108,7 @@ const Default = () => {
 
                 <LibcoreBusyIndicator />
                 <DeviceBusyIndicator />
-
+                <DebugMock />
                 <KeyboardContent sequence="BJBJBJ">
                   <PerfIndicator />
                 </KeyboardContent>

--- a/src/renderer/components/DebugMock.js
+++ b/src/renderer/components/DebugMock.js
@@ -1,0 +1,59 @@
+// @flow
+import React from "react";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+import styled from "styled-components";
+import { getEnv } from "@ledgerhq/live-common/lib/env";
+import Text from "~/renderer/components/Text";
+import { Subject } from "rxjs";
+import { deserializeError } from "@ledgerhq/errors";
+import { deviceInfo155, mockListAppsResult } from "@ledgerhq/live-common/lib/apps/mock";
+
+const Item: ThemedComponent<{}> = styled(Text)`
+  padding: 2px 13px;
+  color: white;
+  position: absolute;
+  left: 8px;
+  bottom: 8px;
+  background: ${p => p.theme.colors.alertRed};
+  border-radius: 4px;
+  opacity: 0.9;
+`;
+
+const mockedEventStream = new Subject<any>();
+export const mockedAppExec = () => mockedEventStream;
+
+const parseRawEvents = (rawEvents, maybeKey): Object => {
+  if (rawEvents && typeof rawEvents === "object") {
+    if (maybeKey === "error") {
+      return deserializeError(rawEvents);
+    }
+    if (Array.isArray(rawEvents)) return rawEvents.map(parseRawEvents);
+    const event = {};
+    for (const k in rawEvents) {
+      if (rawEvents.hasOwnProperty(k)) {
+        event[k] = parseRawEvents(rawEvents[k], k);
+      }
+    }
+    return event;
+  }
+  return rawEvents;
+};
+
+if (getEnv("MOCK")) {
+  window.mockDeviceEvent = (...o: any[]) => {
+    for (const e of parseRawEvents(o)) {
+      mockedEventStream.next(e);
+    }
+  };
+
+  window.mockListAppsResult = mockListAppsResult;
+  window.deviceInfo155 = deviceInfo155;
+}
+
+const DebugMock = () => (
+  <Item color="palette.text.shade100" mb={3} ff="Inter|Medium" fontSize={4}>
+    {"mock"}
+  </Item>
+);
+
+export default getEnv("MOCK") ? DebugMock : () => null;

--- a/src/renderer/components/DeviceAction/rendering.js
+++ b/src/renderer/components/DeviceAction/rendering.js
@@ -243,7 +243,7 @@ export const renderError = ({
   withExportLogs?: boolean,
   list?: boolean,
 }) => (
-  <Wrapper>
+  <Wrapper id={`error-${error.name}`}>
     <Logo>
       <ErrorIcon size={44} error={error} />
     </Logo>
@@ -342,7 +342,7 @@ export const renderLoading = ({
   modelId: DeviceModelId,
   children?: React$Node,
 }) => (
-  <Wrapper>
+  <Wrapper id="deviceAction-loading">
     <Header />
     <AnimationWrapper modelId={modelId}>
       <BigSpinner size={50} />

--- a/src/renderer/components/Switch.js
+++ b/src/renderer/components/Switch.js
@@ -55,13 +55,18 @@ function Switch(props: Props) {
   return (
     <Base
       {...p}
+      key={isChecked ? "ON" : "OFF"}
       disabled={disabled}
       small={small}
       isChecked={isChecked}
       onClick={() => onChange && onChange(!isChecked)}
       className="switch"
     >
-      <input type="checkbox" disabled={disabled || null} checked={isChecked || null} />
+      <input
+        type="checkbox"
+        disabled={disabled || null}
+        {...(isChecked ? { checked: true } : {})}
+      />
       <Ball small={small} isChecked={isChecked} />
     </Base>
   );

--- a/src/renderer/modals/AddAccounts/steps/StepConnectDevice.js
+++ b/src/renderer/modals/AddAccounts/steps/StepConnectDevice.js
@@ -8,9 +8,12 @@ import DeviceAction from "~/renderer/components/DeviceAction";
 import { createAction } from "@ledgerhq/live-common/lib/hw/actions/app";
 import { command } from "~/renderer/commands";
 import type { StepProps } from "..";
+import { getEnv } from "@ledgerhq/live-common/lib/env";
+import { mockedAppExec } from "~/renderer/components/DebugMock";
 
 const connectAppExec = command("connectApp");
-const action = createAction(connectAppExec);
+
+const action = createAction(getEnv("MOCK") ? mockedAppExec : connectAppExec);
 
 const StepConnectDevice = ({ currency, device, transitionTo }: StepProps) => {
   invariant(currency, "No crypto asset given");

--- a/src/renderer/modals/Receive/steps/StepConnectDevice.js
+++ b/src/renderer/modals/Receive/steps/StepConnectDevice.js
@@ -11,9 +11,12 @@ import TrackPage from "~/renderer/analytics/TrackPage";
 import { command } from "~/renderer/commands";
 
 import type { StepProps } from "../Body";
+import { mockedAppExec } from "~/renderer/components/DebugMock";
+import { getEnv } from "@ledgerhq/live-common/lib/env";
 
 const connectAppExec = command("connectApp");
-const action = createAction(connectAppExec);
+
+const action = createAction(getEnv("MOCK") ? mockedAppExec : connectAppExec);
 
 export default function StepConnectDevice({
   account,

--- a/src/renderer/modals/Send/steps/GenericStepConnectDevice.js
+++ b/src/renderer/modals/Send/steps/GenericStepConnectDevice.js
@@ -16,9 +16,12 @@ import type {
   SignedOperation,
 } from "@ledgerhq/live-common/lib/types";
 import { command } from "~/renderer/commands";
+import { getEnv } from "@ledgerhq/live-common/lib/env";
+import { mockedAppExec } from "~/renderer/components/DebugMock";
 
 const connectAppExec = command("connectApp");
-const action = createAction(connectAppExec);
+
+const action = createAction(getEnv("MOCK") ? mockedAppExec : connectAppExec);
 
 const Result = ({
   signedOperation,

--- a/src/renderer/reducers/devices.js
+++ b/src/renderer/reducers/devices.js
@@ -46,7 +46,7 @@ const handlers: Object = {
 };
 
 export function getCurrentDevice(state: { devices: DevicesState }) {
-  if (getEnv("DEVICE_PROXY_URL")) {
+  if (getEnv("DEVICE_PROXY_URL") || getEnv("MOCK")) {
     // bypass the listen devices (we should remove modelId here by instead get it at open time if needed)
     return { path: "", modelId: "nanoS" };
   }

--- a/src/renderer/screens/manager/index.js
+++ b/src/renderer/screens/manager/index.js
@@ -5,9 +5,11 @@ import Dashboard from "~/renderer/screens/manager/Dashboard";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/lib/bridge/react";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import { command } from "~/renderer/commands";
+import { mockedAppExec } from "~/renderer/components/DebugMock";
+import { getEnv } from "@ledgerhq/live-common/lib/env";
 
 const connectManagerExec = command("connectManager");
-const action = createAction(connectManagerExec);
+const action = createAction(getEnv("MOCK") ? mockedAppExec : connectManagerExec);
 
 const Manager = () => {
   const [result, setResult] = useState(null);

--- a/src/renderer/screens/onboarding/index.js
+++ b/src/renderer/screens/onboarding/index.js
@@ -36,6 +36,7 @@ import WriteSeed from "./steps/WriteSeed";
 import SetPassword from "./steps/SetPassword";
 import Analytics from "./steps/Analytics";
 import Finish from "./steps/Finish";
+import DebugMock from "~/renderer/components/DebugMock";
 
 const STEPS = {
   init: InitStep,
@@ -183,6 +184,7 @@ class OnboardingC extends PureComponent<Props> {
         <StepContainer>
           <StepComponent {...stepProps} />
         </StepContainer>
+        <DebugMock />
       </Container>
     );
   }

--- a/src/renderer/screens/onboarding/steps/GenuineCheck/GenuineCheckModal.js
+++ b/src/renderer/screens/onboarding/steps/GenuineCheck/GenuineCheckModal.js
@@ -8,9 +8,11 @@ import { createAction } from "@ledgerhq/live-common/lib/hw/actions/manager";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
 import DeviceAction from "~/renderer/components/DeviceAction";
 import { command } from "~/renderer/commands";
+import { getEnv } from "@ledgerhq/live-common/lib/env";
+import { mockedAppExec } from "~/renderer/components/DebugMock";
 
 const connectManagerExec = command("connectManager");
-const action = createAction(connectManagerExec);
+const action = createAction(getEnv("MOCK") ? mockedAppExec : connectManagerExec);
 
 const Container = styled.div`
   min-height: 450px;

--- a/src/renderer/screens/onboarding/steps/GenuineCheck/index.js
+++ b/src/renderer/screens/onboarding/steps/GenuineCheck/index.js
@@ -2,7 +2,6 @@
 
 import React, { useState, useCallback } from "react";
 import { Trans } from "react-i18next";
-import { getEnv } from "@ledgerhq/live-common/lib/env";
 import { getDeviceModel } from "@ledgerhq/devices";
 import styled from "styled-components";
 import IconCheck from "~/renderer/icons/Check";
@@ -93,13 +92,7 @@ const GenuineCheck = (props: StepProps) => {
 
   const handleOpenGenuineCheckModal = useCallback(() => {
     setGenuineCheckModalOpened(true);
-    if (getEnv("MOCK")) {
-      setTimeout(() => {
-        handleCloseGenuineCheckModal();
-        handleGenuineCheckPass({ result: { installed: ["mock"] } });
-      }, 2000);
-    }
-  }, [handleCloseGenuineCheckModal, handleGenuineCheckPass]);
+  }, []);
 
   const redoGenuineCheck = useCallback(() => {
     setRecovery(undefined);

--- a/tests/applicationProxy.js
+++ b/tests/applicationProxy.js
@@ -44,3 +44,9 @@ export function applicationProxy(envVar = {}, userData = null) {
     env: envVar,
   });
 }
+
+export const getMockDeviceEvent = app => async (...events) => {
+  return await app.client.execute(e => {
+    window.mockDeviceEvent(...e);
+  }, events);
+};


### PR DESCRIPTION
# Event mocking for dev & QA

In order to be able to complete all OK/KO cases of all flows for testing and development, we expose a way to mock events that require interaction with a real device. When running with the env variable `MOCK` you'll have access to `mockDeviceEvent` which receives one or more events that will be emitted to the subscribed observers triggering the associated actions.

### Dev
Simply open the console, `mockDeviceEvent` is available as a global window variable. Pass the snippet below or any event of your liking to that method.

### QA
As it's done in the `onboarding.spec.js` file, we need to get access to that method via a call to `const mockeDeviceEvent = getMockDeviceEvent(app)` afterward the functionality of the method is the same as for dev with the exception of having to `await` the result to not break the tests.

## What is this useful for?
It allows us to interact with all parts of the application without the need for a real device or real accounts. 

## Snippets per-flow
These are a series of snippets that allow you to reach the OK and KO ends of a device interaction for each of the flows. For the KOs, we can essentially use the name of any error and it will throw it, depending on the flow ones make more sense than others.

### Receive
- OK `{ type: "opened" }`
- KO `{ type: "error", error: { name: "WrongDeviceForAccount" } }`
- KO `{ type: "error", error: { name: "DisconnectedDevice" } }`

### Send
- OK `{ type: "opened" }`
- KO `{ type: "error", error: { name: "WrongDeviceForAccount" } }`
- KO `{ type: "error", error: { name: "UserRefusedOnDevice" } }`

### Add accounts
- OK `{ type: "opened" }`
- KO `{ type: "error", error: { name: "DisconnectedDevice" } }`

### Genuine Check / Manager
- OK (note it's not an array) We could make other profiles for devices available and fix the sizes of the apps returned by `mockListAppsResult` to test things like the storage breakdown in the manager. **Note** for devs in the console you will be able to run this snippet only because we've exposed the dependencies as globals when in mock.

  Refer to the signature of `mockListAppsResult` to see the doors it opens. But a tldr is the first parameter are the apps available in the catalog, the second is the list of installed apps.
    ```
    { type: "listingApps", deviceInfo: deviceInfo155 },  
    {  
      type: "result",  
      result: mockListAppsResult("Bitcoin", "Bitcoin", deviceInfo155),  
    }
   ```

- KO `{ type: "error", error: { name: "GenuineCheckFailed" } }`
- KO `{ type: "error", error: { name: "WrongDeviceForAccount" } }`


### Type

Feature

We also now have a little badge indicating we are in a mock mode in case we forget and suddenly add accounts and think we are rich. Not that it happened to me.
![image](https://user-images.githubusercontent.com/4631227/79459594-c9f0bf80-7ff3-11ea-8334-9b3c3f292821.png)