### PR TITLE
LL-2642 Linux App icon

### DIFF
--- a/src/main/window-lifecycle.js
+++ b/src/main/window-lifecycle.js
@@ -68,6 +68,8 @@ export async function createMainWindow({ dimensions, positions }: any, settings:
           frame: false,
           titleBarStyle: "hiddenInset",
         }
+      : process.platform === "linux"
+      ? { icon: path.join(__dirname, "/build/icons/icon.png") } // specific for linux icon
       : {}),
     /* eslint-enable indent */
     width,


### PR DESCRIPTION
(Linux): app icon forced into BrowserWindow config
building on linux should now always show the icon on a relase build or on a dev build as well.

(If that solution is not the best we need to look into why all the icons aren't ported to the webpack build folders during the process)

### Type

UI Polish

### Context

LL-2642

### Parts of the app affected / Test plan

Linux build app icon