### PR TITLE
live-common 14.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ledgerhq/hw-transport-http": "^5.24.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.23.2",
     "@ledgerhq/ledger-core": "6.9.1",
-    "@ledgerhq/live-common": "^14.6.0",
+    "@ledgerhq/live-common": "^14.7.0",
     "@ledgerhq/logs": "^5.23.0",
     "@tippyjs/react": "^4.0.2",
     "@trust/keyto": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,10 +1513,10 @@
     node-pre-gyp "^0.15.0"
     node-pre-gyp-github "^1.4.3"
 
-"@ledgerhq/live-common@^14.6.0":
-  version "14.6.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-14.6.0.tgz#51f0ec8d99699bf33bc1229a4c25a5dde3fd4e87"
-  integrity sha512-69ZjHZpd4Ygr8ny4dluApe3AepeFBohzIeLA0lFTrJguJGN/cztMfJyz25vWW8t3ZWTEIEX5REjiXioC0IRcew==
+"@ledgerhq/live-common@^14.7.0":
+  version "14.7.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-14.7.0.tgz#7caf1df682bb905b52ac86d74273781213514ae4"
+  integrity sha512-liboxMNaT4abSw1HlKwxiDvvZT2nLVIOWbWkazkPI+at8TMrnvJ1bNytiHtiaigVNs4Tl5T8gBIPHfx5YdUu9Q==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.23.0"


### PR DESCRIPTION
- ensure that there is no regression on the manager entrance (as device flow logic has changed)