### PR TITLE
LL-3101 (ClaimRewards): modal scroll issue fix

### DIFF
--- a/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.js
+++ b/src/renderer/families/algorand/Rewards/ClaimRewardsFlowModal/Body.js
@@ -57,7 +57,6 @@ const steps: Array<St> = [
     id: "info",
     label: <Trans i18nKey="algorand.claimRewards.flow.steps.info.title" />,
     component: StepInfo,
-    noScroll: true,
     footer: StepInfoFooter,
   },
   {

--- a/src/renderer/modals/ClaimRewards/Body.js
+++ b/src/renderer/modals/ClaimRewards/Body.js
@@ -57,7 +57,6 @@ const steps: Array<St> = [
     id: "rewards",
     label: <Trans i18nKey="claimReward.steps.rewards.title" />,
     component: StepRewards,
-    noScroll: true,
     footer: StepRewardsFooter,
   },
   {


### PR DESCRIPTION
On Algorand and Tron Claim rewards modal and on smaller screens there was an issue regarding to no scroll.

### Type

UI Polish

### Context

LL-3101

### Parts of the app affected / Test plan

Open the claim rewards flow on algorand and tron on small screen
