### PR TITLE
Device transaction config

### DIFF
--- a/src/internal/commands/connectApp.js
+++ b/src/internal/commands/connectApp.js
@@ -4,7 +4,6 @@ import type { Observable } from "rxjs";
 import { from } from "rxjs";
 import connectApp from "@ledgerhq/live-common/lib/hw/connectApp";
 import type { Input, ConnectAppEvent } from "@ledgerhq/live-common/lib/hw/connectApp";
-
 const cmd = (input: Input): Observable<ConnectAppEvent> => from(connectApp(input));
 
 export default cmd;

--- a/src/renderer/components/TransactionConfirm/index.js
+++ b/src/renderer/components/TransactionConfirm/index.js
@@ -1,5 +1,6 @@
 // @flow
 
+import invariant from "invariant";
 import React from "react";
 import { Trans, withTranslation } from "react-i18next";
 import type { TFunction } from "react-i18next";
@@ -11,14 +12,85 @@ import type {
   Transaction,
   TransactionStatus,
 } from "@ledgerhq/live-common/lib/types";
+import { getDeviceTransactionConfig } from "@ledgerhq/live-common/lib/transaction";
+import type { DeviceTransactionField } from "@ledgerhq/live-common/lib/transaction";
 import type { Device } from "~/renderer/reducers/devices";
 import transactionConfirmFieldsPerFamily from "~/renderer/generated/TransactionConfirmFields";
 import Box from "~/renderer/components/Box";
+import Text from "~/renderer/components/Text";
 import WarnBox from "~/renderer/components/WarnBox";
 import useTheme from "~/renderer/hooks/useTheme";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import { renderVerifyUnwrapped } from "~/renderer/components/DeviceAction/rendering";
 import TransactionConfirmField from "./TransactionConfirmField";
