### PR TITLE
Better UI for searchable selects

### DIFF
--- a/src/renderer/components/Select/createRenderers.js
+++ b/src/renderer/components/Select/createRenderers.js
@@ -7,10 +7,18 @@ import Box from "~/renderer/components/Box";
 import IconCheck from "~/renderer/icons/Check";
 import IconAngleDown from "~/renderer/icons/AngleDown";
 import IconCross from "~/renderer/icons/Cross";
+import { useTranslation } from "react-i18next";
 import type { Option } from ".";
+import SearchIcon from "~/renderer/icons/Search";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 
 type OptionProps = *;
 
+const InputWrapper: ThemedComponent<{}> = styled(Box)`
+  & input::placeholder {
+    color: ${p => p.theme.colors.palette.text.shade30};
+  }
+`;
 export default ({
   renderOption,
   renderValue,
@@ -37,8 +45,9 @@ export default ({
     );
   },
   SingleValue: function SingleValue(props: OptionProps) {
-    const { data } = props;
-    return (
+    const { data, selectProps } = props;
+    const { isSearchable, menuIsOpen } = selectProps;
+    return menuIsOpen && isSearchable ? null : (
       <components.SingleValue {...props}>
         {renderValue ? renderValue(props) : data.label}
       </components.SingleValue>
@@ -59,6 +68,24 @@ const STYLES_OVERRIDE = {
       <components.ClearIndicator {...props}>
         <IconCross size={16} />
       </components.ClearIndicator>
+    );
+  },
+  Input: function Input(props: OptionProps) {
+    const { t } = useTranslation();
+    const { selectProps } = props;
+    const { isSearchable, menuIsOpen } = selectProps;
+
+    return menuIsOpen && isSearchable ? (
+      <InputWrapper color={"palette.text.shade40"} alignItems="center" horizontal pr={3}>
+        <SearchIcon size={16} />
+        <components.Input
+          {...props}
+          style={{ marginLeft: 10 }}
+          placeholder={t("common.searchWithoutEllipsis")}
+        />
+      </InputWrapper>
+    ) : (
+      <components.Input {...props} style={{ opacity: 0 }} />
     );
   },
 };

--- a/src/renderer/components/Select/createRenderers.js
+++ b/src/renderer/components/Select/createRenderers.js
@@ -70,6 +70,12 @@ const STYLES_OVERRIDE = {
       </components.ClearIndicator>
     );
   },
+  Placeholder: function Input(props: OptionProps) {
+    const { selectProps } = props;
+    const { isSearchable, menuIsOpen } = selectProps;
+
+    return menuIsOpen && isSearchable ? null : <components.Placeholder {...props} />;
+  },
   Input: function Input(props: OptionProps) {
     const { t } = useTranslation();
     const { selectProps } = props;

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -48,6 +48,7 @@
     "dismiss": "Dismiss",
     "information": "Information",
     "search": "Search...",
+    "searchWithoutEllipsis": "Search",
     "manage": "Manage",
     "lockScreen": {
       "title": "Welcome back",


### PR DESCRIPTION
This is the result of a proposal the @bscholving made regarding searchable selectors in the app, it should be plug and play and not break any existing selectors. Basically if it's searchable and the list is displayed we change the UI to look like on the screenshots. If not, we keep it as is.

![image](https://user-images.githubusercontent.com/4631227/90406011-dc176300-e0a4-11ea-8f6f-3e27afa6998f.png)
![image](https://user-images.githubusercontent.com/4631227/90405922-bdb16780-e0a4-11ea-813b-11af4d6f92e0.png)
![image](https://user-images.githubusercontent.com/4631227/90406038-e3d70780-e0a4-11ea-943c-737e446bfba1.png)
![image](https://user-images.githubusercontent.com/4631227/90405950-c5710c00-e0a4-11ea-93e6-400958940f2b.png)
![image](https://user-images.githubusercontent.com/4631227/90405973-cdc94700-e0a4-11ea-89f4-07b6de1a76ff.png)

### Type

UI Polish

### Context

Slack conversation

### Parts of the app affected / Test plan

Any flow that has a selector, check it didn't break.
