### PR TITLE
LL-3207 Prevent closing the coin control modal if it has errors

### DIFF
--- a/src/renderer/families/bitcoin/CoinControlModal.js
+++ b/src/renderer/families/bitcoin/CoinControlModal.js
@@ -62,14 +62,15 @@ const CoinControlModal = ({
   const error = errorKeys.length ? status.errors[errorKeys[0]] : null;
 
   const returning = (status.txOutputs || []).find(tx => !!tx.path);
+  const maybeOnClose = error ? undefined : onClose;
 
   return (
-    <Modal width={700} isOpened={isOpened} centered onClose={onClose}>
+    <Modal width={700} isOpened={isOpened} centered onClose={maybeOnClose}>
       <TrackPage category="Modal" name="BitcoinCoinControl" />
       <ModalBody
         width={700}
         title={<Trans i18nKey="bitcoin.modalTitle" />}
-        onClose={onClose}
+        onClose={maybeOnClose}
         render={() => (
           <Box flow={2}>
             <PickingStrategy
@@ -168,7 +169,7 @@ const CoinControlModal = ({
             <LinkWithExternalIcon onClick={onClickLink}>
               <Trans i18nKey="bitcoin.whatIs" />
             </LinkWithExternalIcon>
-            <Button primary onClick={onClose}>
+            <Button primary onClick={onClose} disabled={!!error}>
               <Trans i18nKey="common.done" />
             </Button>
           </>


### PR DESCRIPTION
To avoid a deadlock after an invalid selection in the coin control modal, disable closing said modal if the status reports errors.
This is not what was specified on the Jira task but I believe it makes more sense to not allow closing the coin control modal if the transaction would become invalid than allowing to re open it.

### Type

Bug Fix
### Context

https://ledgerhq.atlassian.net/browse/LL-3207

### Parts of the app affected / Test plan

- Open the coin control modal and make it so the transaction throws an error
- Try to close the modal, it should not be possible
- Select some UTXOs to make the transaction valid again
- Close the modal
