### PR TITLE
LL-3573 Change wording for swap history's empty state

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -133,8 +133,8 @@
     },
     "history": {
       "empty": {
-        "title": "No History",
-        "description": "You don’t have any swap history."
+        "title": "Your previous swaps will appear here",
+        "description": "Either you have not made any swaps yet, or Ledger Live has been reset in the meantime."
       }
     },
     "landing": {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/95078817-06d17f80-0716-11eb-8d00-f22adcedf730.png)

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-3573

### Parts of the app affected / Test plan

Make sure the empty state for swap history looks like the above screenshot
