### PR TITLE
Close delegation modal on operation details click

### DIFF
--- a/src/renderer/families/tezos/DelegateFlowModal/steps/StepConfirmation.js
+++ b/src/renderer/families/tezos/DelegateFlowModal/steps/StepConfirmation.js
@@ -6,7 +6,7 @@ import styled, { withTheme } from "styled-components";
 import { Trans } from "react-i18next";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/lib/bridge/react";
 import { multiline } from "~/renderer/styles/helpers";
-import { openModal, closeModal } from "~/renderer/actions/modals";
+import { openModal } from "~/renderer/actions/modals";
 import { urls } from "~/config/urls";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
@@ -95,6 +95,7 @@ export const StepConfirmationFooter = ({
   onRetry,
   optimisticOperation,
   error,
+  closeModal,
 }: StepProps) => {
   const dispatch = useDispatch();
   const concernedOperation = optimisticOperation
@@ -115,7 +116,7 @@ export const StepConfirmationFooter = ({
           ml={2}
           event="Delegation Flow Step 4 View OpD Clicked"
           onClick={() => {
-            dispatch(closeModal());
+            closeModal();
             if (account && concernedOperation) {
               dispatch(
                 openModal("MODAL_OPERATION_DETAILS", {


### PR DESCRIPTION
We were dispatching the `closeModal` action which would need the modal name instead of the method passed down from the `StepProps` so the modal did not close. This resulted in a double modal when clicking on operation details.
### Type

Bug fix
### Context

I stumbled upon this when writing the bull run Spectron test on the delegation flow. Since the modal uses ids, it was breaking the selected element. 

### Parts of the app affected / Test plan

Complete a delegation, on success, make sure the operation details CTA closes the delegation modal when it opens the new one.