### PR TITLE
LL-2902 Connection troubleshooting banner polish

### DIFF
--- a/src/renderer/components/ConnectTroubleshooting.js
+++ b/src/renderer/components/ConnectTroubleshooting.js
@@ -4,8 +4,7 @@ import { Trans } from "react-i18next";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
-import ConnectTroubleshootingHelpLink from "~/renderer/components/ConnectTroubleshootingHelpLink";
-import IconHelp from "~/renderer/icons/Help";
+import ConnectTroubleshootingHelpButton from "~/renderer/components/ConnectTroubleshootingHelpButton";
 import RepairDeviceButton from "~/renderer/components/RepairDeviceButton";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 
@@ -34,16 +33,13 @@ const ConnectTroubleshooting = ({ appearsAfterDelay = 15000, onRepair }: Props) 
   return visible ? (
     <Wrapper p={2} horizontal alignItems="center">
       <Box p={2} horizontal justifyContent="center">
-        <Box marginRight="8px" justifyContent="center">
-          <IconHelp size={16} />
-        </Box>
         <Text ff="Inter|Regular" fontSize={4}>
           <Trans i18nKey="connectTroubleshooting.desc" />
         </Text>
       </Box>
-      <ConnectTroubleshootingHelpLink />
-      <Box flex="1" />
       {onRepair ? <RepairDeviceButton onRepair={onRepair} /> : null}
+      <Box flex="1" />
+      <ConnectTroubleshootingHelpButton buttonProps={{ primary: true }} />
     </Wrapper>
   ) : null;
 };

--- a/src/renderer/components/ConnectTroubleshooting.js
+++ b/src/renderer/components/ConnectTroubleshooting.js
@@ -24,7 +24,7 @@ const Wrapper: ThemedComponent<{}> = styled(Box).attrs({
   max-width: 550px;
 `;
 
-const ConnectTroubleshooting = ({ appearsAfterDelay = 25000, onRepair }: Props) => {
+const ConnectTroubleshooting = ({ appearsAfterDelay = 15000, onRepair }: Props) => {
   const [visible, setVisible] = useState(false);
   useEffect(() => {
     const timeout = setTimeout(() => setVisible(true), appearsAfterDelay);

--- a/src/renderer/components/ConnectTroubleshootingHelpButton.js
+++ b/src/renderer/components/ConnectTroubleshootingHelpButton.js
@@ -4,17 +4,26 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { urls } from "~/config/urls";
 import { openURL } from "~/renderer/linking";
-import { colors } from "~/renderer/styles/theme";
 import Button from "~/renderer/components/Button";
 import Box from "~/renderer/components/Box";
 import IconHelp from "~/renderer/icons/Help";
 
-const ConnectTroubleshootingHelpButton = () => {
+type Props = {
+  buttonProps?: *,
+  textColor?: string,
+};
+
+const ConnectTroubleshootingHelpButton = ({ buttonProps, textColor }: Props) => {
   const { t } = useTranslation();
+  const boxProps = textColor ? { color: textColor } : {};
 
   return (
-    <Button onClick={() => openURL(urls.troubleshootingUSB)} style={{ margin: "0 10px" }}>
-      <Box color={colors.wallet} horizontal alignItems="center">
+    <Button
+      onClick={() => openURL(urls.troubleshootingUSB)}
+      style={{ margin: "0 10px" }}
+      {...buttonProps}
+    >
+      <Box horizontal alignItems="center" {...boxProps}>
         <IconHelp size={16} />
         {" "}
         {t("common.help")}

--- a/src/renderer/components/RepairDeviceButton.js
+++ b/src/renderer/components/RepairDeviceButton.js
@@ -91,7 +91,7 @@ const RepairDeviceButton = ({ onRepair, buttonProps }: Props) => {
 
   return (
     <>
-      <Button {...buttonProps} primary onClick={open} event="RepairDeviceButton">
+      <Button {...buttonProps} onClick={open} event="RepairDeviceButton">
         {t("settings.repairDevice.button")}
       </Button>
       <RepairModal

--- a/src/renderer/modals/RepairModal/index.js
+++ b/src/renderer/modals/RepairModal/index.js
@@ -17,6 +17,7 @@ import FlashMCU from "~/renderer/components/FlashMCU";
 import Modal, { ModalBody } from "~/renderer/components/Modal";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
 import IconCheck from "~/renderer/icons/Check";
+import { colors } from "~/renderer/styles/theme";
 
 const Container = styled(Box).attrs(() => ({
   alignItems: "center",
@@ -203,7 +204,7 @@ class RepairModal extends PureComponent<Props, *> {
           renderFooter={() =>
             !isLoading ? (
               <Box horizontal alignItems="center" flow={2} flex={1}>
-                <ConnectTroubleshootingHelpButton />
+                <ConnectTroubleshootingHelpButton textColor={colors.wallet} />
                 <div style={{ flex: 1 }} />
                 <Button onClick={onReject}>{t(`common.${error ? "close" : "cancel"}`)}</Button>
                 <Button

--- a/src/renderer/screens/settings/sections/Help/index.js
+++ b/src/renderer/screens/settings/sections/Help/index.js
@@ -64,7 +64,7 @@ const SectionHelp = () => {
           title={t("settings.repairDevice.title")}
           desc={t("settings.repairDevice.descSettings")}
         >
-          <RepairDeviceButton buttonProps={{ small: true }} />
+          <RepairDeviceButton buttonProps={{ small: true, primary: true }} />
         </Row>
       </Body>
     </Section>


### PR DESCRIPTION
The banner now shows up earlier (15 seconds) and puts a greater emphasis on _Help_ versus _Repair_.

Before:
![image](https://user-images.githubusercontent.com/13920153/89551210-f92d7580-d80a-11ea-81ff-a22039767f54.png)

After:
![image](https://user-images.githubusercontent.com/13920153/89551266-0f3b3600-d80b-11ea-84b4-2ce2c82c2b0d.png)


### Type

UX polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2902

### Parts of the app affected / Test plan

- Open _Manager_ with no device plugged
