### PR TITLE
LL-2676 Auto select currency on  account buy cta click

### DIFF
--- a/src/renderer/components/BuyButton.js
+++ b/src/renderer/components/BuyButton.js
@@ -6,9 +6,9 @@ import Button from "~/renderer/components/Button";
 import { useHistory } from "react-router-dom";
 import { closeAllModal } from "~/renderer/actions/modals";
 import { useDispatch } from "react-redux";
-import type { CryptoCurrency } from "@ledgerhq/live-common/lib/types";
+import type { Account, CryptoCurrency } from "@ledgerhq/live-common/lib/types";
 
-const BuyButton = ({ currency }: { currency: CryptoCurrency }) => {
+const BuyButton = ({ currency, account }: { currency: CryptoCurrency, account: Account }) => {
   const history = useHistory();
   const dispatch = useDispatch();
 
@@ -18,9 +18,10 @@ const BuyButton = ({ currency }: { currency: CryptoCurrency }) => {
       pathname: "/exchange",
       state: {
         defaultCurrency: currency,
+        defaultAccount: account,
       },
     });
-  }, [currency, dispatch, history]);
+  }, [account, currency, dispatch, history]);
 
   return (
     <Button mr={1} primary inverted onClick={onClick}>

--- a/src/renderer/components/PerCurrencySelectAccount/state.js
+++ b/src/renderer/components/PerCurrencySelectAccount/state.js
@@ -43,19 +43,28 @@ const getIdsFromTuple = (accountTuple: AccountTuple) => ({
   subAccountId: accountTuple.subAccount ? accountTuple.subAccount.id : null,
 });
 
-export function useCurrencyAccountSelect(
+export function useCurrencyAccountSelect({
+  allCurrencies,
+  allAccounts,
+  defaultCurrency,
+  defaultAccount,
+}: {
   allCurrencies: CryptoOrTokenCurrency[],
   allAccounts: Account[],
-) {
+  defaultCurrency: ?CryptoOrTokenCurrency,
+  defaultAccount: ?Account,
+}) {
   const [state, setState] = useState(() => {
-    const defaultCurrency = allCurrencies[0];
-    const availableAccounts = getAccountTuplesForCurrency(defaultCurrency, allAccounts);
-    const { accountId } = availableAccounts.length
+    const currency = defaultCurrency || allCurrencies[0];
+    const availableAccounts = getAccountTuplesForCurrency(currency, allAccounts);
+    const { accountId } = defaultAccount
+      ? { accountId: defaultAccount.id }
+      : availableAccounts.length
       ? getIdsFromTuple(availableAccounts[0])
       : { accountId: null };
 
     return {
-      currency: defaultCurrency,
+      currency,
       accountId,
     };
   });

--- a/src/renderer/modals/Send/steps/StepAmount.js
+++ b/src/renderer/modals/Send/steps/StepAmount.js
@@ -89,7 +89,7 @@ export class StepAmountFooter extends PureComponent<StepProps> {
       <>
         <AccountFooter parentAccount={parentAccount} account={account} status={status} />
         {gasPrice && gasPrice instanceof NotEnoughGas ? (
-          <BuyButton currency={mainAccount.currency} />
+          <BuyButton currency={mainAccount.currency} account={mainAccount} />
         ) : null}
         <Button
           id={"send-amount-continue-button"}

--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -78,8 +78,14 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
   }, [parentAccount, account, openModal]);
 
   const onBuy = useCallback(() => {
-    history.push("/exchange");
-  }, [history]);
+    history.push({
+      pathname: "/exchange",
+      state: {
+        defaultCurrency: currency,
+        defaultAccount: mainAccount,
+      },
+    });
+  }, [currency, history, mainAccount]);
 
   return (
     <Box horizontal alignItems="center" justifyContent="flex-end" flow={2}>

--- a/src/renderer/screens/exchange/Buy/SelectAccountAndCurrency.js
+++ b/src/renderer/screens/exchange/Buy/SelectAccountAndCurrency.js
@@ -64,6 +64,7 @@ const FormContent: ThemedComponent<{}> = styled.div`
 type Props = {
   selectAccount: (account: AccountLike, parentAccount: ?Account) => void,
   defaultCurrency?: ?(CryptoCurrency | TokenCurrency),
+  defaultAccount?: ?Account,
 };
 
 const AccountSelectorLabel = styled(Label)`
@@ -72,7 +73,7 @@ const AccountSelectorLabel = styled(Label)`
   justify-content: space-between;
 `;
 
-const SelectAccountAndCurrency = ({ selectAccount, defaultCurrency }: Props) => {
+const SelectAccountAndCurrency = ({ selectAccount, defaultCurrency, defaultAccount }: Props) => {
   const { t } = useTranslation();
   const allCurrencies = useCoinifyCurrencies();
   const allAccounts = useSelector(accountsSelector);
@@ -84,7 +85,7 @@ const SelectAccountAndCurrency = ({ selectAccount, defaultCurrency }: Props) => 
     subAccount,
     setAccount,
     setCurrency,
-  } = useCurrencyAccountSelect(allCurrencies, allAccounts);
+  } = useCurrencyAccountSelect({ allCurrencies, allAccounts, defaultCurrency, defaultAccount });
 
   const dispatch = useDispatch();
 

--- a/src/renderer/screens/exchange/Buy/index.js
+++ b/src/renderer/screens/exchange/Buy/index.js
@@ -20,9 +20,10 @@ const BuyContainer: ThemedComponent<{}> = styled.div`
 
 type Props = {
   defaultCurrency?: ?(CryptoCurrency | TokenCurrency),
+  defaultAccount?: ?Account,
 };
 
-const Buy = ({ defaultCurrency }: Props) => {
+const Buy = ({ defaultCurrency, defaultAccount }: Props) => {
   const [state, setState] = useState({
     account: undefined,
     parentAccount: undefined,
@@ -66,7 +67,11 @@ const Buy = ({ defaultCurrency }: Props) => {
       {account ? (
         <CoinifyWidget account={account} parentAccount={parentAccount} mode="buy" onReset={reset} />
       ) : (
-        <SelectAccountAndCurrency selectAccount={selectAccount} defaultCurrency={defaultCurrency} />
+        <SelectAccountAndCurrency
+          selectAccount={selectAccount}
+          defaultCurrency={defaultCurrency}
+          defaultAccount={defaultAccount}
+        />
       )}
     </BuyContainer>
   );


### PR DESCRIPTION
When in an account for a currency that allows us to buy funds through LLD, clicking on the Buy button should preselect that currency and account. In order to do this we've introduced a default currency and default account concept to the new account selector, also fixes a regression in the cta to buy from a token send where the parent ETH account didn't have enough funds, the introduction of the new component broke the auto currency select in that case. This addresses that.

### Type

Feature + Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2676

### Parts of the app affected / Test plan

Any time we click on a buy cta, it should pre select the currency and account on the target form.