+
+const AddressText = styled(Text).attrs(() => ({
+  ml: 1,
+  ff: "Inter|Medium",
+  color: "palette.text.shade80",
+  fontSize: 3,
+}))`
+  word-break: break-all;
+  text-align: right;
+  max-width: 50%;
+`;
+
+export type FieldComponentProps = {
+  account: AccountLike,
+  parentAccount: ?Account,
+  transaction: Transaction,
+  status: TransactionStatus,
+  field: DeviceTransactionField,
+};
+
+export type FieldComponent = React$ComponentType<FieldComponentProps>;
+
+const AmountField = ({ account, status: { amount } }: FieldComponentProps) => (
+  <TransactionConfirmField label={<Trans i18nKey="send.steps.details.amount" />}>
+    <FormattedVal
+      color={"palette.text.shade80"}
+      unit={getAccountUnit(account)}
+      val={amount}
+      fontSize={3}
+      inline
+      showCode
+      disableRounding
+    />
+  </TransactionConfirmField>
+);
+
+const FeesField = ({ account, parentAccount, status }: FieldComponentProps) => {
+  const mainAccount = getMainAccount(account, parentAccount);
+  const { estimatedFees } = status;
+  const feesUnit = getAccountUnit(mainAccount);
+  return (
+    <TransactionConfirmField label={<Trans i18nKey="send.steps.details.fees" />}>
+      <FormattedVal
+        color={"palette.text.shade80"}
+        unit={feesUnit}
+        val={estimatedFees}
+        fontSize={3}
+        inline
+        showCode
+      />
+    </TransactionConfirmField>
+  );
+};
+
+const AddressField = ({ account, parentAccount, field }: FieldComponentProps) => {
+  invariant(field.type === "address", "AddressField invalid");
+  return (
+    <TransactionConfirmField label={field.label}>
+      <AddressText>{field.address}</AddressText>
+    </TransactionConfirmField>
+  );
+};
+
+const commonFieldComponents: { [_: *]: FieldComponent } = {
+  amount: AmountField,
+  fees: FeesField,
+  address: AddressField,
+};
 
 const Container = styled(Box).attrs(() => ({
   alignItems: "center",
@@ -47,19 +119,25 @@ type Props = {
 
 const TransactionConfirm = ({ t, device, account, parentAccount, transaction, status }: Props) => {
   const mainAccount = getMainAccount(account, parentAccount);
-  const { estimatedFees, amount } = status;
-  const unit = getAccountUnit(account);
-  const feesUnit = getAccountUnit(mainAccount);
   const type = useTheme("colors.palette.type");
 
   if (!device) return null;
 
   const r = transactionConfirmFieldsPerFamily[mainAccount.currency.family];
-  const Pre = r && r.pre;
-  const Post = r && r.post;
+
+  const fieldComponents = {
+    ...commonFieldComponents,
+    ...(r && r.fieldComponents),
+  };
   const Warning = r && r.warning;
   const Title = r && r.title;
-  const noFees = r && r.disableFees && r.disableFees(transaction);
+
+  const fields = getDeviceTransactionConfig({
+    account,
+    parentAccount,
+    transaction,
+    status,
+  });
 
   const recipientWording = t(`TransactionConfirm.recipientWording.${transaction.mode || "send"}`);
 
@@ -92,48 +170,25 @@ const TransactionConfirm = ({ t, device, account, parentAccount, transaction, st
       )}
 
       <Box style={{ width: "100%" }} px={80} mb={20}>
-        {Pre ? (
-          <Pre
-            account={account}
-            parentAccount={parentAccount}
-            transaction={transaction}
-            status={status}
-          />
-        ) : null}
-
-        {amount.isZero() ? null : (
-          <TransactionConfirmField label={<Trans i18nKey="send.steps.details.amount" />}>
-            <FormattedVal
-              color={"palette.text.shade80"}
-              unit={unit}
-              val={amount}
-              fontSize={3}
-              inline
-              showCode
-              disableRounding
+        {fields.map((field, i) => {
+          const MaybeComponent = fieldComponents[field.type];
+          if (!MaybeComponent) {
+            console.log(
+              `TransactionConfirm field ${field.type} is not implemented! add a generic implementation in components/TransactionConfirm.js or inside families/*/TransactionConfirmFields.js`,
+            );
+            return null;
+          }
+          return (
+            <MaybeComponent
+              key={i}
+              field={field}
+              account={account}
+              parentAccount={parentAccount}
+              transaction={transaction}
+              status={status}
             />
-          </TransactionConfirmField>
-        )}
-        {noFees ? null : (
-          <TransactionConfirmField label={<Trans i18nKey="send.steps.details.fees" />}>
-            <FormattedVal
-              color={"palette.text.shade80"}
-              unit={feesUnit}
-              val={estimatedFees}
-              fontSize={3}
-              inline
-              showCode
-            />
-          </TransactionConfirmField>
-        )}
-        {Post ? (
-          <Post
-            account={account}
-            parentAccount={parentAccount}
-            transaction={transaction}
-            status={status}
-          />
-        ) : null}
+          );
+        })}
       </Box>
 
       {renderVerifyUnwrapped({ modelId: device.modelId, type })}

--- a/src/renderer/components/TransactionConfirm/index.js
+++ b/src/renderer/components/TransactionConfirm/index.js
@@ -24,7 +24,7 @@ import FormattedVal from "~/renderer/components/FormattedVal";
 import { renderVerifyUnwrapped } from "~/renderer/components/DeviceAction/rendering";
 import TransactionConfirmField from "./TransactionConfirmField";
 
-const AddressText = styled(Text).attrs(() => ({
+const FieldText = styled(Text).attrs(() => ({
   ml: 1,
   ff: "Inter|Medium",
   color: "palette.text.shade80",
@@ -45,8 +45,8 @@ export type FieldComponentProps = {
 
 export type FieldComponent = React$ComponentType<FieldComponentProps>;
 
-const AmountField = ({ account, status: { amount } }: FieldComponentProps) => (
-  <TransactionConfirmField label={<Trans i18nKey="send.steps.details.amount" />}>
+const AmountField = ({ account, status: { amount }, field }: FieldComponentProps) => (
+  <TransactionConfirmField label={field.label}>
     <FormattedVal
       color={"palette.text.shade80"}
       unit={getAccountUnit(account)}
@@ -59,12 +59,12 @@ const AmountField = ({ account, status: { amount } }: FieldComponentProps) => (
   </TransactionConfirmField>
 );
 
-const FeesField = ({ account, parentAccount, status }: FieldComponentProps) => {
+const FeesField = ({ account, parentAccount, status, field }: FieldComponentProps) => {
   const mainAccount = getMainAccount(account, parentAccount);
   const { estimatedFees } = status;
   const feesUnit = getAccountUnit(mainAccount);
   return (
-    <TransactionConfirmField label={<Trans i18nKey="send.steps.details.fees" />}>
+    <TransactionConfirmField label={field.label}>
       <FormattedVal
         color={"palette.text.shade80"}
         unit={feesUnit}
@@ -77,11 +77,22 @@ const FeesField = ({ account, parentAccount, status }: FieldComponentProps) => {
   );
 };
 
-const AddressField = ({ account, parentAccount, field }: FieldComponentProps) => {
+const AddressField = ({ field }: FieldComponentProps) => {
   invariant(field.type === "address", "AddressField invalid");
   return (
     <TransactionConfirmField label={field.label}>
-      <AddressText>{field.address}</AddressText>
+      <FieldText>{field.address}</FieldText>
+    </TransactionConfirmField>
+  );
+};
+
+// NB Leaving AddressField although I think it's redundant at this point
+// in case we want specific styles for addresses.
+const TextField = ({ field }: FieldComponentProps) => {
+  invariant(field.type === "text", "TextField invalid");
+  return (
+    <TransactionConfirmField label={field.label}>
+      <FieldText>{field.value}</FieldText>
     </TransactionConfirmField>
   );
 };
@@ -90,6 +101,7 @@ const commonFieldComponents: { [_: *]: FieldComponent } = {
   amount: AmountField,
   fees: FeesField,
   address: AddressField,
+  text: TextField,
 };
 
 const Container = styled(Box).attrs(() => ({

--- a/src/renderer/families/stellar/TransactionConfirmFields.js
+++ b/src/renderer/families/stellar/TransactionConfirmFields.js
@@ -2,10 +2,10 @@
 
 import invariant from "invariant";
 import React from "react";
-import { withTranslation } from "react-i18next";
-import type { Account, Transaction } from "@ledgerhq/live-common/lib/types";
+import type { Transaction } from "@ledgerhq/live-common/lib/types";
 import TransactionConfirmField from "~/renderer/components/TransactionConfirm/TransactionConfirmField";
 import Text from "~/renderer/components/Text";
+import type { FieldComponentProps } from "~/renderer/components/TransactionConfirm";
 
 const deviceMemoLabels = {
   MEMO_TEXT: "Memo Text",
@@ -21,31 +21,32 @@ const addressStyle = {
   maxWidth: "70%",
 };
 
-const Post = ({ account, transaction }: { account: Account, transaction: Transaction }) => {
+const StellarMemoField = ({ transaction }: { transaction: Transaction }) => {
   invariant(transaction.family === "stellar", "stellar transaction");
 
   return (
-    <>
-      <TransactionConfirmField label={deviceMemoLabels[transaction.memoType || "NO_MEMO"]}>
-        <Text
-          style={addressStyle}
-          ml={1}
-          ff="Inter|Medium"
-          color="palette.text.shade80"
-          fontSize={3}
-        >
-          {transaction.memoValue ? `${transaction.memoValue} ` : "[none]"}
-        </Text>
-      </TransactionConfirmField>
-      <TransactionConfirmField label="Network">
-        <Text ff="Inter|Medium" color="palette.text.shade80" fontSize={3}>
-          {"Public"}
-        </Text>
-      </TransactionConfirmField>
-    </>
+    <TransactionConfirmField label={deviceMemoLabels[transaction.memoType || "NO_MEMO"]}>
+      <Text style={addressStyle} ml={1} ff="Inter|Medium" color="palette.text.shade80" fontSize={3}>
+        {transaction.memoValue ? `${transaction.memoValue} ` : "[none]"}
+      </Text>
+    </TransactionConfirmField>
   );
 };
 
+// NB once we support other networks, we can make this not hardcoded.
+const StellarNetworkField = ({ field }: FieldComponentProps) => (
+  <TransactionConfirmField label={field.label}>
+    <Text ff="Inter|Medium" color="palette.text.shade80" fontSize={3}>
+      {"Public"}
+    </Text>
+  </TransactionConfirmField>
+);
+
+const fieldComponents = {
+  "stellar.memo": StellarMemoField,
+  "stellar.network": StellarNetworkField,
+};
+
 export default {
-  post: withTranslation()(Post),
+  fieldComponents,
 };

--- a/src/renderer/families/tron/TransactionConfirmFields.js
+++ b/src/renderer/families/tron/TransactionConfirmFields.js
@@ -38,38 +38,22 @@ const AddressText = styled(Text).attrs(() => ({
 `;
 
 const TronResourceField = ({ account, parentAccount, transaction, field }: FieldComponentProps) => {
-  invariant(field.type === "tron.resources", "TronResourceField invalid");
+  invariant(field.type === "tron.resource", "TronResourceField invalid");
   return (
-    <TransactionConfirmField label="Resource">
+    <TransactionConfirmField label={field.label}>
       <AddressText ff="Inter|SemiBold">{field.value}</AddressText>
     </TransactionConfirmField>
   );
 };
 
-const TronVotesField = ({
-  account,
-  parentAccount,
-  transaction,
-}: {
-  account: AccountLike,
-  parentAccount: ?Account,
-  transaction: Transaction,
-}) => {
+const TronVotesField = ({ account, parentAccount, transaction, field }: FieldComponentProps) => {
   const mainAccount = getMainAccount(account, parentAccount);
   invariant(transaction.family === "tron", "tron transaction");
   const { votes } = transaction;
   if (!votes) return null;
   return (
     <Box vertical justifyContent="space-between" mb={2}>
-      <TransactionConfirmField
-        label={
-          <Trans
-            i18nKey="TransactionConfirm.votes"
-            count={votes.length}
-            values={{ count: votes.length }}
-          />
-        }
-      />
+      <TransactionConfirmField label={field.label} />
 
       <OperationDetailsVotes votes={votes} account={mainAccount} isTransactionField />
     </Box>

--- a/src/renderer/families/tron/TransactionConfirmFields.js
+++ b/src/renderer/families/tron/TransactionConfirmFields.js
@@ -10,6 +10,7 @@ import { getMainAccount } from "@ledgerhq/live-common/lib/account";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 
 import TransactionConfirmField from "~/renderer/components/TransactionConfirm/TransactionConfirmField";
+import type { FieldComponentProps } from "~/renderer/components/TransactionConfirm";
 import Text from "~/renderer/components/Text";
 import WarnBox from "~/renderer/components/WarnBox";
 import Box from "~/renderer/components/Box";
@@ -36,82 +37,42 @@ const AddressText = styled(Text).attrs(() => ({
   max-width: 50%;
 `;
 
-const Pre = ({
-  account,
-  parentAccount,
-  transaction,
-}: {
-  account: AccountLike,
-  parentAccount: ?Account,
-  transaction: Transaction,
-}) => {
-  const mainAccount = getMainAccount(account, parentAccount);
-
-  invariant(transaction.family === "tron", "tron transaction");
-
-  const { votes, resource } = transaction;
-
+const TronResourceField = ({ account, parentAccount, transaction, field }: FieldComponentProps) => {
+  invariant(field.type === "tron.resources", "TronResourceField invalid");
   return (
-    <>
-      {resource && (
-        <TransactionConfirmField label="Resource">
-          <AddressText ff="Inter|SemiBold">
-            {resource.slice(0, 1).toUpperCase() + resource.slice(1).toLowerCase()}
-          </AddressText>
-        </TransactionConfirmField>
-      )}
-
-      {votes && votes.length > 0 && (
-        <Box vertical justifyContent="space-between" mb={2}>
-          <TransactionConfirmField
-            label={
-              <Trans
-                i18nKey="TransactionConfirm.votes"
-                count={votes.length}
-                values={{ count: votes.length }}
-              />
-            }
-          />
-
-          <OperationDetailsVotes votes={votes} account={mainAccount} isTransactionField />
-        </Box>
-      )}
-    </>
+    <TransactionConfirmField label="Resource">
+      <AddressText ff="Inter|SemiBold">{field.value}</AddressText>
+    </TransactionConfirmField>
   );
 };
 
-const Post = ({
-  transaction,
+const TronVotesField = ({
   account,
   parentAccount,
+  transaction,
 }: {
   account: AccountLike,
   parentAccount: ?Account,
   transaction: Transaction,
 }) => {
-  invariant(transaction.family === "tron", "tron transaction");
   const mainAccount = getMainAccount(account, parentAccount);
-
   invariant(transaction.family === "tron", "tron transaction");
-
-  const from = mainAccount.freshAddress;
-
-  const { mode } = transaction;
-
+  const { votes } = transaction;
+  if (!votes) return null;
   return (
-    <>
-      {(mode === "freeze" || mode === "unfreeze") && (
-        <TransactionConfirmField label={mode === "freeze" ? "Freeze To" : "Delegate To"}>
-          <AddressText>{from}</AddressText>
-        </TransactionConfirmField>
-      )}
+    <Box vertical justifyContent="space-between" mb={2}>
+      <TransactionConfirmField
+        label={
+          <Trans
+            i18nKey="TransactionConfirm.votes"
+            count={votes.length}
+            values={{ count: votes.length }}
+          />
+        }
+      />
 
-      {mode !== "send" ? (
-        <TransactionConfirmField label="From Address">
-          <AddressText>{from}</AddressText>
-        </TransactionConfirmField>
-      ) : null}
-    </>
+      <OperationDetailsVotes votes={votes} account={mainAccount} isTransactionField />
+    </Box>
   );
 };
 
@@ -149,9 +110,13 @@ const Title = ({ transaction }: { transaction: Transaction }) => {
   );
 };
 
+const fieldComponents = {
+  "tron.resource": TronResourceField,
+  "tron.votes": TronVotesField,
+};
+
 export default {
-  pre: Pre,
-  post: Post,
+  fieldComponents,
   warning: Warning,
   title: Title,
   disableFees: () => true,


### PR DESCRIPTION
~To be tested alongside https://github.com/LedgerHQ/ledger-live-common/pull/636 from live-common.~ Already bumped

If this works, on the device verification step of a device-involving operation we should see the fields pertinent to the operation. For instance, on a send for stellar with a memo, we should see the memo on the validating fields on the device.  If this works, we will have the ability to customize the rendering per field per currency, and determining what gets displayed on the app at the live-common level.

### Type

Feature

### Context
https://ledgerhq.atlassian.net/browse/LL-2423

### Parts of the app affected / Test plan
Once https://github.com/LedgerHQ/ledger-live-common/pull/636 is merged we need to go over all the send/delegate/vote/freeze/unfreeze/etc flows to make sure the fields displayed are correct. Sorry.