### PR TITLE
Fixes LL-2424: currencyBridge.preload() proxy to run in internal

### DIFF
--- a/src/renderer/bridge/proxy-commands.js
+++ b/src/renderer/bridge/proxy-commands.js
@@ -33,6 +33,9 @@ import { getCryptoCurrencyById } from "@ledgerhq/live-common/lib/currencies";
 import { toScanAccountEventRaw } from "@ledgerhq/live-common/lib/bridge";
 import * as bridgeImpl from "@ledgerhq/live-common/lib/bridge/impl";
 
+const cmdCurrencyPreload = ({ currencyId }: { currencyId: string }): Observable<mixed> =>
+  from(bridgeImpl.getCurrencyBridge(getCryptoCurrencyById(currencyId)).preload());
+
 const cmdCurrencyScanAccounts = (o: {
   currencyId: string,
   deviceId: string,
@@ -120,6 +123,7 @@ const cmdAccountEstimateMaxSpendable = (o: {
 };
 
 export const commands = {
+  CurrencyPreload: cmdCurrencyPreload,
   AccountSync: cmdAccountSync,
   AccountGetTransactionStatus: cmdAccountGetTransactionStatus,
   AccountPrepareTransaction: cmdAccountPrepareTransaction,

--- a/src/renderer/bridge/proxy.js
+++ b/src/renderer/bridge/proxy.js
@@ -36,7 +36,11 @@ const scanAccounts = ({ currency, deviceId, syncConfig }) =>
   }).pipe(map(fromScanAccountEventRaw));
 
 export const getCurrencyBridge = (currency: CryptoCurrency): CurrencyBridge => ({
-  preload: () => bridgeImpl.getCurrencyBridge(currency).preload(),
+  preload: async () => {
+    const value = await command("CurrencyPreload")({ currencyId: currency.id }).toPromise();
+    bridgeImpl.getCurrencyBridge(currency).hydrate(value);
+    return value;
+  },
 
   hydrate: value => bridgeImpl.getCurrencyBridge(currency).hydrate(value),
 


### PR DESCRIPTION
regarding the test plan of this, you can heavily test the only 2 coins that today rely on preload(): TRON and Tezos.

- TRON and Tezos both need that to display properly the bakers/delegators list.
- preload() is getting called at the first synchronisation of a given currency (sync OR add accounts) and its data is getting cached.
- That cache is destroyed when you do a **clear cache**.
- That cache is also reloaded each time you re-open Ledger Live.