### PR TITLE
added an extra status for when the user click 'download now', updatin…

### DIFF
--- a/src/renderer/components/Updater/Banner.js
+++ b/src/renderer/components/Updater/Banner.js
@@ -25,6 +25,7 @@ export const VISIBLE_STATUS = [
   "check-success",
   "error",
   "update-available",
+  "downloading-update",
 ];
 
 const CONTENT_BY_STATUS = (
@@ -51,6 +52,10 @@ const CONTENT_BY_STATUS = (
         <Trans i18nKey="update.quitAndInstall" />
       </FakeLink>
     ),
+  },
+  "downloading-update": {
+    Icon: IconUpdate,
+    message: <Trans i18nKey="update.downloadInProgress" />,
   },
   "update-available": {
     Icon: IconUpdate,

--- a/src/renderer/components/Updater/UpdaterContext.js
+++ b/src/renderer/components/Updater/UpdaterContext.js
@@ -14,6 +14,7 @@ export type UpdateStatus =
   | "update-downloaded"
   | "checking"
   | "check-success"
+  | "downloading-update"
   | "error";
 
 export type UpdaterContextType = {
@@ -88,7 +89,10 @@ class Provider extends Component<UpdaterProviderProps, UpdaterProviderState> {
 
   quitAndInstall = () => ipcRenderer.send("updater", "quit-and-install");
 
-  downloadUpdate = () => ipcRenderer.send("updater", "download-update");
+  downloadUpdate = () => {
+    this.setStatus("downloading-update");
+    return ipcRenderer.send("updater", "download-update");
+  };
 
   render() {
     const { status, downloadProgress, error, version } = this.state;


### PR DESCRIPTION
…g the banner to give the user immediate feedback

QA test procedure:
Pull the local branch
edit package.json and set version to anterior (2.0.0 will do the trick)
package the app locally (yarn dist)
run the packaged app that sit in /dist (no need to install it)
you should see the blue update banner, clicking it should instantly switch to "download in progress" and the a few time later % download completion should appear