### PR TITLE
add xpub warning on advanced account settings (bitcoin family)

### DIFF
--- a/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.js
+++ b/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.js
@@ -153,8 +153,6 @@ class AccountSettingRenderBody extends PureComponent<Props, State> {
 
     const account = this.getAccount(data);
 
-    console.log({ account });
-
     const usefulData = {
       xpub: account.xpub || undefined,
       index: account.index,


### PR DESCRIPTION
Adds and info banner into Account => Settings => Advanced warning about the xpub use. 

Only for Bitcoin family

### Type

Feat

### Context

LL-2039
