### PR TITLE
LL-2394 (Tron): unfreeze success modal wording updated

### DIFF
--- a/src/renderer/modals/Unfreeze/steps/StepConfirmation.js
+++ b/src/renderer/modals/Unfreeze/steps/StepConfirmation.js
@@ -29,6 +29,7 @@ const Container: ThemedComponent<{ shouldSpace?: boolean }> = styled(Box).attrs(
 function StepConfirmation({
   account,
   t,
+  transaction,
   optimisticOperation,
   error,
   theme,
@@ -42,7 +43,11 @@ function StepConfirmation({
         <SyncOneAccountOnMount priority={10} accountId={optimisticOperation.accountId} />
         <SuccessDisplay
           title={<Trans i18nKey="unfreeze.steps.confirmation.success.title" />}
-          description={multiline(t("unfreeze.steps.confirmation.success.text"))}
+          description={multiline(
+            t("unfreeze.steps.confirmation.success.text", {
+              resource: transaction && transaction.resource && transaction.resource.toLowerCase(),
+            }),
+          )}
         />
       </Container>
     );

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -590,7 +590,7 @@
         "title": "Confirmation",
         "success": {
           "title": "",
-          "text": "Your assets have been unfrozen successfully. Your Bandwidth points will be decreased and your votes will be canceled.",
+          "text": "Your assets have been unfrozen successfully. Your {{resource}} points will be decreased and your votes will be canceled.",
           "continue": "Continue"
         },
         "pending": {


### PR DESCRIPTION
After unfreezing some trx the success modal confirmation text should display the correct resource unfrozen for. (energy or bandwidth)

### Type

Wording

### Context

LL-2394

### Parts of the app affected / Test plan

Unfreeze some trx chose energy -> success modal should refer to energy unfrozen same applies in the case of bandwidth
