### PR TITLE
LL-2411 (OperationRow): ammount cell ellipsis issue

### DIFF
--- a/src/renderer/components/OperationsList/AmountCell.js
+++ b/src/renderer/components/OperationsList/AmountCell.js
@@ -16,8 +16,7 @@ const Cell: ThemedComponent<{}> = styled(Box).attrs(() => ({
   horizontal: false,
   alignItems: "flex-end",
 }))`
-  flex: 0.5;
-  width: 150px;
+  flex: 0 0 auto;
   text-align: right;
   justify-content: center;
   height: 32px;


### PR DESCRIPTION
Issue on small width screens on the amount cell on operation lists triggering ellipsis.

![localhost_8080_webpack_index html_theme=null](https://user-images.githubusercontent.com/11752937/79888976-ad8ec180-83fd-11ea-83a5-e9f95a684951.png)


### Type

UI Polish

### Context

LL-2411

### Parts of the app affected / Test plan

Operation lists
