### PR TITLE
wip regression test with jest image snapshots

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -16,7 +16,7 @@ jobs:
         run: yarn --ignore-scripts --frozen-lockfile
       - name: build the app
         run: yarn nightly
-      - uses: ledgerhq/actions/get-package-infos@v1.1.0
+      - uses: ledgerhq/actions/get-package-infos@v1.2.0
         id: version
       - name: upload macOS app
         uses: actions/upload-artifact@v1
@@ -45,7 +45,7 @@ jobs:
         run: yarn --ignore-scripts --frozen-lockfile
       - name: build the app
         run: yarn nightly
-      - uses: ledgerhq/actions/get-package-infos@v1.1.0
+      - uses: ledgerhq/actions/get-package-infos@v1.2.0
         id: version
       - name: upload linux app
         uses: actions/upload-artifact@v1
@@ -75,7 +75,7 @@ jobs:
         run: yarn --ignore-scripts --frozen-lockfile
       - name: build the app
         run: yarn nightly
-      - uses: ledgerhq/actions/get-package-infos@v1.1.0
+      - uses: ledgerhq/actions/get-package-infos@v1.2.0
         id: version
       - name: upload windows
         uses: actions/upload-artifact@v1

--- a/.github/workflows/bundle-app.yml
+++ b/.github/workflows/bundle-app.yml
@@ -12,7 +12,7 @@ jobs:
   bundle-macos:
     runs-on: macos-latest
     steps:
-      - uses: ledgerhq/actions/check-member@v1.1.0
+      - uses: ledgerhq/actions/check-member@v1.2.0
         with:
           username: ${{ github.actor }}
           ban: ledgerlive
@@ -100,7 +100,7 @@ jobs:
   bundle-windows:
     runs-on: windows-latest
     steps:
-      - uses: ledgerhq/actions/check-member@v1.1.0
+      - uses: ledgerhq/actions/check-member@v1.2.0
         with:
           username: ${{ github.actor }}
           ban: ledgerlive
@@ -127,9 +127,9 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: install dependencies
         run: yarn --ignore-scripts --frozen-lockfile
-      - uses: ledgerhq/actions/get-package-infos@v1.1.0
+      - uses: ledgerhq/actions/get-package-infos@v1.2.0
         id: version
-      - uses: ledgerhq/actions/get-pr-number@v1.1.0
+      - uses: ledgerhq/actions/get-pr-number@v1.2.0
         id: pr
         if: github.event_name == 'pull_request'
       - name: make local version (pr)
@@ -140,7 +140,7 @@ jobs:
         if: github.event_name == 'push'
       - name: build the app
         run: yarn nightly
-      - uses: ledgerhq/actions/get-package-infos@v1.1.0
+      - uses: ledgerhq/actions/get-package-infos@v1.2.0
         id: post-version
       - name: upload windows
         uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: run headless tests
-        uses: ledgerhq/actions/run-headless@v1.1.0
+        uses: ledgerhq/actions/run-headless@v1.2.0
+      - name: upload diffs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v1
+        with:
+          name: "diff_output"
+          path: tests/specs/__image_snapshots__/__diff_output__

