### PR TITLE
LL-2400 Fix missing renderer logs in exported logs

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -7,6 +7,7 @@ import "./internal-lifecycle";
 import resolveUserDataDirectory from "~/helpers/resolveUserDataDirectory";
 import db from "./db";
 import debounce from "lodash/debounce";
+import logger from "~/logger";
 
 app.allowRendererProcessReuse = false;
 
@@ -85,6 +86,8 @@ app.on("ready", async () => {
     console.log("reloading renderer ...");
     loadWindow();
   });
+
+  ipcMain.on("log", (event, { log }) => logger.log(log));
 
   Menu.setApplicationMenu(menu);
 


### PR DESCRIPTION
At some point between the upgrade from v1 to v2 we forgot about renderer logs reaching the exported logs. This means that we lose track of what the user was doing before a cmd crash for example, or what was the screen flow prior to an error. This restores the functionality we had before.

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2400

### Parts of the app affected / Test plan

Before this PR exported logs would have no instances of logs coming from the renderer thread, ie if you search for `"pname":"renderer"`  you will find nothing. On this PR, you should see many instances of logs from the renderer, including the one that made us notice this regression, `"message":"exportLogsMeta"`.
