### PR TITLE
fix banner button going over dropdown menu

### DIFF
--- a/src/renderer/screens/manager/AppsList/InstallSuccessBanner.js
+++ b/src/renderer/screens/manager/AppsList/InstallSuccessBanner.js
@@ -110,10 +110,10 @@ const InstallSuccessBanner = ({ state, isIncomplete, dispatch, addAccount, disab
             py={3}
             position="relative"
           >
-            <IconContainer style={{ zIndex: 10 }} onClick={onClose}>
+            <IconContainer onClick={onClose}>
               <IconCross size={16} />
             </IconContainer>
-            <Box style={{ zIndex: 10 }} flex={1} justifyContent="space-between">
+            <Box flex={1} justifyContent="space-between">
               <Box mb={3}>
                 <Text ff="Inter|SemiBold" fontSize={6} color="palette.primary.contrastText">
                   {installedSupportedApps.length === 1 ? (


### PR DESCRIPTION
dropdown would go under the button in the "add account" banner after a supported live app install.

### Type
Fix

### Context

LL-3060

### Parts of the app affected / Test plan

![image](https://user-images.githubusercontent.com/671786/91866554-f2134f00-ec72-11ea-860c-f21b3fce4f1f.png)

