### PR TITLE
(csms): fix ui modals error stepper handling

### DIFF
--- a/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.js
+++ b/src/renderer/families/cosmos/ClaimRewardsFlowModal/Body.js
@@ -171,6 +171,14 @@ const Body = ({
   const error = transactionError || bridgeError || status.errors.amount;
   const warning = status.warnings ? Object.values(status.warnings)[0] : null;
 
+  const errorSteps = [];
+
+  if (transactionError) {
+    errorSteps.push(2);
+  } else if (bridgeError) {
+    errorSteps.push(0);
+  }
+
   const stepperProps = {
     title: t("cosmos.claimRewards.flow.title"),
     device,
@@ -180,9 +188,9 @@ const Body = ({
     signed,
     stepId,
     steps,
-    errorSteps: [],
+    errorSteps,
     disabledSteps: [],
-    hideBreadcrumb: !!error || !!warning,
+    hideBreadcrumb: (!!error || !!warning) && ["claimRewards"].includes(stepId),
     onRetry: handleRetry,
     onStepChange: handleStepChange,
     onClose: handleCloseModal,

--- a/src/renderer/families/cosmos/DelegationFlowModal/Body.js
+++ b/src/renderer/families/cosmos/DelegationFlowModal/Body.js
@@ -158,6 +158,14 @@ const Body = ({
 
   const error = transactionError || bridgeError;
 
+  const errorSteps = [];
+
+  if (transactionError) {
+    errorSteps.push(2);
+  } else if (bridgeError) {
+    errorSteps.push(0);
+  }
+
   const stepperProps = {
     title: t("cosmos.delegation.flow.title"),
     device,
@@ -167,9 +175,9 @@ const Body = ({
     signed,
     stepId,
     steps,
-    errorSteps: [],
+    errorSteps,
     disabledSteps: [],
-    hideBreadcrumb: !!error,
+    hideBreadcrumb: !!error && ["castDelegations"].includes(stepId),
     onRetry: handleRetry,
     onStepChange: handleStepChange,
     onClose: handleCloseModal,

--- a/src/renderer/families/cosmos/RedelegationFlowModal/Body.js
+++ b/src/renderer/families/cosmos/RedelegationFlowModal/Body.js
@@ -183,6 +183,14 @@ const Body = ({
 
   const error = transactionError || bridgeError;
 
+  const errorSteps = [];
+
+  if (transactionError) {
+    errorSteps.push(2);
+  } else if (bridgeError) {
+    errorSteps.push(0);
+  }
+
   const stepperProps = {
     title: t("cosmos.redelegation.flow.title"),
     device,
@@ -192,9 +200,11 @@ const Body = ({
     signed,
     stepId,
     steps,
-    errorSteps: [],
+    errorSteps,
     disabledSteps: [],
-    hideBreadcrumb: !!error || ["starter", "destinationValidators"].includes(stepId),
+    hideBreadcrumb:
+      (!!error && ["validators"].includes(stepId)) ||
+      ["starter", "destinationValidators"].includes(stepId),
     onRetry: handleRetry,
     onStepChange: handleStepChange,
     onClose: handleCloseModal,

--- a/src/renderer/families/cosmos/UndelegationFlowModal/Body.js
+++ b/src/renderer/families/cosmos/UndelegationFlowModal/Body.js
@@ -135,6 +135,14 @@ function Body({
     setTransactionError(error);
   }, []);
 
+  const errorSteps = [];
+
+  if (transactionError) {
+    errorSteps.push(2);
+  } else if (bridgeError) {
+    errorSteps.push(0);
+  }
+
   const stepperProps = {
     title: t("cosmos.undelegation.flow.title"),
     device,
@@ -143,9 +151,9 @@ function Body({
     signed,
     stepId,
     steps,
-    errorSteps: [],
+    errorSteps,
     disabledSteps: [],
-    hideBreadcrumb: !!error,
+    hideBreadcrumb: !!error && ["amount"].includes(stepId),
     onRetry: handleRetry,
     onStepChange: handleStepChange,
     onClose: handleCloseModal,


### PR DESCRIPTION
Issues on the UI stepper not reacting properly to errors on the cosmos flows

![localhost_8080_webpack_index html_theme=dusk](https://user-images.githubusercontent.com/11752937/84795246-84eb0880-aff7-11ea-93cf-3182837a01fc.png)


### Type

UI Polish

### Context

Pixel polish from @khalilbenihoud 

### Parts of the app affected / Test plan

Try and refuse cosmos operation to see the error stepper.
