### PR TITLE
Fix store creation to re enable dev tools

### DIFF
--- a/src/renderer/createStore.js
+++ b/src/renderer/createStore.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { createStore, applyMiddleware, compose } from "redux";
-// import { routerMiddleware } from 'react-router-redux'
 import thunk from "redux-thunk";
 import logger from "~/renderer/middlewares/logger";
 import analytics from "~/renderer/middlewares/analytics";
@@ -21,10 +20,10 @@ export default ({ state, dbMiddleware }: Props) => {
   if (dbMiddleware) {
     middlewares.push(dbMiddleware);
   }
-  const enhancers = compose(
-    applyMiddleware(...middlewares),
-    window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f, // eslint-disable-line
-  );
+
+  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+  const enhancers = composeEnhancers(applyMiddleware(...middlewares));
+
   // $FlowFixMe
   return createStore(reducers, state, enhancers);
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/93528050-0d9c7c00-f93a-11ea-8e7b-7cccaa83fc9c.png)
![image](https://user-images.githubusercontent.com/4631227/93528082-1725e400-f93a-11ea-9c4d-1c611b5a5f6a.png)
![image](https://user-images.githubusercontent.com/4631227/93528124-2311a600-f93a-11ea-96a0-30882f3def80.png)

We needed to update the way we create the store for it to continue to work with the current electron version.
This brings it back in all its glory.