### PR TITLE
Show all decimals even if they're zeros on dashboard total

### DIFF
--- a/src/renderer/components/BalanceInfos/index.js
+++ b/src/renderer/components/BalanceInfos/index.js
@@ -6,6 +6,8 @@ import styled from "styled-components";
 
 import type { Unit, ValueChange, AccountLike } from "@ledgerhq/live-common/lib/types";
 import type { TFunction } from "react-i18next";
+import { useSelector } from "react-redux";
+import { counterValueCurrencySelector } from "~/renderer/reducers/settings";
 
 import Box from "~/renderer/components/Box";
 import FormattedVal from "~/renderer/components/FormattedVal";
@@ -89,6 +91,9 @@ export function BalanceTotal(props: BalanceTotalProps) {
     withTransactionsPendingConfirmationWarning,
     account,
   } = props;
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+  const showAllDigits = counterValueCurrency.type === "FiatCurrency";
+
   return (
     <Box horizontal grow shrink>
       <Box {...props}>
@@ -103,7 +108,7 @@ export function BalanceTotal(props: BalanceTotalProps) {
               unit={unit}
               fontSize={8}
               disableRounding
-              showAllDigits
+              showAllDigits={showAllDigits}
               showCode
               val={totalBalance}
             />

--- a/src/renderer/components/BalanceInfos/index.js
+++ b/src/renderer/components/BalanceInfos/index.js
@@ -103,6 +103,7 @@ export function BalanceTotal(props: BalanceTotalProps) {
               unit={unit}
               fontSize={8}
               disableRounding
+              showAllDigits
               showCode
               val={totalBalance}
             />


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/89524173-637eef80-d7e4-11ea-9bf5-ced4538a9b14.png)

### Type

UI Polish

### Context

Slack

### Parts of the app affected / Test plan

With a fiat total balance that ends in 0, make sure we still see the two decimals.
For a crypto countervalue (eth/btc) we should still remove zeros to the right.

### OK
`USD 12.10`
`ETH 1.000004`

### KO
`USD 12.1`
`ETH 1.0000040000000000`
