### PR TITLE
LL-3574 Change wording for update available banner

### DIFF
--- a/src/renderer/components/Updater/DebugUpdater.js
+++ b/src/renderer/components/Updater/DebugUpdater.js
@@ -6,7 +6,14 @@ import React, { Component } from "react";
 import { withUpdaterContext } from "./UpdaterContext";
 import type { UpdaterContextType } from "./UpdaterContext";
 
-const statusToDebug = ["idle", "download-progress", "checking", "check-success", "error"];
+const statusToDebug = [
+  "idle",
+  "download-progress",
+  "checking",
+  "check-success",
+  "error",
+  "update-available",
+];
 
 type Props = {
   context: UpdaterContextType,

--- a/src/renderer/components/Updater/UpdaterContext.js
+++ b/src/renderer/components/Updater/UpdaterContext.js
@@ -56,6 +56,7 @@ class Provider extends Component<UpdaterProviderProps, UpdaterProviderState> {
       status: "idle",
       downloadProgress: 0,
       error: null,
+      version: process.env.DEBUG_UPDATE ? "1.2.3" : undefined,
     };
   }
 

--- a/static/i18n/de/app.json
+++ b/static/i18n/de/app.json
@@ -1624,11 +1624,11 @@
     "checking": "Checking update...",
     "checkSuccess": "Update ready to install",
     "quitAndInstall": "Install now",
-    "updateAvailable": "Ledger Live {{version}} is available for update",
+    "updateAvailable": "Update to Ledger Live version {{version}} is available",
     "error": "Error during update. Please download again",
     "reDownload": "Download again",
     "nightlyWarning": "This version cannot auto-update. Please install the latest version manually",
-    "downloadNow": "Download now"
+    "downloadNow": "Download update"
   },
   "crash": {
     "title": "Something went wrong",

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -1624,11 +1624,11 @@
     "checking": "Checking update...",
     "checkSuccess": "Update ready to install",
     "quitAndInstall": "Install now",
-    "updateAvailable": "Ledger Live {{version}} is available for update",
+    "updateAvailable": "Update to Ledger Live version {{version}} is available",
     "error": "Error during update. Please download again",
     "reDownload": "Download again",
     "nightlyWarning": "This version cannot auto-update. Please install the latest version manually",
-    "downloadNow": "Download now"
+    "downloadNow": "Download update"
   },
   "crash": {
     "title": "Something went wrong",


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/95357561-4c35ae80-08c8-11eb-927e-590e462b3ad0.png)


Change the wording for the description and cta of the update banner + fix for the debug updater that was no longer working.

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-3574

### Parts of the app affected / Test plan

- Launch LLD with the `DEBUG_UPDATE=1` env flag.
- Set the updated state to "update-available" by clicking on the green button.
- Check the banner matches the screenshot.
