### PR TITLE
LL-2395 (Tron): claim rewards button issue after unfreezing all assets

### DIFF
--- a/src/renderer/families/tron/Votes/index.js
+++ b/src/renderer/families/tron/Votes/index.js
@@ -132,8 +132,9 @@ const Delegation = ({ account }: Props) => {
         >
           <Trans i18nKey="tron.voting.header" />
         </Text>
-        {tronPower > 0 && (formattedVotes.length > 0 || canClaimRewards) ? (
-          <Box horizontal>
+
+        <Box horizontal>
+          {tronPower > 0 && formattedVotes.length > 0 ? (
             <Button small primary onClick={onDelegate} mr={2}>
               <Box horizontal flow={1} alignItems="center">
                 <Vote size={12} />
@@ -148,6 +149,8 @@ const Delegation = ({ account }: Props) => {
                 </Box>
               </Box>
             </Button>
+          ) : null}
+          {formattedVotes.length > 0 || canClaimRewards ? (
             <ToolTip
               content={
                 !canClaimRewards ? (
@@ -190,8 +193,8 @@ const Delegation = ({ account }: Props) => {
                 </Box>
               </Button>
             </ToolTip>
-          </Box>
-        ) : null}
+          ) : null}
+        </Box>
       </Box>
       {tronPower > 0 && formattedVotes.length > 0 ? (
         <Card p={0} mt={24} mb={6}>


### PR DESCRIPTION
 after unfreezing all assets claim rewards should now be available if theres rewards to be claimed

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug Fix

### Context

LL-2395

### Parts of the app affected / Test plan

Have a tron account with rewards that can be claimed, unfreeze everything.
You should now still see the claim rewards button if you have available rewards to be collected.
