### PR TITLE
LL-3187 fix open user data broken

### DIFF
--- a/src/renderer/components/OpenUserDataDirectoryBtn.js
+++ b/src/renderer/components/OpenUserDataDirectoryBtn.js
@@ -18,7 +18,7 @@ const OpenUserDataDirectoryBtn = ({
   const handleOpenUserDataDirectory = useCallback(() => {
     const userDataDirectory = resolveUserDataDirectory();
     logger.log(`Opening user data directory: ${userDataDirectory}`);
-    shell.openItem(userDataDirectory);
+    shell.showItemInFolder(userDataDirectory);
   }, []);
 
   return (

--- a/src/renderer/reset.js
+++ b/src/renderer/reset.js
@@ -79,6 +79,6 @@ export async function softReset({ cleanAccountsCache }: *) {
 }
 
 export async function openUserDataFolderAndQuit() {
-  shell.openItem(resolveUserDataDirectory());
+  shell.showItemInFolder(resolveUserDataDirectory());
   remote.app.quit();
 }


### PR DESCRIPTION
Since `electron` 9, we could not open the User Data directory anymore

`shell.openItem` does not exist on electron 9

replaced with `shell. showItemInFolder`

### Type

Fix

### Context

LL-3187

### Parts of the app affected / Test plan

Settings => Help => Open User Data
