### PR TITLE
Fix DelegateAmountCell rendering when amount==0

### DIFF
--- a/src/renderer/families/cosmos/operationDetails.js
+++ b/src/renderer/families/cosmos/operationDetails.js
@@ -299,7 +299,7 @@ const DelegateAmountCell = ({ operation, currency, unit }: Props) => {
       ? operation.extra.validators.reduce((sum, { amount }) => sum.plus(amount), BigNumber(0))
       : BigNumber(0);
 
-  if (amount.isZero()) return;
+  if (amount.isZero()) return null;
 
   const formattedAmount = formatCurrencyUnit(unit, amount, {
     disableRounding: false,


### PR DESCRIPTION
React prefers a `return null` over a bare `return` and that breaks the UI when reaching that branch

### Type
Bug Fix

### Context
Internal Slack channel

