### PR TITLE
LL-2759 Cosmos earn rewards modal ui updated

### DIFF
--- a/src/renderer/families/cosmos/DelegationFlowModal/Info/index.js
+++ b/src/renderer/families/cosmos/DelegationFlowModal/Info/index.js
@@ -7,9 +7,10 @@ import type { Account, AccountLike } from "@ledgerhq/live-common/lib/types";
 
 import { openModal, closeModal } from "~/renderer/actions/modals";
 import EarnRewardsInfoModal from "~/renderer/components/EarnRewardsInfoModal";
-import InfoBox from "~/renderer/components/InfoBox";
+import WarnBox from "~/renderer/components/WarnBox";
 import { urls } from "~/config/urls";
 import { openURL } from "~/renderer/linking";
+import LinkWithExternalIcon from "~/renderer/components/LinkWithExternalIcon";
 
 type Props = {
   name?: string,
@@ -45,10 +46,9 @@ export default function CosmosEarnRewardsInfoModal({ name, account, parentAccoun
         t("cosmos.delegation.flow.steps.starter.bullet.2"),
       ]}
       additional={
-        <InfoBox onLearnMore={onLearnMore}>
-          {t("cosmos.delegation.flow.steps.starter.warning.description")}
-        </InfoBox>
+        <WarnBox>{t("cosmos.delegation.flow.steps.starter.warning.description")}</WarnBox>
       }
+      footerLeft={<LinkWithExternalIcon label={t("delegation.howItWorks")} onClick={onLearnMore} />}
     />
   );
 }


### PR DESCRIPTION
(Cosmos): earn rewards info modal ui normalized

![localhost_8080_webpack_index html_theme=null](https://user-images.githubusercontent.com/11752937/87048219-bff9e980-c1fb-11ea-9a9c-656891521d2b.png)


### Type

UI Polish

### Context

LL-2759

### Parts of the app affected / Test plan

Open a cosmos account without any delegations and that can delegate to see this modal.
