### PR TITLE
Cosmos: fix redelegation errors

### DIFF
--- a/src/renderer/families/cosmos/RedelegationFlowModal/Body.js
+++ b/src/renderer/families/cosmos/RedelegationFlowModal/Body.js
@@ -1,6 +1,7 @@
 // @flow
 import invariant from "invariant";
 import React, { useState, useCallback } from "react";
+import { BigNumber } from "bignumber.js";
 import { compose } from "redux";
 import { connect, useDispatch } from "react-redux";
 import { Trans, withTranslation } from "react-i18next";
@@ -131,13 +132,17 @@ const Body = ({
 
     invariant(account && account.cosmosResources, "cosmos: account and cosmos resources required");
 
+    const source = account.cosmosResources?.delegations.find(
+      d => d.validatorAddress === validatorAddress,
+    );
+
     const bridge = getAccountBridge(account, undefined);
 
     const t = bridge.createTransaction(account);
 
     const transaction = bridge.updateTransaction(t, {
       mode: "redelegate",
-      validators: [],
+      validators: [{ address: "", amount: source?.amount ?? BigNumber(0) }],
       cosmosSourceValidator: validatorAddress,
     });
 

--- a/src/renderer/families/cosmos/RedelegationFlowModal/fields/RedelegationSelectorField.js
+++ b/src/renderer/families/cosmos/RedelegationFlowModal/fields/RedelegationSelectorField.js
@@ -59,6 +59,7 @@ export default function RedelegationSelectorField({
         onInputChange={setQuery}
         inputValue={query}
         filterOption={false}
+        isDisabled={options.length <= 1}
         placeholder={t("common.selectAccount")}
         noOptionsMessage={({ inputValue }) =>
           t("common.selectAccountNoOption", { accountName: inputValue })

--- a/src/renderer/families/cosmos/RedelegationFlowModal/index.js
+++ b/src/renderer/families/cosmos/RedelegationFlowModal/index.js
@@ -23,7 +23,7 @@ class RedelegationModal extends PureComponent<{ name: string }, State> {
     const { stepId } = this.state;
     const { name } = this.props;
 
-    const isModalLocked = !["connectDevice", "confirmation"].includes(stepId);
+    const isModalLocked = ["connectDevice", "confirmation"].includes(stepId);
 
     return (
       <Modal

--- a/src/renderer/families/cosmos/UndelegationFlowModal/fields/Amount.js
+++ b/src/renderer/families/cosmos/UndelegationFlowModal/fields/Amount.js
@@ -29,10 +29,11 @@ export default function AmountField({
   const unit = getAccountUnit(account);
 
   const [currentValidator, setCurrentValidator] = useState(validator);
+  const [focused, setFocused] = useState(false);
   const [initialAmount, setInitialAmount] = useState(validator ? validator.amount : BigNumber(0));
 
   useEffect(() => {
-    if (validator && validator.address !== currentValidator.address) {
+    if (validator && validator.validatorAddress !== currentValidator.validatorAddress) {
       setCurrentValidator(validator);
       setInitialAmount(validator.amount);
     }
@@ -60,8 +61,8 @@ export default function AmountField({
     [initialAmount],
   );
 
-  const error = useMemo(() => Object.values(errors || {})[0], [errors]);
-  const warning = useMemo(() => Object.values(warnings || {})[0], [warnings]);
+  const error = useMemo(() => focused && Object.values(errors || {})[0], [focused, errors]);
+  const warning = useMemo(() => focused && Object.values(warnings || {})[0], [focused, warnings]);
 
   return (
     <Box my={2}>
@@ -74,6 +75,7 @@ export default function AmountField({
         unit={unit}
         value={amount}
         onChange={onChange}
+        onChangeFocus={setFocused}
         renderLeft={<InputLeft>{unit.code}</InputLeft>}
         renderRight={
           <InputRight>

--- a/src/renderer/families/cosmos/operationDetails.js
+++ b/src/renderer/families/cosmos/operationDetails.js
@@ -135,7 +135,10 @@ const OperationDetailsExtra = ({ extra, type, account }: OperationDetailsExtraPr
       );
     }
     case "UNDELEGATE": {
-      const validator = extra?.validators[0];
+      const { validators } = extra;
+      if (!validators || validators.length <= 0) return null;
+
+      const validator = extra.validators[0];
 
       const formattedValidator = cosmosValidators.find(
         v => v.validatorAddress === validator.address,
@@ -170,9 +173,10 @@ const OperationDetailsExtra = ({ extra, type, account }: OperationDetailsExtraPr
       );
     }
     case "REDELEGATE": {
-      const validator = extra?.validators[0];
-      const { cosmosSourceValidator } = extra;
-      if (!validator || !cosmosSourceValidator) return null;
+      const { cosmosSourceValidator, validators } = extra;
+      if (!validators || validators.length <= 0 || !cosmosSourceValidator) return null;
+
+      const validator = extra.validators[0];
 
       const formattedValidator = cosmosValidators.find(
         v => v.validatorAddress === validator.address,
@@ -220,8 +224,10 @@ const OperationDetailsExtra = ({ extra, type, account }: OperationDetailsExtraPr
       );
     }
     case "REWARD": {
-      const validator = extra?.validators[0];
-      if (!validator) return null;
+      const { validators } = extra;
+      if (!validators || validators.length <= 0) return null;
+
+      const validator = extra.validators[0];
 
       const formattedValidator = cosmosValidators.find(
         v => v.validatorAddress === validator.address,

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -2060,6 +2060,9 @@
     "NotEnoughBalanceToDelegate": {
       "title": "Insufficient balance to delegate"
     },
+    "NotEnoughDelegationBalance": {
+      "title": "Insufficient balance to delegate"
+    },
     "NotEnoughBalanceInParentAccount": {
       "title": "Insufficient balance in parent account"
     },


### PR DESCRIPTION
- Fix redelegation error handling
- The errors should appear when editing not when the form is still empty.
- Issue on redelegation preview operations

### Type

Bug Fix

### Context

#33 #34

### Parts of the app affected / Test plan

:atom: accounts