--- a/.github/workflows/generate-screenshots.yml
+++ b/.github/workflows/generate-screenshots.yml
@@ -1,0 +1,43 @@
+name: generate jest screenshots
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  generate-screenshots:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@master
+        with:
+          node-version: 12.x
+      - name: get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: check if PR is not screenshots already
+        uses: ledgerhq/actions/check-pr-screenshots@v1.2.0
+      - name: generate new screenshots
+        uses: ledgerhq/actions/run-headless@v1.2.0
+        with:
+          should-update-screenshots: 1
+      - name: check diff
+        run: git status
+        if: ${{ always() }}
+      - name: create pull request with new screenshots if needed
+        uses: peter-evans/create-pull-request@v2
+        with:
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          title: "[Screenshots] new screenshots for ${{ github.sha }}"
+          body: |
+            Auto generated screenshots for ${{ github.sha }} by ${{ github.actor }}
+          assignees: ${{ github.actor }}
+          reviewers: ${{ github.actor }}
+          branch: new-screenshots-${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ dist
 !tools/dist
 
 src/renderer/generated/
+tests/specs/__image_snapshots__/__diff_output__

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "release": "node ./tools/dist --publish",
     "ci": "node ./tools/ci.js",
     "test": "jest src",
-    "spectron": "jest tests/specs/bullrun.spec.js"
+    "spectron": "jest tests/specs/bullrun.spec.js",
+    "generate-screenshots": "PWD=$(pwd); cd docker; docker run -v \"$PWD:/github/workspace\" -w \"/github/workspace\" --rm -it $(docker build -q .)"
   },
   "engines": {
     "node": ">=12"
@@ -164,7 +165,7 @@
     "hasha": "^5.2.0",
     "html-webpack-plugin": "^3.2.0",
     "jest": "^25.1.0",
-    "jest-image-snapshot": "^2.12.0",
+    "jest-image-snapshot": "^4.0.0",
     "listr": "^0.14.3",
     "listr-verbose-renderer": "^0.6.0",
     "prettier": "^1.19.1",

--- a/tests/specs/bullrun.spec.js
+++ b/tests/specs/bullrun.spec.js
@@ -4,23 +4,28 @@ import ModalPage from "../po/modal.page";
 import GenuinePage from "../po/genuine.page";
 import PasswordPage from "../po/password.page";
 import AnalyticsPage from "../po/analytics.page";
-import PortfolioPage from "../po/portfolio.page";
+// import PortfolioPage from "../po/portfolio.page";
 import data from "../data/onboarding/";
 import {
   deviceInfo155 as deviceInfo,
   mockListAppsResult,
 } from "@ledgerhq/live-common/lib/apps/mock";
+import { toMatchImageSnapshot } from "jest-image-snapshot";
+import { delay } from "@ledgerhq/live-common/lib/promise";
+
+expect.extend({ toMatchImageSnapshot });
 
 jest.setTimeout(600000);
 
 describe("Bullrun", () => {
   let app;
+  let image;
   let onboardingPage;
   let modalPage;
   let genuinePage;
   let passwordPage;
   let analyticsPage;
-  let portfolioPage;
+  // let portfolioPage;
   let mockDeviceEvent;
 
   beforeAll(async () => {
@@ -30,9 +35,8 @@ describe("Bullrun", () => {
     genuinePage = new GenuinePage(app);
     passwordPage = new PasswordPage(app);
     analyticsPage = new AnalyticsPage(app);
-    portfolioPage = new PortfolioPage(app);
+    // portfolioPage = new PortfolioPage(app);
     mockDeviceEvent = getMockDeviceEvent(app);
-
     return app.start();
   });
 
@@ -63,8 +67,26 @@ describe("Bullrun", () => {
   it("go through onboarding", async () => {
     await app.client.waitForVisible("#onboarding-get-started-button", 20000);
     await onboardingPage.getStarted();
+    await delay(1000);
+    image = await app.browserWindow.capturePage();
+    expect(image).toMatchImageSnapshot({
+      customSnapshotIdentifier: "onboarding-get-started",
+      allowSizeMismatch: true,
+    });
     await onboardingPage.selectConfiguration("new");
+    await delay(1000);
+    image = await app.browserWindow.capturePage();
+    expect(image).toMatchImageSnapshot({
+      customSnapshotIdentifier: "onboarding-screen-new",
+      allowSizeMismatch: true,
+    });
     await onboardingPage.selectDevice("nanox");
+    await delay(1000);
+    image = await app.browserWindow.capturePage();
+    expect(image).toMatchImageSnapshot({
+      customSnapshotIdentifier: "onboarding-screen-nano-x",
+      allowSizeMismatch: true,
+    });
     await onboardingPage.continue();
     await onboardingPage.continue();
     await onboardingPage.continue();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7800,18 +7800,18 @@ jest-haste-map@^25.4.0:
   optionalDependencies:
     fsevents "^2.1.2"
 
-jest-image-snapshot@^2.12.0:
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/jest-image-snapshot/-/jest-image-snapshot-2.12.0.tgz#5289438cbdc8f2ed834e798c3503ed7313153df8"
-  integrity sha512-hRiy+1Ygv1Of0As9R8M2Q8eTawT9wmmezJKAGfeciZrYllQW5bGL0n6Wgk/J2OG70t5zJr3ZXDx2faui1uGw0g==
+jest-image-snapshot@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jest-image-snapshot/-/jest-image-snapshot-4.0.0.tgz#e0c46b953d04420682d9f5636d186a0e98dd96be"
+  integrity sha512-kIbc/NcG0D51PS/5fGJrhg0hj6t2zasOIZzTxN6QjBkRLAevdYkm/DqrLgWSX6wU0YZV4hNtayRWCReCjnE44w==
   dependencies:
     chalk "^1.1.3"
     get-stdin "^5.0.1"
     glur "^1.1.2"
     lodash "^4.17.4"
     mkdirp "^0.5.1"
-    pixelmatch "^4.0.2"
-    pngjs "^3.3.3"
+    pixelmatch "^5.1.0"
+    pngjs "^3.4.0"
     rimraf "^2.6.2"
 
 jest-jasmine2@^25.4.0:
@@ -9981,12 +9981,12 @@ pirates@^4.0.1:
   dependencies:
     node-modules-regexp "^1.0.0"
 
-pixelmatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/pixelmatch/-/pixelmatch-4.0.2.tgz#8f47dcec5011b477b67db03c243bc1f3085e8854"
-  integrity sha1-j0fc7FARtHe2fbA8JDvB8wheiFQ=
+pixelmatch@^5.1.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/pixelmatch/-/pixelmatch-5.2.0.tgz#6433386c6a830b0d9ee3962f9ad59695500677cd"
+  integrity sha512-TdleROuanI+Uo/4PcOAH7b7qgO4kjzJO8K4y/TBAo1wx/5BE8cn1B0I6Jfk3mKcJsGpWvX7zjM8OjU5o9i+aog==
   dependencies:
-    pngjs "^3.0.0"
+    pngjs "^4.0.1"
 
 pkg-config@^1.1.0:
   version "1.1.1"
@@ -10037,10 +10037,15 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
-pngjs@^3.0.0, pngjs@^3.3.0, pngjs@^3.3.3:
+pngjs@^3.3.0, pngjs@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
   integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
+
+pngjs@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-4.0.1.tgz#f803869bb2fc1bfe1bf99aa4ec21c108117cfdbe"
+  integrity sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
### Type

Feat

### Context

LL-2438

### Parts of the app affected / Test plan

Tests

This PR setup jest-image-snapshot as a way of doing regression testing on the screen of Ledger Live. 

What this PR is NOT: a full suite of test using jest-snapshot-testing.

I believe it's pretty easy to keep on improving the test using the bullrun and this PR. QA team here you go !!!


