### PR TITLE
POC Notification system

### DIFF
--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -13,6 +13,7 @@ import "tippy.js/dist/svg-arrow.css";
 
 import type { State } from "~/renderer/reducers";
 import StyleProvider from "~/renderer/styles/StyleProvider";
+import NotificationsProvider from "~/renderer/components/Notifications/NotificationsProvider";
 import { UpdaterProvider } from "~/renderer/components/Updater/UpdaterContext";
 import ThrowBlock from "~/renderer/components/ThrowBlock";
 import LiveStyleSheetManager from "~/renderer/styles/LiveStyleSheetManager";
@@ -27,15 +28,17 @@ const App = ({ store }: Props) => (
   <LiveStyleSheetManager>
     <Provider store={store}>
       <StyleProvider selectedPalette="light">
-        <ThrowBlock>
-          <RemoteConfigProvider>
-            <UpdaterProvider>
-              <Router>
-                <Default />
-              </Router>
-            </UpdaterProvider>
-          </RemoteConfigProvider>
-        </ThrowBlock>
+        <NotificationsProvider>
+          <ThrowBlock>
+            <RemoteConfigProvider>
+              <UpdaterProvider>
+                <Router>
+                  <Default />
+                </Router>
+              </UpdaterProvider>
+            </RemoteConfigProvider>
+          </ThrowBlock>
+        </NotificationsProvider>
       </StyleProvider>
     </Provider>
   </LiveStyleSheetManager>

--- a/src/renderer/Default.js
+++ b/src/renderer/Default.js
@@ -17,6 +17,7 @@ import Account from "~/renderer/screens/account";
 import Asset from "~/renderer/screens/asset";
 import Box from "~/renderer/components/Box/Box";
 import ListenDevices from "~/renderer/components/ListenDevices";
+import Notifications from "~/renderer/components/Notifications";
 import ExportLogsButton from "~/renderer/components/ExportLogsButton";
 import Idler from "~/renderer/components/Idler";
 import IsUnlocked from "~/renderer/components/IsUnlocked";
@@ -104,6 +105,7 @@ const Default = () => {
                       <Route path="/asset/:assetId+" render={props => <Asset {...props} />} />
                     </Switch>
                   </Page>
+                  <Notifications />
                 </Box>
 
                 <LibcoreBusyIndicator />

--- a/src/renderer/components/Notifications/Notification.js
+++ b/src/renderer/components/Notifications/Notification.js
@@ -1,0 +1,104 @@
+// @flow
+import React, { useEffect } from "react";
+import styled from "styled-components";
+import Text from "~/renderer/components/Text";
+import IconCross from "~/renderer/icons/Cross";
+import TimeBasedProgressBar from "./TimeBasedProgressBar";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+import { animated, useTransition } from "react-spring";
+import { delay } from "@ledgerhq/live-common/lib/promise";
+
+const Content: ThemedComponent<{}> = styled.div`
+  color: ${p => p.theme.colors.palette.background.paper};
+  opacity: 0.9;
+  padding: 12px 22px;
+  display: grid;
+  grid-template-columns: "1fr auto";
+  grid-gap: 10px;
+`;
+
+const Wrapper: ThemedComponent<{ onClick?: () => void }> = styled(animated.div)`
+  cursor: ${p => (p.onClick ? "pointer" : "auto")};
+  background-color: ${p => p.theme.colors.palette.text.shade100};
+  position: relative;
+  overflow: hidden;
+  height: auto;
+  border-radius: 3px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  width: 250px;
+`;
+
+const DismissWrapper: ThemedComponent<{}> = styled.div`
+  position: absolute;
+  cursor: pointer;
+  color: ${p => p.theme.colors.palette.background.paper};
+  top: 3px;
+  right: 3px;
+`;
+
+const Notification = ({
+  duration,
+  onDismiss,
+  callback,
+  text,
+  id,
+}: {
+  duration?: number,
+  onDismiss: (id: string) => void,
+  callback: any,
+  text: string,
+  id: string,
+}) => {
+  const transitions = useTransition(1, null, {
+    from: {
+      height: 0,
+      opacity: 0,
+    },
+    enter: {
+      height: "auto",
+      opacity: 1,
+    },
+    leave: {
+      height: 0,
+      opacity: 0,
+    },
+    config: { duration: 1000, tension: 125, friction: 20, precision: 0.1 },
+  });
+
+  useEffect(() => {
+    async function scheduledDismiss(duration) {
+      await delay(duration);
+      onDismiss(id);
+    }
+    if (duration) {
+      scheduledDismiss(duration);
+    }
+  }, [duration, id, onDismiss]);
+
+  return transitions.map(({ key, item, props }) => (
+    <Wrapper
+      key={key}
+      style={props}
+      onClick={() => {
+        callback();
+        onDismiss(id);
+      }}
+    >
+      <Content>
+        <Text ff="Inter|Regular" fontSize={4}>
+          {text}
+        </Text>
+      </Content>
+      {duration ? (
+        <TimeBasedProgressBar duration={duration} />
+      ) : (
+        <DismissWrapper onClick={() => onDismiss(id)}>
+          <IconCross size={12} />
+        </DismissWrapper>
+      )}
+    </Wrapper>
+  ));
+};
+
+export default Notification;

--- a/src/renderer/components/Notifications/NotificationsProvider.js
+++ b/src/renderer/components/Notifications/NotificationsProvider.js
@@ -1,0 +1,34 @@
+// @flow
+
+import React, { useState, useCallback } from "react";
+
+type Props = {
+  children: React$Node,
+};
+
+export const NotificationsContext = React.createContext<any>();
+export type NotificationType = {
+  id: string,
+  text: string,
+  duration?: number,
+  callback?: () => void,
+};
+
+const NotificationsProvider = ({ children }: Props) => {
+  const [items, setItems] = useState([] /* initial notifications */);
+  const dismiss = useCallback(id => {
+    setItems(currentItems => currentItems.filter(item => item.id !== id));
+  }, []);
+  const add = useCallback(
+    notification => setItems(currentItems => [...currentItems, notification]),
+    [],
+  );
+  const value = {
+    items,
+    dismiss,
+    add,
+  };
+  return <NotificationsContext.Provider value={value}>{children}</NotificationsContext.Provider>;
+};
+
+export default NotificationsProvider;

--- a/src/renderer/components/Notifications/TimeBasedProgressBar.js
+++ b/src/renderer/components/Notifications/TimeBasedProgressBar.js
@@ -1,0 +1,57 @@
+// @flow
+import React, { useEffect } from "react";
+import { animated, useTransition } from "react-spring";
+
+type Props = {
+  duration: number,
+  onComplete?: () => void,
+  nonce?: number,
+};
+
+const TimeBasedProgrerssBar = ({ duration, onComplete, nonce = 1 }: Props) => {
+  const config = { duration, tension: 125, friction: 20, precision: 0.1 };
+  const transitions = useTransition(1, null, {
+    from: {
+      width: "0%",
+    },
+    enter: {
+      width: "100%",
+    },
+    config,
+  });
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      if (nonce && onComplete) onComplete();
+    }, duration);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [duration, onComplete, nonce]);
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        height: 5,
+      }}
+    >
+      {transitions.map(({ key, item, props }) => (
+        <animated.div
+          key={key}
+          style={{
+            height: 5,
+            width: "100%",
+            borderRadius: 4,
+            transformOrigin: "left center",
+            background: "#6490F1", // "#00000022",
+            ...props,
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default TimeBasedProgrerssBar;

--- a/src/renderer/components/Notifications/index.js
+++ b/src/renderer/components/Notifications/index.js
@@ -1,0 +1,38 @@
+// @flow
+
+import React, { useContext } from "react";
+import styled from "styled-components";
+import Notification from "~/renderer/components/Notifications/Notification";
+import { NotificationsContext } from "~/renderer/components/Notifications/NotificationsProvider";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+const Wrapper: ThemedComponent<{}> = styled.div`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  padding: 8px;
+  padding-bottom: 0;
+  & *:nth-child(n + 6) {
+    display: none;
+  }
+`;
+
+const Notifications = () => {
+  const { items, dismiss } = useContext(NotificationsContext);
+  return (
+    <Wrapper>
+      {items.map(({ duration, id, text, callback }) => (
+        <Notification
+          id={id}
+          callback={callback}
+          onDismiss={dismiss}
+          duration={duration}
+          key={id}
+          text={text}
+        />
+      ))}
+    </Wrapper>
+  );
+};
+
+export default Notifications;


### PR DESCRIPTION
Weekend project that aims to kickstart the proposal of having ephemeral notifications on the app to transmit some message to our users. The current system is pretty easy to plug into, it relies on a shared context and we can emit/dismiss notifications from anywhere that uses it. What I mean by ephemeral is that there's no memory of the notifications after we launch the app for now, perhaps we could keep track of dismissed ids to do single use notifications too.

![image](https://user-images.githubusercontent.com/4631227/85270094-1b487f80-b479-11ea-9183-6027cd897d72.png)
![image](https://user-images.githubusercontent.com/4631227/85270060-11bf1780-b479-11ea-8ca8-9f840efaa857.png)


### Type

Feature

### How to emit/consume/dismiss notifications
```
const { items, dismiss, add } = useContext(NotificationsContext);
```
Everything is exposed from the notification context, we can then list notifications, emit them from pertinent events such as broadcasting, or price changes, etc.

### How to consume notifications
### TODO/Wishlist
- Types of notifications (error/warning/success)
- Icon support
- Different positioning on screen/size
- Return an id from the add to autogenerate instead of having to provide the id