### PR TITLE
Make the address field use full width on receive flow

### DIFF
--- a/src/renderer/components/ReadOnlyAddressField.js
+++ b/src/renderer/components/ReadOnlyAddressField.js
@@ -41,6 +41,7 @@ const ClipboardSuspicious = styled.div`
   font-weight: 400;
   font-style: normal;
   font-size: 12px;
+  align-self: center;
   color: ${p => p.theme.colors.alertRed};
 `;
 
@@ -91,7 +92,7 @@ function ReadOnlyAddressField({ address }: Props) {
   }, []);
 
   return (
-    <Box vertical alignItems="center">
+    <Box vertical>
       {clibboardChanged ? (
         <ClipboardSuspicious>
           <Trans i18nKey="common.addressCopiedSuspicious" />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/79918526-d8dcd500-842c-11ea-9244-8ea2aa1033ee.png)
<!-- Descriptio

n of what the PR does go here... screenshot might be good if appropriate -->

### Type

UI Polish

### Context

Slack

### Parts of the app affected / Test plan

On the address step of the receive flow, the address read-only input should take the full width again.