### PR TITLE
LL-3547 Allow the first launch of the app to be tracked after onboarding

### DIFF
--- a/src/renderer/Default.js
+++ b/src/renderer/Default.js
@@ -2,11 +2,11 @@
 
 import React, { useEffect, useRef } from "react";
 import { Route, Switch, useLocation } from "react-router-dom";
+import TrackAppStart from "~/renderer/components/TrackAppStart";
 
 import { BridgeSyncProvider } from "~/renderer/bridge/BridgeSyncContext";
 import CounterValues from "~/renderer/countervalues";
 import { SyncNewAccounts } from "~/renderer/bridge/SyncNewAccounts";
-import Track from "~/renderer/analytics/Track";
 import Dashboard from "~/renderer/screens/dashboard";
 import Settings from "~/renderer/screens/settings";
 import Accounts from "~/renderer/screens/accounts";
@@ -67,7 +67,7 @@ const Default = () => {
       <TriggerAppReady />
       <ListenDevices />
       <ExportLogsButton hookToShortcut />
-      <Track mandatory onMount event="App Starts" />
+      <TrackAppStart />
       <Idler />
       {process.platform === "darwin" ? <AppRegionDrag /> : null}
 

--- a/src/renderer/components/TrackAppStart.js
+++ b/src/renderer/components/TrackAppStart.js
@@ -1,0 +1,13 @@
+// @flow
+
+import React from "react";
+import { useSelector } from "react-redux";
+import { hasCompletedOnboardingSelector } from "~/renderer/reducers/settings";
+import Track from "~/renderer/analytics/Track";
+
+const TrackAppStart = () => {
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  return hasCompletedOnboarding ? <Track mandatory onMount event="App Starts" /> : null;
+};
+
+export default TrackAppStart;


### PR DESCRIPTION
### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-3547

### Parts of the app affected / Test plan

- Launch a clean installation of the app with `DEBUG=info VERBOSE=1 yarn start` or similar
- Complete the onboarding
- Export the logs, make sure the "App Start" event is exported
