### PR TITLE
add new format to firmware hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ledgerhq/hw-transport-http": "^5.22.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.20.0",
     "@ledgerhq/ledger-core": "6.8.8",
-    "@ledgerhq/live-common": "^14.1.7",
+    "@ledgerhq/live-common": "^14.1.8",
     "@ledgerhq/logs": "^5.22.0",
     "@tippyjs/react": "^4.0.2",
     "@trust/keyto": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ledgerhq/hw-transport-http": "^5.22.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.20.0",
     "@ledgerhq/ledger-core": "6.8.8",
-    "@ledgerhq/live-common": "^14.1.5",
+    "@ledgerhq/live-common": "^14.1.7",
     "@ledgerhq/logs": "^5.22.0",
     "@tippyjs/react": "^4.0.2",
     "@trust/keyto": "^1.0.1",

--- a/src/renderer/modals/UpdateFirmwareModal/steps/01-step-install-full-firmware.js
+++ b/src/renderer/modals/UpdateFirmwareModal/steps/01-step-install-full-firmware.js
@@ -90,7 +90,10 @@ const Body = ({
           {t("manager.modal.identifier")}
         </Text>
         <Identifier>
-          {firmware.osu && manager.formatHashName(firmware.osu.hash, deviceModelId, deviceInfo)}
+          {firmware.osu &&
+            manager
+              .formatHashName(firmware.osu.hash, deviceModelId, deviceInfo)
+              .map(hash => <span key={hash}>{hash}</span>)}
         </Identifier>
       </Box>
       <Box mt={isBlue ? 4 : null}>

--- a/src/renderer/modals/UpdateFirmwareModal/steps/01-step-install-full-firmware.js
+++ b/src/renderer/modals/UpdateFirmwareModal/steps/01-step-install-full-firmware.js
@@ -93,7 +93,7 @@ const Body = ({
           {firmware.osu &&
             manager
               .formatHashName(firmware.osu.hash, deviceModelId, deviceInfo)
-              .map(hash => <span key={hash}>{hash}</span>)}
+              .map((hash, i) => <span key={`${i}-${hash}`}>{hash}</span>)}
         </Identifier>
       </Box>
       <Box mt={isBlue ? 4 : null}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,10 +1476,10 @@
     node-pre-gyp "^0.14.0"
     node-pre-gyp-github "^1.4.3"
 
-"@ledgerhq/live-common@^14.1.5":
-  version "14.1.5"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-14.1.5.tgz#926bb32d2ecb278b46194c867f3bd032bac043d7"
-  integrity sha512-BGJg80eiRNY4hHj//JNaMjZNM8QDthlZh6dSqu7dQwgltxQQ8p7EDLIrzIYIKNXbfAZxvScRRTgbTh8eLfzdfg==
+"@ledgerhq/live-common@^14.1.7":
+  version "14.1.7"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-14.1.7.tgz#e6c5225ae405529788abaedb9ee096f49a188f44"
+  integrity sha512-IclBqQz67Qz5x304JCnc6EBkH8zeVoz06kYE0QhEDC/SC+ozDxAh3vWAjFHgmgYCnSGdDVX5IpGf7QxKjMwYaA==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,10 +1476,10 @@
     node-pre-gyp "^0.14.0"
     node-pre-gyp-github "^1.4.3"
 
-"@ledgerhq/live-common@^14.1.7":
-  version "14.1.7"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-14.1.7.tgz#e6c5225ae405529788abaedb9ee096f49a188f44"
-  integrity sha512-IclBqQz67Qz5x304JCnc6EBkH8zeVoz06kYE0QhEDC/SC+ozDxAh3vWAjFHgmgYCnSGdDVX5IpGf7QxKjMwYaA==
+"@ledgerhq/live-common@^14.1.8":
+  version "14.1.8"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-14.1.8.tgz#19f78778687514b114ed1d45f4830c5f9d2841cf"
+  integrity sha512-s6AIl/mdnGZa5iG5TTY7IPr32tbZh9egxfbOpWAuAtzbfjc3RUcTYflgdA36h0JbKw43WiSGv84z7St9WCdu/A==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.22.0"


### PR DESCRIPTION
LL-3066
split FW hash to be displayed the same way nano S|X display them

![image](https://user-images.githubusercontent.com/671786/91566880-8feddd80-e944-11ea-8da4-1cfd0de5eee4.png)

waiting for https://github.com/LedgerHQ/ledger-live-common/pull/842 to be merged and bump live-common