### PR TITLE
(Cosmos): fix wording regression on min safe warning tooltip

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -962,7 +962,7 @@
       "estYield": "est. yield",
       "activeTooltip": "Delegated amounts generate rewards",
       "inactiveTooltip": "Undelegated amounts do not generate rewards",
-      "minSafeWarning": "To safely start delegating you need at least {{amount}}",
+      "minSafeWarning": "Not enough funds",
       "flow": {
         "title": "Delegate",
         "steps": {


### PR DESCRIPTION
Fix regression issue on min safe warning tooltip.

### Type

Fix wording

### Parts of the app affected / Test plan

Cosmos accounts
