### PR TITLE
LL-2962 (OperationDetails): Tx id now shows up on two lines if required

### DIFF
--- a/src/renderer/modals/OperationDetails/index.js
+++ b/src/renderer/modals/OperationDetails/index.js
@@ -65,6 +65,7 @@ import {
   B,
   TextEllipsis,
   Separator,
+  HashContainer,
 } from "./styledComponents";
 
 const mapStateToProps = (state, { operationId, accountId, parentId }) => {
@@ -434,7 +435,7 @@ const OperationDetails: React$ComponentType<OwnProps> = connect(mapStateToProps)
           <Box>
             <OpDetailsTitle>{t("operationDetails.identifier")}</OpDetailsTitle>
             <OpDetailsData>
-              <Ellipsis canSelect>{hash}</Ellipsis>
+              <HashContainer>{hash}</HashContainer>
               <GradientHover>
                 <CopyWithFeedback text={hash} />
               </GradientHover>

--- a/src/renderer/modals/OperationDetails/styledComponents.js
+++ b/src/renderer/modals/OperationDetails/styledComponents.js
@@ -36,6 +36,7 @@ export const Address: ThemedComponent<{}> = styled(Text)`
 
 export const GradientHover: ThemedComponent<{}> = styled(Box).attrs(() => ({
   alignItem: "center",
+  justifyContent: "center",
   color: "wallet",
 }))`
   background: ${p => p.theme.colors.palette.background.paper};
@@ -107,4 +108,9 @@ export const OpDetailsVoteData: ThemedComponent<{}> = styled.blockquote`
   ${Address} {
     cursor: pointer;
   }
+`;
+
+export const HashContainer: ThemedComponent<{}> = styled.div`
+  word-break: break-all;
+  user-select: text;
 `;


### PR DESCRIPTION
(OperationDetails): Tx id now shows up on two lines if required

![localhost_8080_webpack_index html_theme=null](https://user-images.githubusercontent.com/11752937/88673637-24b4af80-d0e9-11ea-8ab5-a16f38469a2e.png)

### Type

UI Polish

### Context

LL-2962

### Parts of the app affected / Test plan

Operation details modal transaction field.
