### PR TITLE
outdated app warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ledgerhq/hw-transport-http": "^5.17.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.17.0",
     "@ledgerhq/ledger-core": "6.5.4",
-    "@ledgerhq/live-common": "^12.34.0",
+    "@ledgerhq/live-common": "^12.35.1",
     "@ledgerhq/logs": "^5.17.0",
     "@tippyjs/react": "^4.0.2",
     "@trust/keyto": "^1.0.1",

--- a/src/renderer/components/DeviceAction/index.js
+++ b/src/renderer/components/DeviceAction/index.js
@@ -22,6 +22,7 @@ import {
   renderLoading,
   renderRequestQuitApp,
   renderRequiresAppInstallation,
+  renderWarningOutdated,
 } from "./rendering";
 
 type OwnProps<R, H, P> = {
@@ -71,6 +72,7 @@ const DeviceAction = <R, H, P>({
 }: Props<R, H, P>) => {
   const hookState = action.useHook(reduxDevice, request);
   const {
+    appAndVersion,
     device,
     unresponsive,
     error,
@@ -89,6 +91,8 @@ const DeviceAction = <R, H, P>({
     onRepairModal,
     deviceSignatureRequested,
     deviceStreamingProgress,
+    displayUpgradeWarning,
+    passWarning,
   } = hookState;
 
   const type = useTheme("colors.palette.type");
@@ -99,6 +103,10 @@ const DeviceAction = <R, H, P>({
       dispatch(setPreferredDeviceModel(modelId));
     }
   }, [dispatch, modelId, preferredDeviceModel]);
+
+  if (displayUpgradeWarning && appAndVersion) {
+    return renderWarningOutdated({ appName: appAndVersion.name, passWarning });
+  }
 
   if (repairModalOpened && repairModalOpened.auto) {
     return <AutoRepair onDone={closeRepairModal} />;
@@ -143,7 +151,14 @@ const DeviceAction = <R, H, P>({
   }
 
   if ((!isLoading && !device) || unresponsive) {
-    return renderConnectYourDevice({ modelId, type, unresponsive, device, onRepairModal, onRetry });
+    return renderConnectYourDevice({
+      modelId,
+      type,
+      unresponsive,
+      device,
+      onRepairModal,
+      onRetry,
+    });
   }
 
   if (isLoading) {

--- a/src/renderer/components/DeviceAction/rendering.js
+++ b/src/renderer/components/DeviceAction/rendering.js
@@ -21,6 +21,7 @@ import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import { getDeviceAnimation } from "./animations";
 import { DeviceBlocker } from "./DeviceBlocker";
 import ErrorIcon from "~/renderer/components/ErrorIcon";
+import IconTriangleWarning from "~/renderer/icons/TriangleWarning";
 import SupportLinkError from "~/renderer/components/SupportLinkError";
 
 const AnimationWrapper: ThemedComponent<{ modelId: DeviceModelId }> = styled.div`
@@ -44,12 +45,12 @@ const Wrapper: ThemedComponent<{}> = styled.div`
   max-width: 100%;
 `;
 
-const Logo = styled.div`
+const Logo: ThemedComponent<{ warning?: boolean }> = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  color: ${p => p.theme.colors.alertRed};
+  color: ${p => (p.warning ? p.theme.colors.warning : p.theme.colors.alertRed)};
   margin-bottom: 20px;
 `;
 
@@ -146,9 +147,11 @@ export const renderVerifyUnwrapped = ({
 const OpenManagerBtn = ({
   closeAllModal,
   appName,
+  mt = 2,
 }: {
   closeAllModal: () => void,
   appName?: string,
+  mt?: number,
 }) => {
   const history = useHistory();
   const onClick = useCallback(() => {
@@ -156,7 +159,7 @@ const OpenManagerBtn = ({
     closeAllModal();
   }, [history, appName, closeAllModal]);
   return (
-    <Button mt={2} primary onClick={onClick}>
+    <Button mt={mt} primary onClick={onClick}>
       <Trans i18nKey="DeviceAction.openManager" />
     </Button>
   );
@@ -229,6 +232,32 @@ export const renderAllowOpeningApp = ({
         )}
       </Title>
     </Footer>
+  </Wrapper>
+);
+
+export const renderWarningOutdated = ({
+  passWarning,
+  appName,
+}: {
+  passWarning: () => void,
+  appName: string,
+}) => (
+  <Wrapper id={`warning-outdated-app`}>
+    <Logo warning>
+      <IconTriangleWarning size={44} />
+    </Logo>
+    <ErrorTitle>
+      <Trans i18nKey="DeviceAction.outdated" />
+    </ErrorTitle>
+    <ErrorDescription>
+      <Trans i18nKey="DeviceAction.outdatedDesc" values={{ appName }} />
+    </ErrorDescription>
+    <ButtonContainer>
+      <Button secondary onClick={passWarning}>
+        <Trans i18nKey="common.continue" />
+      </Button>
+      <OpenManagerButton ml={4} mt={0} appName={appName} />
+    </ButtonContainer>
   </Wrapper>
 );
 

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -411,7 +411,9 @@
     "unlockDevice": "Unlock your device",
     "quitApp": "Quit the application on your device",
     "appNotInstalled": "Please install the {{appName}} app",
-    "openManager": "Open Manager"
+    "openManager": "Open Manager",
+    "outdated": "App version outdated",
+    "outdatedDesc": "An important update is available for the {{appName}} application on your device. Please go to the Manager to update it."
   },
   "manager": {
     "tabs": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,10 +1439,10 @@
     node-pre-gyp "^0.14.0"
     node-pre-gyp-github "^1.4.3"
 
-"@ledgerhq/live-common@^12.34.0":
-  version "12.34.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.34.0.tgz#2eee17c5d319ec77cdcb122f16cf90bbc3c754b9"
-  integrity sha512-vtY62EeY8HPvFsbOueMIxZnnuf6p5gAGRK5FW8l0AXO3k0TZFl03Ba+ZsZgtEaFLc6GZolMz0kj21WIrv39d4A==
+"@ledgerhq/live-common@^12.35.1":
+  version "12.35.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.35.1.tgz#902d0ae9617177eb2e8eac51519202b254e07de3"
+  integrity sha512-RD4FFM6L9RuoQFUt14CG/t6/CxS7KzwQyO2dB9s0q7GSN2i1r4rWdPgF/htfNjCeXwx2J4LUu94RXcv63cDoAw==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.17.0"


### PR DESCRIPTION
Adds a new screen telling the user when one of their app needs to do a `critical` update of their app

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-2650

### Parts of the app affected / Test plan

**To test the feature, you need to yalc https://github.com/LedgerHQ/ledger-live-common/pull/730**

Any flow that has an `open app` in it (all transactions and add account)

![CleanShot 2020-06-18 at 17 53 32](https://user-images.githubusercontent.com/671786/85043487-b6490d00-b18c-11ea-8f0c-9229300115fa.png)

