### PR TITLE
LL-2641 NavigationGuard issue

### DIFF
--- a/src/renderer/components/NavigationGuard.js
+++ b/src/renderer/components/NavigationGuard.js
@@ -87,14 +87,16 @@ const NavigationGuard = ({
   return (
     <>
       <Prompt when={when} message={handleBlockedNavigation} />
-      <ConfirmModal
-        {...confirmModalProps}
-        analyticsName={analyticsName}
-        isOpened={modalVisible}
-        onCancel={closeModal}
-        onReject={handleConfirmNavigationClick}
-        onConfirm={closeModal}
-      />
+      {when && (
+        <ConfirmModal
+          {...confirmModalProps}
+          analyticsName={analyticsName}
+          isOpened={modalVisible}
+          onCancel={closeModal}
+          onReject={handleConfirmNavigationClick}
+          onConfirm={closeModal}
+        />
+      )}
     </>
   );
 };

--- a/src/renderer/components/NavigationGuard.js
+++ b/src/renderer/components/NavigationGuard.js
@@ -33,6 +33,8 @@ const NavigationGuard = ({
   useEffect(() => {
     /** Set redux navigation lock status */
     dispatch(setNavigationLock(when));
+    /** force close modal when condition is over */
+    if (!when) setModalVisible(false);
     return () => {
       /** Reset redux navigation lock status */
       dispatch(setNavigationLock(false));


### PR DESCRIPTION
(NavigationGuard): close modal when condition is over; not only after a cta click.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug Fix

### Context

LL-2641

### Parts of the app affected / Test plan

Try un/installing an app on the manager and immediately after navigation to the portfolio:
- the navigation guard modal should appear
- the modal should close itself once the un/installation is complete
