### PR TITLE
LL-2822 (OperationDetails): add type to modal header title

### DIFF
--- a/src/renderer/components/Modal/ModalBody.js
+++ b/src/renderer/components/Modal/ModalBody.js
@@ -10,6 +10,7 @@ import type { RenderProps } from ".";
 
 type Props = {
   title?: React$Node,
+  subTitle?: React$Node,
   onBack?: void => void,
   onClose?: void => void,
   render?: (?RenderProps) => any,
@@ -35,6 +36,7 @@ class ModalBody extends PureComponent<Props> {
       onBack,
       onClose,
       title,
+      subTitle,
       render,
       renderFooter,
       renderProps,
@@ -47,7 +49,7 @@ class ModalBody extends PureComponent<Props> {
 
     return (
       <>
-        <ModalHeader onBack={onBack} onClose={onClose}>
+        <ModalHeader subTitle={subTitle} onBack={onBack} onClose={onClose}>
           {title || null}
         </ModalHeader>
         <ModalContent ref={this._content} noScroll={noScroll}>

--- a/src/renderer/components/Modal/ModalHeader.js
+++ b/src/renderer/components/Modal/ModalHeader.js
@@ -21,17 +21,31 @@ const MODAL_HEADER_STYLE = {
   minHeight: 66,
 };
 
+const TitleContainer = styled(Box).attrs(() => ({
+  vertical: true,
+}))`
+  position: absolute;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+`;
+
 const ModalTitle = styled(Box).attrs(() => ({
   color: "palette.text.shade100",
   ff: "Inter|Medium",
   fontSize: 6,
 }))`
-  position: absolute;
-  left: 0;
-  right: 0;
   text-align: center;
   line-height: 1;
-  pointer-events: none;
+`;
+
+const ModalSubTitle = styled(Box).attrs(() => ({
+  color: "palette.text.shade50",
+  ff: "Inter|Regular",
+  fontSize: 3,
+}))`
+  text-align: center;
+  line-height: 2;
 `;
 
 const ModalHeaderAction = styled(Tabbable).attrs(() => ({
@@ -81,10 +95,12 @@ const ModalHeaderAction = styled(Tabbable).attrs(() => ({
 
 const ModalHeader = ({
   children,
+  subTitle,
   onBack,
   onClose,
 }: {
   children: any,
+  subTitle?: React$Node,
   onBack?: void => void,
   onClose?: void => void,
 }) => {
@@ -101,7 +117,11 @@ const ModalHeader = ({
       ) : (
         <div />
       )}
-      <ModalTitle id="modal-title">{children}</ModalTitle>
+      <TitleContainer>
+        {subTitle && <ModalSubTitle id="modal-subtitle">{subTitle}</ModalSubTitle>}
+        <ModalTitle id="modal-title">{children}</ModalTitle>
+      </TitleContainer>
+
       {onClose ? (
         <ModalHeaderAction
           right

--- a/src/renderer/modals/OperationDetails/index.js
+++ b/src/renderer/modals/OperationDetails/index.js
@@ -200,7 +200,8 @@ const OperationDetails: React$ComponentType<OwnProps> = connect(mapStateToProps)
 
   return (
     <ModalBody
-      title={t("operationDetails.title")}
+      title={t(`operation.type.${operation.type}`)}
+      subTitle={t("operationDetails.title")}
       onClose={onClose}
       onBack={parentOperation ? () => openOperation("goBack", parentOperation) : undefined}
       render={() => (


### PR DESCRIPTION
Operation details modal added type to header title

![localhost_8080_webpack_index html_theme=null](https://user-images.githubusercontent.com/11752937/88666346-3e052e00-d0e0-11ea-95df-e61dfad3e5ee.png)


### Type

UI-Polish

### Context

LL-2822

### Parts of the app affected / Test plan

Operation details modal header.
