### PR TITLE
LL-3549 Analytics onboarding + add learn crypto entry

### DIFF
--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -25,8 +25,14 @@ export const urls = {
   faq: "https://support.ledger.com/hc/en-us",
   syncErrors: "https://support.ledger.com/hc/en-us/articles/360012207759",
   terms: "https://www.ledger.com/pages/terms-of-use-and-disclaimer",
-  noDeviceBuyNew: "https://www.ledger.com/",
-  noDeviceLearnMore: "https://www.ledger.com/",
+  noDevice: {
+    buyNew:
+      "https://shop.ledger.com/pages/hardware-wallets-comparison?utm_source=ledger_live&utm_medium=self_referral&utm_content=onboarding",
+    learnMore:
+      "https://www.ledger.com?utm_source=ledger_live&utm_medium=self_referral&utm_content=onboarding",
+    learnMoreCrypto:
+      "https://www.ledger.com/academy?utm_source=ledger_live&utm_medium=self_referral&utm_content=onboarding",
+  },
   managerHelpRequest: "https://support.ledger.com/hc/en-us/articles/360006523674 ",
   contactSupport: "https://support.ledger.com/hc/en-us/requests/new?ticket_form_id=248165",
   feesMoreInfo: "https://support.ledger.com/hc/en-us/articles/360006535873",

--- a/src/renderer/screens/onboarding/steps/NoDevice.js
+++ b/src/renderer/screens/onboarding/steps/NoDevice.js
@@ -4,6 +4,7 @@ import { Trans } from "react-i18next";
 import { openURL } from "~/renderer/linking";
 import { urls } from "~/config/urls";
 import IconCart from "~/renderer/icons/Cart";
+import IconBook from "~/renderer/icons/Book";
 import IconInfoCircle from "~/renderer/icons/InfoCircle";
 import Box from "~/renderer/components/Box";
 import GrowScroll from "~/renderer/components/GrowScroll";
@@ -26,7 +27,7 @@ class NoDevice extends PureComponent<StepProps, *> {
         icon: <IconCart size={20} />,
         title: t("onboarding.noDevice.buyNew.title"),
         onClick: () => {
-          openURL(urls.noDeviceBuyNew);
+          openURL(urls.noDevice.buyNew);
         },
       },
       {
@@ -34,7 +35,15 @@ class NoDevice extends PureComponent<StepProps, *> {
         icon: <IconInfoCircle size={20} />,
         title: t("onboarding.noDevice.learnMore.title"),
         onClick: () => {
-          openURL(urls.noDeviceLearnMore);
+          openURL(urls.noDevice.learnMore);
+        },
+      },
+      {
+        key: "learnMoreCrypto",
+        icon: <IconBook size={20} />,
+        title: t("onboarding.noDevice.learnMoreCrypto.title"),
+        onClick: () => {
+          openURL(urls.noDevice.learnMoreCrypto);
         },
       },
     ];

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -1690,6 +1690,9 @@
       },
       "learnMore": {
         "title": "Learn about Ledger"
+      },
+      "learnMoreCrypto": {
+        "title": "Learn about crypto"
       }
     },
     "selectDevice": {


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/95322836-6ad28000-089d-11eb-93b8-9c0312845506.png)

Change the urls of the no device menu on the onboarding flow to add some analytics to trace the source of the user, and add a new entry to that screen with a link to learn more about crypto. There was no design for the learn crypto items so I used the book icon, probably fine.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-3549

### Parts of the app affected / Test plan

- Go to the onboarding
- Select I don't have a device
- Check the links