### PR TITLE
Select currency order tokens after currencies

### DIFF
--- a/src/renderer/components/SelectCurrency.js
+++ b/src/renderer/components/SelectCurrency.js
@@ -14,6 +14,7 @@ import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
 type Props<C: Currency> = {
   onChange: (?C) => void,
   currencies: C[],
+  tokens: C[],
   value?: C,
   placeholder?: string,
   autoFocus?: boolean,
@@ -29,6 +30,7 @@ const SelectCurrency = <C: Currency>({
   value,
   placeholder,
   currencies,
+  tokens,
   autoFocus,
   minWidth,
   width,
@@ -50,8 +52,8 @@ const SelectCurrency = <C: Currency>({
   );
 
   const options = useMemo(
-    () => cryptos.map(c => ({ ...c, value: c, label: c.name, currency: c })),
-    [cryptos],
+    () => cryptos.concat(tokens).map(c => ({ ...c, value: c, label: c.name, currency: c })),
+    [cryptos, tokens],
   );
 
   const fuseOptions = {
@@ -59,12 +61,14 @@ const SelectCurrency = <C: Currency>({
     keys: ["name", "ticker"],
     shouldSort: false,
   };
+
   const manualFilter = useCallback(() => {
     const fuse = new Fuse(options, fuseOptions);
     return searchInputValue.length > 0 ? fuse.search(searchInputValue) : options;
   }, [searchInputValue, options, fuseOptions]);
 
   const filteredOptions = manualFilter();
+
   return (
     <Select
       autoFocus={autoFocus}

--- a/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.js
+++ b/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.js
@@ -43,12 +43,19 @@ const TokenTips = memo(function TokenTips({ currency }: { currency: TokenCurrenc
 });
 
 const StepChooseCurrency = ({ currency, setCurrency }: StepProps) => {
-  const currencies = useMemo(() => listSupportedCurrencies().concat(listTokens()), []);
+  const currencies = useMemo(() => listSupportedCurrencies(), []);
+  const tokens = useMemo(() => listTokens(), []);
   return (
     <>
       {currency ? <CurrencyDownStatusAlert currency={currency} /> : null}
       {/* $FlowFixMe: onChange type is not good */}
-      <SelectCurrency currencies={currencies} autoFocus onChange={setCurrency} value={currency} />
+      <SelectCurrency
+        currencies={currencies}
+        tokens={tokens}
+        autoFocus
+        onChange={setCurrency}
+        value={currency}
+      />
       {currency && currency.type === "TokenCurrency" ? <TokenTips currency={currency} /> : null}
     </>
   );


### PR DESCRIPTION
(SelectCurrency): reorder tokens after currencies on the select lists

tokens are appended to the cryptocurrencies list after marketcap sorting

![localhost_8080_webpack_index html_theme=dusk](https://user-images.githubusercontent.com/11752937/84781182-d0e18180-afe6-11ea-88db-187fe04a47c6.png)


point #81 of cosmos ICC

### Type

UI Polish

### Parts of the app affected / Test plan

on add accounts or any currency selector the ordering should reflect those changes
