### PR TITLE
use ledgerhq/actions for headless tests + bump of other actions

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -16,7 +16,7 @@ jobs:
         run: yarn --ignore-scripts --frozen-lockfile
       - name: build the app
         run: yarn nightly
-      - uses: ledgerhq/actions/get-package-infos@v1.0.0
+      - uses: ledgerhq/actions/get-package-infos@v1.1.0
         id: version
       - name: upload macOS app
         uses: actions/upload-artifact@v1
@@ -45,7 +45,7 @@ jobs:
         run: yarn --ignore-scripts --frozen-lockfile
       - name: build the app
         run: yarn nightly
-      - uses: ledgerhq/actions/get-package-infos@v1.0.0
+      - uses: ledgerhq/actions/get-package-infos@v1.1.0
         id: version
       - name: upload linux app
         uses: actions/upload-artifact@v1
@@ -75,7 +75,7 @@ jobs:
         run: yarn --ignore-scripts --frozen-lockfile
       - name: build the app
         run: yarn nightly
-      - uses: ledgerhq/actions/get-package-infos@v1.0.0
+      - uses: ledgerhq/actions/get-package-infos@v1.1.0
         id: version
       - name: upload windows
         uses: actions/upload-artifact@v1

--- a/.github/workflows/bundle-app.yml
+++ b/.github/workflows/bundle-app.yml
@@ -5,7 +5,7 @@ jobs:
   bundle-macos:
     runs-on: macos-latest
     steps:
-      - uses: ledgerhq/actions/check-member@v1.0.0
+      - uses: ledgerhq/actions/check-member@v1.1.0
         with:
           username: ${{ github.actor }}
           ban: ledgerlive
@@ -81,7 +81,7 @@ jobs:
   bundle-windows:
     runs-on: windows-latest
     steps:
-      - uses: ledgerhq/actions/check-member@v1.0.0
+      - uses: ledgerhq/actions/check-member@v1.1.0
         with:
           username: ${{ github.actor }}
           ban: ledgerlive
@@ -107,15 +107,15 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: install dependencies
         run: yarn --ignore-scripts --frozen-lockfile
-      - uses: ledgerhq/actions/get-package-infos@v1.0.0
+      - uses: ledgerhq/actions/get-package-infos@v1.1.0
         id: version
-      - uses: ledgerhq/actions/get-pr-number@v1.0.0
+      - uses: ledgerhq/actions/get-pr-number@v1.1.0
         id: pr
       - name: make local version
         run: yarn version --new-version=${{ steps.version.outputs.clean }}-pr.${{ steps.pr.outputs.pr }}
       - name: build the app
         run: yarn nightly
-      - uses: ledgerhq/actions/get-package-infos@v1.0.0
+      - uses: ledgerhq/actions/get-package-infos@v1.1.0
         id: post-version
       - name: upload windows
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 12.x
-      - name: install linux dependencies
-        run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
       - name: get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -26,15 +24,5 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: install dependencies
-        # yarn prepublish is actually run after a normal `yarn install`
-        # however since we skip with --ignore-scripts to avoid rebuilding libcore twice
-        # we need to run yarn prepublish
-        run: |
-          yarn --ignore-scripts --frozen-lockfile
-          yarn prepublish
-      - name: test
-        run: yarn ci
-      - name: Run spectron
-        id: spectron
-        uses: IAmMorrow/run-headless@v4
+      - name: run headless tests
+        uses: ledgerhq/actions/run-headless@v1.1.0


### PR DESCRIPTION
Reuses @IAmMorrow action to run headless tests, but now centralised in https://github.com/LedgerHQ/actions

+ bump of other actions

### Type

Chore

### Parts of the app affected / Test plan

CI
