### PR TITLE
LL-2777 (Wording): tezos change provider name and url

### DIFF
--- a/src/renderer/families/tezos/DelegateFlowModal/steps/StepValidator.js
+++ b/src/renderer/families/tezos/DelegateFlowModal/steps/StepValidator.js
@@ -90,7 +90,7 @@ const StepValidator = ({
     [account, onChangeTransaction, parentAccount, transaction, transitionTo],
   );
   const openPartner = useCallback(() => {
-    openURL("https://mytezosbaker.com/");
+    openURL("https://baking-bad.org/");
   }, []);
 
   return (
@@ -131,13 +131,16 @@ const StepValidator = ({
         </Button>
         <Box mt={5}>
           <Text ff="Inter|Medium" fontSize={2} color="palette.text.shade40">
-            <Trans i18nKey="delegation.flow.steps.validator.providedBy">
+            <Trans
+              i18nKey="delegation.flow.steps.validator.providedBy"
+              values={{ name: "Baking Bad" }}
+            >
               {"Yield rates provided by"}
               <Text
                 onClick={openPartner}
                 style={{ cursor: "pointer", textDecoration: "underline" }}
               >
-                {"MyTezosBaker"}
+                {"Baking Bad"}
               </Text>
             </Trans>
           </Text>

--- a/static/i18n/de/app.json
+++ b/static/i18n/de/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/el/app.json
+++ b/static/i18n/el/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/es/app.json
+++ b/static/i18n/es/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/fi/app.json
+++ b/static/i18n/fi/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/fr/app.json
+++ b/static/i18n/fr/app.json
@@ -1162,7 +1162,7 @@
           "title": "Sélectionner un validateur",
           "description": "Vous pouvez sélectionner un validateur en comparant les taux de rendement estimés",
           "customValidator": "Validateur personnalisé",
-          "providedBy": "Taux de rendements fournis par <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Taux de rendements fournis par <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Validateur personnalisé",

--- a/static/i18n/hu/app.json
+++ b/static/i18n/hu/app.json
@@ -1162,7 +1162,7 @@
           "title": "Válassz hitelesítőt",
           "description": "Választhatsz hitelesítőt a becsült jutalom mértékének összehasonlításával",
           "customValidator": "Egyedi érvényesítő",
-          "providedBy": "A hozam mértéke biztosított általa: <1><0>MyTezosBaker</0></1>"
+          "providedBy": "A hozam mértéke biztosított általa: <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Egyedi megerősítő",

--- a/static/i18n/it/app.json
+++ b/static/i18n/it/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/ja/app.json
+++ b/static/i18n/ja/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/ko/app.json
+++ b/static/i18n/ko/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/nl/app.json
+++ b/static/i18n/nl/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/no/app.json
+++ b/static/i18n/no/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/pl/app.json
+++ b/static/i18n/pl/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/pt/app.json
+++ b/static/i18n/pt/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/ru/app.json
+++ b/static/i18n/ru/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/sr/app.json
+++ b/static/i18n/sr/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/sv/app.json
+++ b/static/i18n/sv/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/tr/app.json
+++ b/static/i18n/tr/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",

--- a/static/i18n/zh/app.json
+++ b/static/i18n/zh/app.json
@@ -1162,7 +1162,7 @@
           "title": "Select validator",
           "description": "You can select a validator by comparing the estimated reward rates",
           "customValidator": "Custom validator",
-          "providedBy": "Yield rates provided by <1><0>MyTezosBaker</0></1>"
+          "providedBy": "Yield rates provided by <1><0>{{name}}</0></1>"
         },
         "custom": {
           "title": "Custom validator",


### PR DESCRIPTION
Updated tezos baking provider name and url in the informations.

Will need an update on crowdin as well

### Type

Wording

### Context

LL-2777

### Parts of the app affected / Test plan

When choosing a new validator you should see the information changed regarding to the provider.
