### PR TITLE
LL-3422 Preload the portfolio behind the onboarding

### DIFF
--- a/src/renderer/components/OnboardingOrElse.js
+++ b/src/renderer/components/OnboardingOrElse.js
@@ -13,12 +13,14 @@ type Props = {
 const OnboardingOrElse = ({ children }: Props) => {
   const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
   const onboardingRelaunched = useSelector(onboardingRelaunchedSelector);
+  const showOnboarding = !hasCompletedOnboarding || onboardingRelaunched;
 
-  if (!hasCompletedOnboarding || onboardingRelaunched) {
-    return <Onboarding />;
-  }
-
-  return children;
+  return (
+    <>
+      {showOnboarding ? <Onboarding /> : null}
+      {children}
+    </>
+  );
 };
 
 const ConnectedOnboardingOrElse: React$ComponentType<Props> = memo(OnboardingOrElse);


### PR DESCRIPTION
Instead of loading the onboarding OR the dashboard, load both. Since the onboarding is absolutely positioned and takes the whole screen we can't see any difference. Once the onboarding is finished, the other content becomes visible and has everything already rendered an in place

### Type

UI Polish (and testing)

### Context

https://ledgerhq.atlassian.net/browse/LL-3422

### Parts of the app affected / Test plan

- Launch the bullrun
- Record the bullrun
- Go frame by frame and try to see one where after the confetti screen the no-accounts illustration hasn't loaded but the text has loaded. If you don't find one, we good.