### PR TITLE
PoC of Websocket Bridge

### DIFF
--- a/src/internal/commands/index.js
+++ b/src/internal/commands/index.js
@@ -17,6 +17,7 @@ import testCrash from "./testCrash";
 import testInterval from "./testInterval";
 import appOpExec from "./appOpExec";
 import initSwap from "./initSwap";
+import websocketBridge from "./websocketBridge";
 import { commands as bridgeProxyCommands } from "~/renderer/bridge/proxy-commands";
 
 export const commandsById = {
@@ -39,6 +40,7 @@ export const commandsById = {
   initSwap,
   testCrash,
   testInterval,
+  websocketBridge,
 };
 
 export type Commands = typeof commandsById;

--- a/src/internal/commands/websocketBridge.js
+++ b/src/internal/commands/websocketBridge.js
@@ -1,0 +1,137 @@
+// @flow
+import { Observable } from "rxjs";
+import { log, listen } from "@ledgerhq/logs";
+import { open } from "@ledgerhq/live-common/lib/hw";
+import WebSocket from "ws";
+
+type Input = {
+  origin: ?string,
+  deviceId: string,
+};
+type Result = { log: string };
+
+const cmd = ({ origin, deviceId }: Input): Observable<Result> =>
+  Observable.create(o => {
+    const unsubLogs = listen(l => {
+      if (l.type === "proxy" && l.message) {
+        o.next({ log: l.message });
+      }
+    });
+
+    const port = "8435";
+    const ws = new WebSocket.Server({ port });
+
+    let wsIndex = 0;
+    let wsBusyIndex = 0;
+
+    ws.on("connection", (ws, connection) => {
+      if (origin && new URL(connection.headers.origin).host !== origin) {
+        o.next({ log: "invalid origin " + connection.headers.origin });
+        ws.close();
+        return;
+      }
+
+      const index = ++wsIndex;
+      try {
+        let transport;
+        let transportP;
+        let destroyed = false;
+
+        const onClose = async () => {
+          if (destroyed) return;
+          destroyed = true;
+          if (wsBusyIndex === index) {
+            log("proxy", `WS(${index}): close`);
+            if (transportP) {
+              await transportP.then(
+                t => t.close(),
+                () => {},
+              );
+              o.complete();
+            }
+            wsBusyIndex = 0;
+          }
+        };
+
+        ws.on("close", onClose);
+
+        ws.on("message", async apduHex => {
+          if (destroyed) return;
+
+          if (apduHex === "open") {
+            if (wsBusyIndex) {
+              ws.send(
+                JSON.stringify({
+                  error: "WebSocket is busy (previous session not closed)",
+                }),
+              );
+              ws.close();
+              destroyed = true;
+              return;
+            }
+            transportP = open(deviceId);
+            wsBusyIndex = index;
+
+            log("proxy", `WS(${index}): opening...`);
+            try {
+              transport = await transportP;
+              transport.on("disconnect", () => ws.close());
+              log("proxy", `WS(${index}): opened!`);
+              ws.send(JSON.stringify({ type: "opened" }));
+            } catch (e) {
+              log("proxy", `WS(${index}): open failed! ${e}`);
+              ws.send(
+                JSON.stringify({
+                  error: e.message,
+                }),
+              );
+              ws.close();
+            }
+            return;
+          }
+
+          if (wsBusyIndex !== index) {
+            console.warn("ignoring message because busy transport");
+            return;
+          }
+
+          if (!transport) {
+            console.warn("received message before device was opened");
+            return;
+          }
+          try {
+            const res = await transport.exchange(Buffer.from(apduHex, "hex"));
+            log("proxy", `WS(${index}): ${apduHex} => ${res.toString("hex")}`);
+            if (destroyed) return;
+            ws.send(JSON.stringify({ type: "response", data: res.toString("hex") }));
+          } catch (e) {
+            log("proxy", `WS(${index}): ${apduHex} =>`, e);
+            if (destroyed) return;
+            ws.send(JSON.stringify({ type: "error", error: e.message }));
+            if (e.name === "RecordStoreWrongAPDU") {
+              console.error(e.message);
+              process.exit(1);
+            }
+          }
+        });
+      } catch (e) {
+        ws.close();
+      }
+    });
+
+    ws.on("error", e => {
+      log("proxy", "Error: " + e.message);
+      o.error(e);
+    });
+
+    ws.on("listening", () => {
+      log("proxy", "Proxy is running");
+    });
+
+    return () => {
+      unsubLogs();
+      ws.close();
+    };
+  });
+
+export default cmd;

--- a/src/renderer/hooks/useDeeplinking.js
+++ b/src/renderer/hooks/useDeeplinking.js
@@ -48,10 +48,7 @@ export function useDeepLinkHandler() {
     (event: any, deeplink: string) => {
       const { pathname, searchParams } = new URL(deeplink);
       const query = Object.fromEntries(searchParams);
-
-      const matcher = /^\/+/;
-
-      const url = pathname.replace(matcher, "");
+      const url = pathname.replace(/^\/+/, "");
 
       switch (url) {
         case "accounts":
@@ -75,6 +72,17 @@ export function useDeepLinkHandler() {
             navigate(`/account/${chosen.parentId}/${chosen.id}`);
           }
 
+          break;
+        }
+
+        case "bridge": {
+          const { origin, appName } = query;
+          dispatch(
+            openModal("MODAL_WEBSOCKET_BRIDGE", {
+              origin,
+              appName,
+            }),
+          );
           break;
         }
 

--- a/src/renderer/modals/WebSocketBridge/Bridge.js
+++ b/src/renderer/modals/WebSocketBridge/Bridge.js
@@ -1,0 +1,132 @@
+// @flow
+import React, { useEffect, useState, useCallback } from "react";
+import { useSelector } from "react-redux";
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import { getEnv } from "@ledgerhq/live-common/lib/env";
+import { createAction } from "@ledgerhq/live-common/lib/hw/actions/app";
+import { ModalBody } from "~/renderer/components/Modal";
+import Box from "~/renderer/components/Box";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Button from "~/renderer/components/Button";
+import { command } from "~/renderer/commands";
+import DeviceAction from "~/renderer/components/DeviceAction";
+import ErrorDisplay from "~/renderer/components/ErrorDisplay";
+import SuccessDisplay from "~/renderer/components/SuccessDisplay";
+import StepProgress from "~/renderer/components/StepProgress";
+import { mockedEventEmitter } from "~/renderer/components/DebugMock";
+import { getCurrentDevice } from "~/renderer/reducers/devices";
+
+const connectAppExec = command("connectApp");
+
+const action = createAction(getEnv("MOCK") ? mockedEventEmitter : connectAppExec);
+
+const Container = styled(Box).attrs(() => ({
+  alignItems: "center",
+  grow: true,
+  color: "palette.text.shade100",
+}))`
+  justify-content: center;
+  min-height: 220px;
+`;
+
+const Connected = ({
+  origin,
+  onComplete,
+  onError,
+}: {
+  origin: ?string,
+  onComplete: () => void,
+  onError: Error => void,
+}) => {
+  const device = useSelector(getCurrentDevice);
+
+  useEffect(() => {
+    if (!device) return;
+    const { deviceId } = device;
+    const sub = command("websocketBridge")({ deviceId, origin }).subscribe({
+      complete: onComplete,
+      error: onError,
+    });
+    return () => {
+      sub.unsubscribe();
+    };
+  }, [origin, device, onError, onComplete]);
+
+  return null;
+};
+
+const Bridge = ({
+  origin,
+  appName,
+  onClose,
+}: {
+  origin: ?string,
+  appName: ?string,
+  onClose: () => void,
+}) => {
+  const { t } = useTranslation();
+  const [state, setState] = useState({ status: "device" });
+
+  const onResult = useCallback(
+    result => {
+      setState({ status: "init", result });
+    },
+    [setState],
+  );
+
+  const onError = useCallback(
+    error => {
+      setState({ status: "error", error });
+    },
+    [setState],
+  );
+
+  const onComplete = useCallback(() => {
+    setState({ status: "done" });
+  }, [setState]);
+
+  return (
+    <ModalBody
+      onClose={onClose}
+      title={t("modals.bridge.title")}
+      render={() => (
+        <Box relative style={{ height: 500 }} px={5} pb={8}>
+          <TrackPage category="Modal" name="Bridge" origin={origin} />
+
+          {state.status === "device" ? (
+            <DeviceAction
+              action={action}
+              request={{ appName: appName || "Ethereum" }}
+              onResult={onResult}
+            />
+          ) : state.status === "init" ? (
+            <>
+              <StepProgress modelId={state.result.device.modelId}>
+                Bridge connection established.
+              </StepProgress>
+              <Connected origin={origin} onError={onError} onComplete={onComplete} />
+            </>
+          ) : state.status === "error" ? (
+            <Container>
+              <ErrorDisplay error={state.error} />
+            </Container>
+          ) : (
+            <Container>
+              <SuccessDisplay title={"Bridge connection terminated."} />
+            </Container>
+          )}
+        </Box>
+      )}
+      renderFooter={() => (
+        <Box horizontal justifyContent="flex-end">
+          <Button onClick={onClose} primary>
+            {t("common.close")}
+          </Button>
+        </Box>
+      )}
+    />
+  );
+};
+
+export default Bridge;

--- a/src/renderer/modals/WebSocketBridge/index.js
+++ b/src/renderer/modals/WebSocketBridge/index.js
@@ -1,0 +1,15 @@
+// @flow
+
+import React from "react";
+import Modal from "~/renderer/components/Modal";
+import Bridge from "./Bridge";
+
+const BridgeModal = () => (
+  <Modal
+    name="MODAL_WEBSOCKET_BRIDGE"
+    centered
+    render={({ data, onClose }) => <Bridge {...data} onClose={onClose} />}
+  />
+);
+
+export default BridgeModal;

--- a/src/renderer/modals/index.js
+++ b/src/renderer/modals/index.js
@@ -1,4 +1,5 @@
 // @flow
+import MODAL_WEBSOCKET_BRIDGE from "./WebSocketBridge";
 import MODAL_DELEGATE from "../families/tezos/DelegateFlowModal";
 import MODAL_TRON_REWARDS_INFO from "../families/tron/EarnRewardsInfoModal";
 import MODAL_EXPORT_OPERATIONS from "./ExportOperations";
@@ -41,6 +42,7 @@ import MODAL_ALGORAND_CLAIM_REWARDS from "../families/algorand/Rewards/ClaimRewa
 import MODAL_ALGORAND_EARN_REWARDS_INFO from "../families/algorand/Rewards/EarnRewardsInfoModal";
 
 const modals: { [_: string]: React$ComponentType<any> } = {
+  MODAL_WEBSOCKET_BRIDGE,
   MODAL_EXPORT_OPERATIONS,
   MODAL_CONFIRM,
   MODAL_MANAGE_TRON,

--- a/src/renderer/screens/settings/sections/Experimental/index.js
+++ b/src/renderer/screens/settings/sections/Experimental/index.js
@@ -7,9 +7,11 @@ import { experimentalFeatures, isReadOnlyEnv } from "~/renderer/experimental";
 import { useDispatch } from "react-redux";
 import { setEnvOnAllThreads } from "~/helpers/env";
 import type { Feature } from "~/renderer/experimental";
+import { openModal } from "~/renderer/actions/modals";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import useEnv from "~/renderer/hooks/useEnv";
 import Disclaimer from "~/renderer/components/Disclaimer";
+import Button from "~/renderer/components/Button";
 import IconAtom from "~/renderer/icons/Atom";
 import IconSensitiveOperationShield from "~/renderer/icons/SensitiveOperationShield";
 import { setShowClearCacheBanner } from "~/renderer/actions/settings";
@@ -64,6 +66,26 @@ const ExperimentalFeatureRow = ({
   ) : null;
 };
 
+const EthereumBridgeRow = () => {
+  const dispatch = useDispatch();
+
+  return (
+    <Row title="Open Ethereum WebSocket Bridge" desc="open a websocket bridge for web escape hatch">
+      <Button
+        onClick={() => {
+          dispatch(
+            openModal("MODAL_WEBSOCKET_BRIDGE", {
+              appName: "Ethereum",
+            }),
+          );
+        }}
+      >
+        Open
+      </Button>
+    </Row>
+  );
+};
+
 const SectionExperimental = () => {
   const { t } = useTranslation();
   const [needsCleanCache, setNeedsCleanCache] = useState(false);
@@ -104,6 +126,7 @@ const SectionExperimental = () => {
             />
           ) : null,
         )}
+        <EthereumBridgeRow />
       </Body>
     </Section>
   );


### PR DESCRIPTION
This implements an escape hatch to allow Ledger Live to expose the device over WebSocket for web app that requires the device but when U2F/webusb is not possible / not working.

This allows a web app to link the user to, for instance `ledgerlive://bridge?appName=Ethereum&origin=mydomain.com` which will open the Bridge on Ledger Live.

**Here is basically how it works:**

- user open via an intent (using URI scheme) to use a specific appName and an origin, Ledger Live will open a modal that requests the user to connect the device and open the correct app:

<img width="520" alt="Capture d’écran 2020-09-23 à 09 04 07" src="https://user-images.githubusercontent.com/211411/93978819-d0424f00-fd7c-11ea-992e-d94a150d2129.png">

- Once the user open the app on his device, a WebSocket server on port 8435 starts (like `ledger-live proxy` CLI) and will allow clients to run APDU to the device. The client must be run from the same domain as provided by origin, if provided.
- The modals is establishing the a bi directionnel channel to the device. As soon as the user close that websocket channel, the modals turns into the success final step and the server is stopped.
- When the user closes the modal, the WebSocket server will also be stopped.

### To be determined / To be implemented

- [x] the origin, which is uses to deny websocket client that wouldn't be on same domain, is not yet implemented. It's also not clear if we want or not to allow it to be optional.
- [ ] The fact the device can BLOCK on apdus makes me think we might want to BLOCK the modal each time an apdu run. Typically we don't want to allow a web app to start doing something with the device (like a verify address) and to let the user close the modal and go do something else, it's both bad in term of UX and security.
- [ ] It it not clear yet on the behavior of two clients consuming at the same time, we likely want to deny the second connection
- [ ] UX: to be implemented the various cases where the WebSocket server can fail to be created (e.g. port in use). probably reuse the GenericError component.
- [ ] What should we do when the user disconnect the device during the bridge. Think about what it means for user land too.
- [ ] validate that URI scheme is enough and drop the experimental row.

### Note on user land integration

For a web page it would mean:

(1) Adding some kind of `<a href="ledgerlive://bridge?appName=Ethereum&origin=mydomain.com">Open Ledger Live Bridge</a>` to the web app
(2) on click of that bridge (or not even on click), actively polling for websocket availability.
(3) when the WebSocket is connected, you can use it to communicate to the device.

Please check a full example at https://ledger-live-tools.now.sh/bridgetest

Source code: https://github.com/LedgerHQ/ledger-live-common/blob/master/tools/src/demos/bridgetest/index.js

### Type

escape hatch

### Context

LL-3391

### How to test

For testing the URI scheme, you need the app builded. You can grab one of the build that our CI will generate on this PR.
