### PR TITLE
increase carousel bullet hit area

### DIFF
--- a/src/renderer/components/Carousel/index.js
+++ b/src/renderer/components/Carousel/index.js
@@ -62,12 +62,16 @@ const Bullets = styled.div`
   justify-content: center;
   & > div {
     cursor: pointer;
-    border-radius: 6px;
-    height: 6px;
-    width: 6px;
-    background: rgba(255, 255, 255, 0.3);
-    margin: 0 5px;
-    &:nth-child(${p => p.index + 1}) {
+    & > span {
+      display: block;
+      border-radius: 6px;
+      height: 6px;
+      width: 6px;
+      background: rgba(255, 255, 255, 0.3);
+    }
+    padding: 15px 5px;
+    margin-bottom: -15px;
+    &:nth-child(${p => p.index + 1}) > span {
       background: #ffffff;
     }
   }
@@ -183,7 +187,9 @@ const Carousel = ({
           ) : (
             <Bullets index={index}>
               {slides.map((_, i) => (
-                <div key={i} onClick={() => onChooseSlide(i)} />
+                <div key={i} onClick={() => onChooseSlide(i)}>
+                  <span />
+                </div>
               ))}
             </Bullets>
           )}


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/86781608-67d9b080-c05e-11ea-88c0-921959b305e4.png)

### Type

UI Polish

### Context

https://ledger.slack.com/archives/GBVR3MAGJ/p1594119617035500

### Parts of the app affected / Test plan

Carousel, make sure the bullets have plenty of padding around them to be clicked and don't show the blue border around them.
