### PR TITLE
Bump live-common and use newly exposed imports instead of ledgerhq/cryptoassets

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ledgerhq/hw-transport-http": "^5.25.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.25.0",
     "@ledgerhq/ledger-core": "6.9.1",
-    "@ledgerhq/live-common": "^15.0.0",
+    "@ledgerhq/live-common": "^15.0.4",
     "@ledgerhq/logs": "^5.25.0",
     "@tippyjs/react": "^4.0.2",
     "@trust/keyto": "^1.0.1",

--- a/src/renderer/screens/swap/Form/index.js
+++ b/src/renderer/screens/swap/Form/index.js
@@ -6,7 +6,6 @@ import useBridgeTransaction from "@ledgerhq/live-common/lib/bridge/useBridgeTran
 import { BigNumber } from "bignumber.js";
 import { useSelector, useDispatch } from "react-redux";
 import { Trans } from "react-i18next";
-import { getAbandonSeedAddress } from "@ledgerhq/cryptoassets";
 import Card from "~/renderer/components/Box/Card";
 import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
 import { modalsStateSelector } from "~/renderer/reducers/modals";
@@ -18,6 +17,7 @@ import type {
   Currency,
 } from "@ledgerhq/live-common/lib/types";
 import getExchangeRates from "@ledgerhq/live-common/lib/swap/getExchangeRates";
+import { getAbandonSeedAddress } from "@ledgerhq/live-common/lib/currencies";
 import ArrowSeparator from "~/renderer/components/ArrowSeparator";
 import { swapSupportedCurrenciesSelector } from "~/renderer/reducers/settings";
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1362,10 +1362,10 @@
   dependencies:
     commander "^2.20.0"
 
-"@ledgerhq/cryptoassets@5.25.1", "@ledgerhq/cryptoassets@^5.25.1":
-  version "5.25.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-5.25.1.tgz#da436b9d03ed1bba8453d1dba6ce1db9ad3e5607"
-  integrity sha512-kXkp2YAUbOCam7IdL1b6B46YtBAmBqwy7IJnNR/c6MxrNd5YGjZqMuJbv0ag6Vk1/1RAht2Yaem3PzzqyAY/Hw==
+"@ledgerhq/cryptoassets@5.25.2", "@ledgerhq/cryptoassets@^5.25.2":
+  version "5.25.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-5.25.2.tgz#7341db85999a3e92e3aa7b016dfae0d682cb5a3e"
+  integrity sha512-G85bqj8KatX75d2oqj7lLS+kazuHJDjM4hh+EviPYWHLT/y0mxmHaa0+decIAKiSp/114bIhGDbvS0IBUEZsqg==
   dependencies:
     invariant "2"
 
@@ -1410,12 +1410,12 @@
     semver "^7.3.2"
     sha.js "2"
 
-"@ledgerhq/hw-app-eth@5.25.1":
-  version "5.25.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-5.25.1.tgz#b46e86111a53aa9dfec4879cb16a372594350841"
-  integrity sha512-xKdMrfLRybVB5p2x/JgCfVCO8p5uOk7/4iX0Aasg83yd/QRV20q+GdNM05HvGOLJ89+rsHMqw7g/mCfIsZnzQg==
+"@ledgerhq/hw-app-eth@5.25.2":
+  version "5.25.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-5.25.2.tgz#1db973e32025e7157ebe6086c455fb5add876fe2"
+  integrity sha512-IgAY2H7xSh2jAnsJioLgaOnVhgvvJDy8GcCD5c9urlmMSgX4BJZXufbESkXvellGAe3SuLwLN+uztfPrfwue+Q==
   dependencies:
-    "@ledgerhq/cryptoassets" "^5.25.1"
+    "@ledgerhq/cryptoassets" "^5.25.2"
     "@ledgerhq/errors" "^5.25.0"
     "@ledgerhq/hw-transport" "^5.25.0"
     bignumber.js "^9.0.0"
@@ -1521,17 +1521,17 @@
     node-pre-gyp "^0.15.0"
     node-pre-gyp-github "^1.4.3"
 
-"@ledgerhq/live-common@^15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-15.0.0.tgz#66ba4303d6138f035003e2ad9dd8b3eaa24a50d7"
-  integrity sha512-XbOZfQibugua1KBzFe9v0A/YHQifnoS6hQDO+YuKy86N+xfdZP7fyJ5s8yvvgjVxOmtld+TzpQ1pSX87vv65Fg==
+"@ledgerhq/live-common@^15.0.4":
+  version "15.0.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-15.0.4.tgz#cb99a57b45d9afcedd859891cfbda97089bd6e7e"
+  integrity sha512-g1o/OT6OM3l3hHR6I7+xqncyDZHfb9emgOThknGUf0a8iMpxkerkLwMSrLHycm5QQXM5mJ3cY10dQBs2ocOPPA==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
-    "@ledgerhq/cryptoassets" "5.25.1"
+    "@ledgerhq/cryptoassets" "5.25.2"
     "@ledgerhq/devices" "5.25.0"
     "@ledgerhq/errors" "5.25.0"
     "@ledgerhq/hw-app-btc" "^5.25.0"
-    "@ledgerhq/hw-app-eth" "5.25.1"
+    "@ledgerhq/hw-app-eth" "5.25.2"
     "@ledgerhq/hw-app-str" "^5.25.0"
     "@ledgerhq/hw-app-trx" "5.25.0"
     "@ledgerhq/hw-app-xrp" "5.25.0"
@@ -1542,7 +1542,7 @@
     async "^3.2.0"
     axios "0.20.0"
     bchaddrjs "^0.4.9"
-    bignumber.js "^9.0.0"
+    bignumber.js "^9.0.1"
     bip32-path "^0.4.2"
     blake2b "^2.1.3"
     bs58check "^2.1.2"
@@ -1559,6 +1559,7 @@
     prando "^5.1.2"
     redux "^4.0.5"
     reselect "^4.0.0"
+    ripemd160 "^2.0.2"
     ripple-binary-codec "^0.2.0"
     ripple-bs58check "^2.0.2"
     ripple-lib "1.1.2"
@@ -3260,10 +3261,10 @@ bignumber.js@^4.1.0:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
   integrity sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==
 
-bignumber.js@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
-  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
+bignumber.js@^9.0.0, bignumber.js@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
+  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
 
 binary-extensions@^1.0.0:
   version "1.13.1"
@@ -11608,7 +11609,7 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-ripemd160@2, ripemd160@^2.0.0, ripemd160@^2.0.1:
+ripemd160@2, ripemd160@^2.0.0, ripemd160@^2.0.1, ripemd160@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
   integrity sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==


### PR DESCRIPTION
The swap feature was importing some dependencies. from `@ledgerhq/cryptoassets` since we lacked an export of the abandonseed helper. With the bump of live-common which includes https://github.com/LedgerHQ/ledger-live-common/pull/896 we can clean the imports on LLD an go back to importing from live-common.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Code Quality Improvement

### Parts of the app affected / Test plan

Nothing should break, but of course, a bit of testing might be due.
