### PR TITLE
LL-2523 Fix tooltip text color on freeze confirmation modal

### DIFF
--- a/src/renderer/modals/Freeze/steps/StepConfirmation.js
+++ b/src/renderer/modals/Freeze/steps/StepConfirmation.js
@@ -33,10 +33,10 @@ const Container: ThemedComponent<{ shouldSpace?: boolean }> = styled(Box).attrs(
 
 const TooltipContent = () => (
   <Box style={{ padding: 4 }}>
-    <Text color="palette.primary.contrastText" style={{ marginBottom: 5 }}>
+    <Text style={{ marginBottom: 5 }}>
       <Trans i18nKey="freeze.steps.confirmation.tooltip.title" />
     </Text>
-    <Text color="palette.primary.contrastText">
+    <Text>
       <Trans i18nKey="freeze.steps.confirmation.tooltip.desc" />
     </Text>
   </Box>


### PR DESCRIPTION

![tooltip](https://user-images.githubusercontent.com/4631227/84757679-b8606f80-afc4-11ea-8f86-6fba6b0991a6.png)

Dropping the contrast color fixes the bug, contrast color as discussed with @IAmMorrow is not supposed to be used for a black/white contrast but rather as a contrast the ledger blue, so it's basically white for now, and that is confusing.

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2523

### Parts of the app affected / Test plan

Follow the freeze flow, check the modal tooltip works (text visible) with the different themes