### PR TITLE
LL-2051 Fix missing placeholder text for tokens, plus alignment polish

### DIFF
--- a/src/renderer/screens/account/TokensList.js
+++ b/src/renderer/screens/account/TokensList.js
@@ -3,7 +3,10 @@
 import React, { PureComponent } from "react";
 import type { PortfolioRange } from "@ledgerhq/live-common/lib/types/portfolio";
 import { listSubAccounts } from "@ledgerhq/live-common/lib/account/helpers";
-import { listTokenTypesForCryptoCurrency } from "@ledgerhq/live-common/lib/currencies";
+import {
+  listTokensForCryptoCurrency,
+  listTokenTypesForCryptoCurrency,
+} from "@ledgerhq/live-common/lib/currencies";
 import styled from "styled-components";
 import { Trans, withTranslation } from "react-i18next";
 import { withRouter } from "react-router-dom";
@@ -49,6 +52,7 @@ const EmptyState: ThemedComponent<{}> = styled.div`
   border-radius: 4px;
   display: flex;
   flex-direction: row;
+  align-items: center;
   > :first-child {
     flex: 1;
   }
@@ -99,10 +103,15 @@ class TokensList extends PureComponent<Props> {
 
     if (!isTokenAccount && isEmpty) return null;
 
-    const url =
-      currency && currency.type === "TokenCurrency"
-        ? supportLinkByTokenType[currency.tokenType]
-        : null;
+    let url;
+    let firstToken;
+    if (currency && currency.type !== "TokenCurrency") {
+      const tokens = listTokensForCryptoCurrency(currency);
+      if (tokens) {
+        firstToken = tokens[0];
+        url = supportLinkByTokenType[tokens[0].tokenType];
+      }
+    }
 
     return (
       <Box mb={50}>
@@ -117,13 +126,18 @@ class TokensList extends PureComponent<Props> {
             <Placeholder>
               {url ? (
                 <Text color="palette.text.shade80" ff="Inter|SemiBold" fontSize={4}>
-                  <Trans i18nKey={"tokensList.placeholder"} />{" "}
+                  <Trans
+                    i18nKey={"tokensList.placeholder"}
+                    values={{ currencyName: currency.name }}
+                  />{" "}
                   <LabelWithExternalIcon
                     color="wallet"
                     ff="Inter|SemiBold"
                     onClick={() => {
-                      openURL(url);
-                      track("More info on Manage ERC20 tokens");
+                      if (url) {
+                        openURL(url);
+                        track(`More info on Manage ${firstToken.name} tokens`);
+                      }
                     }}
                     label={t("tokensList.link")}
                   />

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -256,7 +256,7 @@
   "tokensList": {
     "title": "Tokens",
     "cta": "Add token",
-    "placeholder": "To add tokens, simply send them to your Ethereum address.",
+    "placeholder": "To add tokens, simply send them to your {{currencyName}} address.",
     "link": "Learn more",
     "seeTokens": "Show tokens ({{tokenCount}})",
     "hideTokens": "Hide tokens ({{tokenCount}})",


### PR DESCRIPTION

<img width="1136" alt="Screenshot 2020-06-02 at 12 19 25" src="https://user-images.githubusercontent.com/4631227/83509549-e83f4b80-a4cb-11ea-90ba-46ab9232bdf8.png">
<img width="1136" alt="Screenshot 2020-06-02 at 12 13 52" src="https://user-images.githubusercontent.com/4631227/83509559-ed9c9600-a4cb-11ea-94fd-9f3df6f4b2f5.png">

When looking at the alignment issue I saw we weren't even showing the text with the current version, meaning users will not see the placeholder nor the help link until this is merged.

### Type

Bug Fix + UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2051
### Parts of the app affected / Test plan

Test the wording and links are correct for all currencies supporting tokens, it should refer to the first available token, meaning for example for tron it would refer to trc10 and not trc20 (or the other way around)