### PR TITLE
LL-2685 Add buy cta to notEnoughGas

### DIFF
--- a/src/renderer/components/BuyButton.js
+++ b/src/renderer/components/BuyButton.js
@@ -1,0 +1,32 @@
+// @flow
+
+import React, { useCallback } from "react";
+import { Trans } from "react-i18next";
+import Button from "~/renderer/components/Button";
+import { useHistory } from "react-router-dom";
+import { closeAllModal } from "~/renderer/actions/modals";
+import { useDispatch } from "react-redux";
+import type { CryptoCurrency } from "@ledgerhq/live-common/lib/types";
+
+const BuyButton = ({ currency }: { currency: CryptoCurrency }) => {
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  const onClick = useCallback(() => {
+    dispatch(closeAllModal());
+    history.push({
+      pathname: "/exchange",
+      state: {
+        defaultCurrency: currency,
+      },
+    });
+  }, [currency, dispatch, history]);
+
+  return (
+    <Button mr={1} primary inverted onClick={onClick}>
+      <Trans i18nKey="buy.buyCTA" values={{ currencyTicker: currency.ticker }} />
+    </Button>
+  );
+};
+
+export default BuyButton;

--- a/src/renderer/modals/Send/steps/StepAmount.js
+++ b/src/renderer/modals/Send/steps/StepAmount.js
@@ -9,6 +9,8 @@ import Button from "~/renderer/components/Button";
 import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAlert";
 import ErrorBanner from "~/renderer/components/ErrorBanner";
 import SpendableBanner from "~/renderer/components/SpendableBanner";
+import BuyButton from "~/renderer/components/BuyButton";
+import { NotEnoughGas } from "@ledgerhq/errors";
 
 import AccountFooter from "../AccountFooter";
 import SendAmountFields from "../SendAmountFields";
@@ -82,10 +84,13 @@ export class StepAmountFooter extends PureComponent<StepProps> {
     const isTerminated = mainAccount.currency.terminated;
     const hasErrors = Object.keys(errors).length;
     const canNext = !bridgePending && !hasErrors && !isTerminated;
-
+    const { gasPrice } = errors;
     return (
       <>
         <AccountFooter parentAccount={parentAccount} account={account} status={status} />
+        {gasPrice && gasPrice instanceof NotEnoughGas ? (
+          <BuyButton currency={mainAccount.currency} />
+        ) : null}
         <Button
           id={"send-amount-continue-button"}
           isLoading={bridgePending}

--- a/src/renderer/screens/exchange/Buy/SelectAccountAndCurrency.js
+++ b/src/renderer/screens/exchange/Buy/SelectAccountAndCurrency.js
@@ -60,6 +60,7 @@ const FormContent: ThemedComponent<{}> = styled.div`
 
 type Props = {
   selectAccount: (account: AccountLike, parentAccount: ?Account) => void,
+  defaultCurrency?: ?(CryptoCurrency | TokenCurrency),
 };
 
 type State = {
@@ -74,16 +75,16 @@ const AccountSelectorLabel = styled(Label)`
   justify-content: space-between;
 `;
 
-const SelectAccountAndCurrency = ({ selectAccount }: Props) => {
+const SelectAccountAndCurrency = ({ selectAccount, defaultCurrency }: Props) => {
   const { t } = useTranslation();
   const allAccounts = useSelector(accountsSelector);
 
   const currencies = useCoinifyCurrencies();
   const [{ currency, account, parentAccount }, setState] = useState<State>(() => {
-    const defaultCurrency = currencies[0];
+    const _defaultCurrency = defaultCurrency || currencies[0];
 
     return {
-      currency: defaultCurrency,
+      currency: _defaultCurrency,
       account: null,
       parentAccount: null,
     };

--- a/src/renderer/screens/exchange/Buy/index.js
+++ b/src/renderer/screens/exchange/Buy/index.js
@@ -9,6 +9,7 @@ import { openModal } from "~/renderer/actions/modals";
 import type { Account, AccountLike } from "@ledgerhq/live-common/lib/types/account";
 import { useDispatch } from "react-redux";
 import TrackPage from "~/renderer/analytics/TrackPage";
+import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/live-common/lib/types";
 
 const BuyContainer: ThemedComponent<{}> = styled.div`
   display: flex;
@@ -17,7 +18,11 @@ const BuyContainer: ThemedComponent<{}> = styled.div`
   flex: 1;
 `;
 
-const Buy = () => {
+type Props = {
+  defaultCurrency?: ?(CryptoCurrency | TokenCurrency),
+};
+
+const Buy = ({ defaultCurrency }: Props) => {
   const [state, setState] = useState({
     account: undefined,
     parentAccount: undefined,
@@ -61,7 +66,7 @@ const Buy = () => {
       {account ? (
         <CoinifyWidget account={account} parentAccount={parentAccount} mode="buy" onReset={reset} />
       ) : (
-        <SelectAccountAndCurrency selectAccount={selectAccount} />
+        <SelectAccountAndCurrency selectAccount={selectAccount} defaultCurrency={defaultCurrency} />
       )}
     </BuyContainer>
   );

--- a/src/renderer/screens/exchange/index.js
+++ b/src/renderer/screens/exchange/index.js
@@ -2,6 +2,7 @@
 import React, { useState } from "react";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";
+import { useLocation } from "react-router-dom";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import TabBar from "~/renderer/components/TabBar";
 import Card from "~/renderer/components/Box/Card";
@@ -17,17 +18,19 @@ const Container: ThemedComponent<{ selectable: boolean, pb: number }> = styled(B
 const tabs = [
   {
     title: "exchange.buy.tab",
-    component: <Buy />,
+    component: Buy,
   },
   {
     title: "exchange.history.tab",
-    component: <History />,
+    component: History,
   },
 ];
 
 const Exchange = () => {
   const [activeTabIndex, setActiveTabIndex] = useState(0);
+  const location = useLocation();
   const { t } = useTranslation();
+  const Component = tabs[activeTabIndex].component;
 
   return (
     <Container pb={6} selectable>
@@ -36,7 +39,7 @@ const Exchange = () => {
       </Box>
       <TabBar tabs={tabs.map(tab => t(tab.title))} onIndexChange={setActiveTabIndex} />
       <Card grow style={{ overflow: "hidden" }}>
-        {tabs[activeTabIndex].component}
+        <Component {...location?.state} />
       </Card>
     </Container>
   );

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -741,7 +741,8 @@
   },
   "buy": {
     "title": "Buy",
-    "titleCrypto": "Buy {{currency}}"
+    "titleCrypto": "Buy {{currency}}",
+    "buyCTA": "Buy {{currencyTicker}}"
   },
   "receive": {
     "title": "Receive",


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/89522922-506b2000-d7e2-11ea-915a-e2df4c44f99c.png)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-2685
### Parts of the app affected / Test plan

Clicking on the action "Buy ETH" button should dismiss any open modal and navigate to the `Buy` feature screen where the user can start a buy flow for the selected currency.  The selected currency (in this case only eth would trigger the UI) should be pre-selected in the buy screen. This pre-selection will not work if you are already in the buy screen.