### PR TITLE
LL-2499 (Modals): fixed focus issue

### DIFF
--- a/src/renderer/components/Modal/index.js
+++ b/src/renderer/components/Modal/index.js
@@ -172,7 +172,8 @@ class Modal extends PureComponent<Props> {
 
   /** combined with tab-index 0 this will allow tab navigation into the modal disabling tab navigation behind it */
   setFocus = (r: *) => {
-    r && r.focus();
+    /** only pull focus if focus is out of modal ie: no input autofocused in modal */
+    r && !r.contains(document.activeElement) && r.focus();
   };
 
   swallowClick = (e: Event) => {


### PR DESCRIPTION
Modals issue when an input was requesting autoFocus but was overtaken by modal focus instead.
Now modals should only pull focus if the active element is out of the modal container element for tab issues.

### Type

Bug Fix

### Context

LL-2499

### Parts of the app affected / Test plan

Open the modal of password or send/receive:
inputs should autoFocus now
as for the modals in the manager (dependencies app installation) they should retain tab navigation as well.
