### PR TITLE
LL-2938 (SendSummary): add memo field 

### DIFF
--- a/src/renderer/modals/Send/steps/StepSummary.js
+++ b/src/renderer/modals/Send/steps/StepSummary.js
@@ -63,6 +63,9 @@ export default class StepSummary extends PureComponent<StepProps> {
     const feesUnit = getAccountUnit(mainAccount);
     const unit = getAccountUnit(account);
 
+    // $FlowFixMe
+    const memo = transaction.memo;
+
     return (
       <Box flow={4} mx={40}>
         <TrackPage category="Send Flow" name="Step Summary" />
@@ -104,6 +107,16 @@ export default class StepSummary extends PureComponent<StepProps> {
             </Box>
           </Box>
           <Separator />
+          {memo && (
+            <Box horizontal justifyContent="space-between" mb={2}>
+              <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+                <Trans i18nKey="operationDetails.extra.memo" />
+              </Text>
+              <Text ff="Inter|Medium" fontSize={4}>
+                {memo}
+              </Text>
+            </Box>
+          )}
           <Box horizontal justifyContent="space-between" mb={2}>
             <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
               <Trans i18nKey="send.steps.details.amount" />


### PR DESCRIPTION
add memo field  when available to the summary step of Send flow

![localhost_8080_webpack_index html_theme=null](https://user-images.githubusercontent.com/11752937/92623486-924a2300-f2c6-11ea-852e-f59727076dd2.png)


<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

UI Polish

### Context

LL-2938

### Parts of the app affected / Test plan

Send flow summary for memo enabled transactions (Cosmos, XRP, Stellar)
