### PR TITLE
live-common 12.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ledgerhq/hw-transport-http": "^5.17.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.17.0",
     "@ledgerhq/ledger-core": "6.5.4",
-    "@ledgerhq/live-common": "^12.35.1",
+    "@ledgerhq/live-common": "^12.36.0",
     "@ledgerhq/logs": "^5.17.0",
     "@tippyjs/react": "^4.0.2",
     "@trust/keyto": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,10 +1439,10 @@
     node-pre-gyp "^0.14.0"
     node-pre-gyp-github "^1.4.3"
 
-"@ledgerhq/live-common@^12.35.1":
-  version "12.35.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.35.1.tgz#902d0ae9617177eb2e8eac51519202b254e07de3"
-  integrity sha512-RD4FFM6L9RuoQFUt14CG/t6/CxS7KzwQyO2dB9s0q7GSN2i1r4rWdPgF/htfNjCeXwx2J4LUu94RXcv63cDoAw==
+"@ledgerhq/live-common@^12.36.0":
+  version "12.36.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.36.0.tgz#3f8974e179aaac00cfde790474f10145ac90fc7d"
+  integrity sha512-JI1FIJMxxQPQJGzDTC6bx+pS8rzUujiXNxbK+u9l4Fx5VpaVrKFCZgYvqtM0pTguVvQVhji56wVVyaxD0xnR6g==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.17.0"


### PR DESCRIPTION
work included: https://github.com/LedgerHQ/ledger-live-common/releases/tag/v12.36.0
please only focus on the Ethereum part (rest is unused / part of the bigger firmware update testing)

**This should fixes two important things:**

- Ethereum Classic will get correct balances and amounts for the first time. (that is not easily testable, you can just test sending etc works fine, covered by bot anyway). In future that will unlock possibility to do send max, but not for now.
- Ethereum gas price calculation **works fine** and is "better" at precisely calculating what is necessary. Right now, we use a x2 factor, i wonder if we want to lower it in future or not. Do QA team have accumulated clear pattern of what ERC20 / contract addresses used to be problematic in the past?

### Type

bug fixes
