### PR TITLE
LL-2645 Outdated firmware support link banner

### DIFF
--- a/src/renderer/components/TransactionsPendingConfirmationWarning.js
+++ b/src/renderer/components/TransactionsPendingConfirmationWarning.js
@@ -7,7 +7,7 @@ import type { AccountLike } from "@ledgerhq/live-common/lib/types";
 import { isAccountBalanceUnconfirmed } from "@ledgerhq/live-common/lib/account";
 import { accountsSelector } from "./../reducers/accounts";
 import IconClock from "~/renderer/icons/Clock";
-import ToolTip from "~/renderer/components/ToolTip";
+import ToolTip from "~/renderer/components/Tooltip";
 import Box from "~/renderer/components/Box";
 
 const TransactionsPendingConfirmationWarning = ({

--- a/src/renderer/screens/manager/AppsList/index.js
+++ b/src/renderer/screens/manager/AppsList/index.js
@@ -52,7 +52,10 @@ type Props = {
   result: ListAppsResult,
   exec: Exec,
   t: TFunction,
-  render?: ({ disableFirmwareUpdate: boolean, installed: InstalledItem[] }) => React$Node,
+  render?: ({
+    disableFirmwareUpdate: boolean,
+    installed: InstalledItem[],
+  }) => React$Node,
   appsToRestore?: string[],
 };
 

--- a/src/renderer/screens/manager/DeviceStorage/index.js
+++ b/src/renderer/screens/manager/DeviceStorage/index.js
@@ -5,13 +5,15 @@ import styled, { css, keyframes } from "styled-components";
 import { Trans } from "react-i18next";
 import { Transition, TransitionGroup } from "react-transition-group";
 
+import manager from "@ledgerhq/live-common/lib/manager";
+
 import type { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/live-common/lib/types/manager";
 import type { AppsDistribution } from "@ledgerhq/live-common/lib/apps";
 import type { DeviceModel } from "@ledgerhq/devices";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 
 import ByteSize from "~/renderer/components/ByteSize";
-import { lighten, rgba } from "~/renderer/styles/helpers";
+import { rgba } from "~/renderer/styles/helpers";
 import Text from "~/renderer/components/Text";
 import Tooltip from "~/renderer/components/Tooltip";
 import Card from "~/renderer/components/Box/Card";
@@ -242,6 +244,8 @@ const DeviceStorage = ({
 }: Props) => {
   const shouldWarn = distribution.shouldWarnMemory || isIncomplete;
 
+  const firmwareOutdated = manager.firmwareUnsupported(deviceModel.id, deviceInfo) || !firmware;
+
   return (
     <Card p={20} mb={4} horizontal>
       <Box position="relative" flex="0 0 140px" mr={20}>
@@ -259,7 +263,7 @@ const DeviceStorage = ({
           </Box>
         </Box>
         <Text ff="Inter|SemiBold" color="palette.text.shade40" fontSize={4}>
-          {firmware ? (
+          {firmwareOutdated ? (
             <Trans
               i18nKey="manager.deviceStorage.firmwareAvailable"
               values={{ version: deviceInfo.version }}
@@ -270,7 +274,7 @@ const DeviceStorage = ({
               values={{ version: deviceInfo.version }}
             />
           )}{" "}
-          {firmware ? null : <HighlightVersion>{deviceInfo.version}</HighlightVersion>}
+          {<HighlightVersion>{deviceInfo.version}</HighlightVersion>}
         </Text>
         <Separator />
         <Info>

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -429,7 +429,7 @@
       "installed": "Apps",
       "capacity": "Capacity",
       "used": "Used",
-      "firmwareAvailable": "Firmware {{version}}",
+      "firmwareAvailable": "Firmware is outdated:",
       "firmwareUpToDate": "Firmware is up to date:",
       "genuine": "Device is genuine",
       "incomplete": "Some apps were not recognized. Please uninstall, then reinstall them."
@@ -521,6 +521,8 @@
       "update": "Firmware update",
       "updateBtn": "Update firmware",
       "latest": "Firmware version {{version}} is available",
+      "contactSupport": "Contact support",
+      "deprecated": "Device firmware version too old to be updated. Contact Ledger Support for a replacement.",
       "prepareSeed": "Ensure your 24-word Recovery phrase is written down on the Recovery sheet and it is available, as a precaution.",
       "disclaimerTitle": "You are about to install <1>firmware version {{version}}</1>.",
       "downloadingUpdateDesc": "Please wait for the update installer to be downloaded",


### PR DESCRIPTION
(Manager): outdated and non upgradable firmware banner with support contact link added to manager

HODL: needs a live-common bump

![localhost_8080_webpack_index html_theme=dusk(iPad)](https://user-images.githubusercontent.com/11752937/86003513-2cae0080-ba12-11ea-9e42-3881a900e23b.png)


### Type

UI Polish

### Context

LL-2645

### Parts of the app affected / Test plan

Manager
