### PR TITLE
LL-3021 GasLeak bug fix

### DIFF
--- a/src/renderer/components/Modal/index.js
+++ b/src/renderer/components/Modal/index.js
@@ -115,7 +115,11 @@ type Props = {
   backdropColor: ?boolean,
 };
 
-class Modal extends PureComponent<Props> {
+class Modal extends PureComponent<Props, { directlyClickedBackdrop: boolean }> {
+  state = {
+    directlyClickedBackdrop: false,
+  };
+
   componentDidMount() {
     document.addEventListener("keyup", this.handleKeyup);
     document.addEventListener("keydown", this.preventFocusEscape);
@@ -165,10 +169,14 @@ class Modal extends PureComponent<Props> {
 
   handleClickOnBackdrop = () => {
     const { preventBackdropClick, onClose } = this.props;
-    if (!preventBackdropClick && onClose) {
+    const { directlyClickedBackdrop } = this.state;
+    if (directlyClickedBackdrop && !preventBackdropClick && onClose) {
       onClose();
     }
   };
+
+  onDirectMouseDown = () => this.setState({ directlyClickedBackdrop: true });
+  onIndirectMouseDown = () => this.setState({ directlyClickedBackdrop: false });
 
   /** combined with tab-index 0 this will allow tab navigation into the modal disabling tab navigation behind it */
   setFocus = (r: *) => {
@@ -217,6 +225,7 @@ class Modal extends PureComponent<Props> {
               state={state}
               centered={centered}
               isOpened={isOpened}
+              onMouseDown={this.onDirectMouseDown}
               onClick={this.handleClickOnBackdrop}
               backdropColor={backdropColor}
             >
@@ -226,6 +235,10 @@ class Modal extends PureComponent<Props> {
                 state={state}
                 width={width}
                 onClick={this.swallowClick}
+                onMouseDown={e => {
+                  this.onIndirectMouseDown();
+                  e.stopPropagation();
+                }}
                 id="modal-container"
               >
                 {render && render(renderProps)}


### PR DESCRIPTION
There was a bug on the modals behavior that allowed a click event to reach the backdrop when we were interacting with a dom element inside the body but releasing the touch outside of it. This adds a flag when interacting with the body of the modal to prevent the consumption of that click by the backdrop while keeping the direct backdrop and the X CTA clicks working.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-3021

### Parts of the app affected / Test plan

On the send flow for ETH drag the fee's slider out of the modal body and release it. 
On develop, it should close the modal, on this pr it should remain open.
