### PR TITLE
LL-2545 (NatSeg/Seg) add account order

### DIFF
--- a/src/renderer/modals/AddAccounts/steps/StepImport.js
+++ b/src/renderer/modals/AddAccounts/steps/StepImport.js
@@ -141,6 +141,8 @@ class StepImport extends PureComponent<StepProps> {
                 checkedAccountsIds: onlyNewAccounts
                   ? hasAlreadyBeenImported
                     ? []
+                    : checkedAccountsIds.length > 0
+                    ? checkedAccountsIds
                     : [account.id]
                   : !hasAlreadyBeenImported && !isNewAccount
                   ? uniq([...checkedAccountsIds, account.id])


### PR DESCRIPTION
(NatSeg/Seg): when adding a new account preselect the first account scanned and not the last

HODL: this need a live-common bump for the derivation order

### Type

UI Polish

### Context

LL-2545

### Parts of the app affected / Test plan

Try adding bitcoin acounts