### PR TITLE
Ll-2869 (Manager) Do it later buttton removal

### DIFF
--- a/src/renderer/screens/manager/AppsList/InstallSuccessBanner.js
+++ b/src/renderer/screens/manager/AppsList/InstallSuccessBanner.js
@@ -130,9 +130,6 @@ const InstallSuccessBanner = ({ state, isIncomplete, dispatch, addAccount, disab
                 <Button primary inverted onClick={onAddAccount} mr={1}>
                   <Trans i18nKey="manager.applist.installSuccess.manageAccount" />
                 </Button>
-                <Button onClick={onClose} color="palette.primary.contrastText">
-                  <Trans i18nKey="manager.applist.installSuccess.later" />
-                </Button>
               </Box>
             </Box>
             <LogoContainer>

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -503,8 +503,7 @@
       "installSuccess": {
         "title": "App installed successfully. You can now add your {{app}} accounts",
         "title_plural": "Apps installed successfully. You can now add your accounts",
-        "manageAccount": "Manage my accounts",
-        "later": "Do it later"
+        "manageAccount": "Manage my accounts"
       },
       "updatable": {
         "title": "Updates available",


### PR DESCRIPTION
remove Do it later button from install success InstallSuccessBanner

### Type

UI Polish

### Context

LL-2869

### Parts of the app affected / Test plan

Install a live supported app on the manager
you should no longer see the "Do it later" button in the install success banner.
