### PR TITLE
LL-3387 (Storage): increase operation retention storage from 100 -> 500

### DIFF
--- a/src/helpers/accountModel.js
+++ b/src/helpers/accountModel.js
@@ -15,7 +15,7 @@ export const opRetentionStategy = (maxDaysOld: number, keepFirst: number) => (
   index: number,
 ): boolean => index < keepFirst || Date.now() - op.date < 1000 * 60 * 60 * 24 * maxDaysOld;
 
-const opRetentionFilter = opRetentionStategy(366, 100);
+const opRetentionFilter = opRetentionStategy(366, 500);
 
 const accountModel: DataModel<AccountRaw, Account> = createDataModel({
   migrations: [


### PR DESCRIPTION
(Storage): increase operation retention storage from 100 -> 500

### Type

Improvement

### Context

LL-3387

### Parts of the app affected / Test plan

Operations stored on the client are now limited to 500 per account instead of 100. 
