### PR TITLE
Simple proposal for LL-3651

### DIFF
--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -87,5 +87,7 @@ export const urls = {
     CantOpenDevice: "https://support.ledger.com/hc/en-us/articles/115005165269",
     WrongDeviceForAccount: "https://support.ledger.com/hc/en-us/articles/360025321733",
     SyncError: "https://support.ledger.com/hc/en-us/articles/360012109220",
+    BitcoinCashHardforkOct2020Warning:
+      "https://www.ledger.com/bitcoin-cash-fork-15-november-2020-what-it-means-for-you",
   },
 };

--- a/src/renderer/components/CurrencyDownStatusAlert.js
+++ b/src/renderer/components/CurrencyDownStatusAlert.js
@@ -1,13 +1,21 @@
 // @flow
-
+import React from "react";
+import { createCustomErrorClass } from "@ledgerhq/errors";
 import type { TokenCurrency, CryptoCurrency } from "@ledgerhq/live-common/lib/types";
+import ErrorBanner from "./ErrorBanner";
 
 type Props = {
-  currency: CryptoCurrency | TokenCurrency,
+  currencies: Array<CryptoCurrency | TokenCurrency>,
 };
 
-const CurrencyDownStatusAlert = ({ currency }: Props) => {
-  // TODO remove the idea. LL-2256
+const BitcoinCashHardforkOct2020Warning = createCustomErrorClass(
+  "BitcoinCashHardforkOct2020Warning",
+);
+
+const CurrencyDownStatusAlert = ({ currencies }: Props) => {
+  if (currencies.some(c => c.id === "bitcoin_cash")) {
+    return <ErrorBanner error={new BitcoinCashHardforkOct2020Warning()} warning />;
+  }
   return null;
 };
 

--- a/src/renderer/families/tezos/DelegateFlowModal/steps/StepAccount.js
+++ b/src/renderer/families/tezos/DelegateFlowModal/steps/StepAccount.js
@@ -32,7 +32,7 @@ const StepAccount = ({
   return (
     <Box flow={4}>
       <TrackPage category="Delegation Flow" name="Step Account" />
-      {mainAccount ? <CurrencyDownStatusAlert currency={mainAccount.currency} /> : null}
+      {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
       {error ? <ErrorBanner error={error} /> : null}
       <Box flow={1}>
         <Label>{t("delegation.flow.steps.account.toDelegate")}</Label>

--- a/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.js
+++ b/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.js
@@ -49,7 +49,7 @@ const StepChooseCurrency = ({ currency, setCurrency }: StepProps) => {
   const currencies = useMemo(() => listSupportedCurrencies().concat(listTokens()), []);
   return (
     <>
-      {currency ? <CurrencyDownStatusAlert currency={currency} /> : null}
+      {currency ? <CurrencyDownStatusAlert currencies={[currency]} /> : null}
       {/* $FlowFixMe: onChange type is not good */}
       <SelectCurrency currencies={currencies} autoFocus onChange={setCurrency} value={currency} />
       {currency && currency.type === "TokenCurrency" ? <TokenTips currency={currency} /> : null}

--- a/src/renderer/modals/Receive/steps/StepAccount.js
+++ b/src/renderer/modals/Receive/steps/StepAccount.js
@@ -102,7 +102,7 @@ export default function StepAccount({
   return (
     <Box flow={1}>
       <TrackPage category="Receive Flow" name="Step 1" />
-      {mainAccount ? <CurrencyDownStatusAlert currency={mainAccount.currency} /> : null}
+      {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
       {error ? <ErrorBanner error={error} /> : null}
       {receiveTokenMode && mainAccount ? (
         <TokenParentSelection mainAccount={mainAccount} onChangeAccount={onChangeAccount} />

--- a/src/renderer/modals/Receive/steps/StepConnectDevice.js
+++ b/src/renderer/modals/Receive/steps/StepConnectDevice.js
@@ -28,7 +28,7 @@ export default function StepConnectDevice({
   const tokenCurrency = (account && account.type === "TokenAccount" && account.token) || token;
   return (
     <>
-      {mainAccount ? <CurrencyDownStatusAlert currency={mainAccount.currency} /> : null}
+      {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
       <DeviceAction
         action={action}
         request={{ account: mainAccount, tokenCurrency }}

--- a/src/renderer/modals/Send/steps/StepAmount.js
+++ b/src/renderer/modals/Send/steps/StepAmount.js
@@ -36,7 +36,7 @@ const StepAmount = ({
   return (
     <Box flow={4}>
       <TrackPage category="Send Flow" name="Step Amount" />
-      {mainAccount ? <CurrencyDownStatusAlert currency={mainAccount.currency} /> : null}
+      {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
       {error ? <ErrorBanner error={error} /> : null}
       {account && transaction && mainAccount && (
         <Fragment key={account.id}>

--- a/src/renderer/modals/Send/steps/StepRecipient.js
+++ b/src/renderer/modals/Send/steps/StepRecipient.js
@@ -38,7 +38,7 @@ const StepRecipient = ({
   return (
     <Box flow={4}>
       <TrackPage category="Send Flow" name="Step Recipient" />
-      {mainAccount ? <CurrencyDownStatusAlert currency={mainAccount.currency} /> : null}
+      {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
       {error ? <ErrorBanner error={error} /> : null}
       <Box flow={1}>
         <Label>{t("send.steps.details.selectAccountDebit")}</Label>

--- a/src/renderer/screens/dashboard/index.js
+++ b/src/renderer/screens/dashboard/index.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { useCallback, useMemo } from "react";
 import Box from "~/renderer/components/Box";
-import { accountsSelector } from "~/renderer/reducers/accounts";
+import { accountsSelector, currenciesSelector } from "~/renderer/reducers/accounts";
 import BalanceSummary from "./GlobalSummary";
 import { colors } from "~/renderer/styles/theme";
 
@@ -31,6 +31,7 @@ import { useHistory } from "react-router-dom";
 import { createStructuredSelector } from "reselect";
 import EmptyStateInstalledApps from "~/renderer/screens/dashboard/EmptyStateInstalledApps";
 import EmptyStateAccounts from "~/renderer/screens/dashboard/EmptyStateAccounts";
+import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAlert";
 
 // This forces only one visible top banner at a time
 export const TopBannerContainer: ThemedComponent<{}> = styled.div`
@@ -52,6 +53,7 @@ type Props = {
 const DashboardPage = ({ saveSettings }: Props) => {
   const { t } = useTranslation();
   const accounts = useSelector(accountsSelector);
+  const currencies = useSelector(currenciesSelector);
   const history = useHistory();
   const counterValue = useSelector(counterValueCurrencySelector);
   const selectedTimeRange = useSelector(selectedTimeRangeSelector);
@@ -74,6 +76,7 @@ const DashboardPage = ({ saveSettings }: Props) => {
       <TopBannerContainer>
         <UpdateBanner />
         <MigrationBanner />
+        <CurrencyDownStatusAlert currencies={currencies} />
       </TopBannerContainer>
       {showCarousel ? <Carousel /> : null}
       <RefreshAccountsOrdering onMount />

--- a/src/renderer/screens/exchange/Buy/SelectAccountAndCurrency.js
+++ b/src/renderer/screens/exchange/Buy/SelectAccountAndCurrency.js
@@ -26,6 +26,7 @@ import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import { getAccountCurrency, isAccountEmpty } from "@ledgerhq/live-common/lib/account/helpers";
 import { track } from "~/renderer/analytics/segment";
 import { useCurrencyAccountSelect } from "~/renderer/components/PerCurrencySelectAccount/state";
+import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAlert";
 
 const Container: ThemedComponent<{}> = styled.div`
   width: 365px;
@@ -102,6 +103,7 @@ const SelectAccountAndCurrency = ({ selectAccount, defaultCurrency, defaultAccou
         {t("exchange.buy.title")}
       </Text>
       <FormContainer>
+        {currency ? <CurrencyDownStatusAlert currencies={[currency]} /> : null}
         <FormContent>
           <Label>{t("exchange.buy.selectCrypto")}</Label>
           <SelectCurrency onChange={setCurrency} currencies={allCurrencies} value={currency} />

--- a/src/renderer/screens/swap/Form/From.js
+++ b/src/renderer/screens/swap/Form/From.js
@@ -28,6 +28,7 @@ import { AmountRequired } from "@ledgerhq/errors";
 import { useCurrencyAccountSelect } from "~/renderer/components/PerCurrencySelectAccount/state";
 import { useSelector } from "react-redux";
 import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
+import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAlert";
 
 const InputRight = styled(Box).attrs(() => ({
   ff: "Inter|Medium",
@@ -134,6 +135,7 @@ const From = ({
       <Text mb={15} color="palette.text.shade100" ff="Inter|SemiBold" fontSize={5}>
         <Trans i18nKey={`swap.form.from.title`} />
       </Text>
+      {currency ? <CurrencyDownStatusAlert currencies={[currency]} /> : null}
       <Box>
         <Label mb={4}>
           <Trans i18nKey={`swap.form.from.currency`} />

--- a/src/renderer/screens/swap/Form/To.js
+++ b/src/renderer/screens/swap/Form/To.js
@@ -30,6 +30,7 @@ import useTheme from "~/renderer/hooks/useTheme";
 import { useCurrencyAccountSelect } from "~/renderer/components/PerCurrencySelectAccount/state";
 import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
 import { getAccountCurrency } from "@ledgerhq/live-common/lib/account";
+import CurrencyDownStatusAlert from "~/renderer/components/CurrencyDownStatusAlert";
 
 const InputRight = styled(Box).attrs(() => ({
   ff: "Inter|Medium",
@@ -156,6 +157,7 @@ const SwapInputGroup = ({
       <Text mb={15} color="palette.text.shade100" ff="Inter|SemiBold" fontSize={5}>
         <Trans i18nKey={`swap.form.to.title`} />
       </Text>
+      {currency ? <CurrencyDownStatusAlert currencies={[currency]} /> : null}
       <Box>
         <Label mb={4}>
           <Trans i18nKey={`swap.form.to.currency`} />

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -1951,6 +1951,10 @@
     "AmountRequired": {
       "title": "Amount required"
     },
+    "BitcoinCashHardforkOct2020Warning": {
+      "title": "",
+      "description": "Bitcoin Cash is currently undergoing a hard fork without replay protection. We will temporarily interrupt the Bitcoin Cash service until the network has stabilized."
+    },
     "NoAccessToCamera": {
       "title": "Please ensure your system has a camera, that it is not in use by another application and that Ledger Live has permission to use it.",
       "description": ""


### PR DESCRIPTION
this enable a contextual warning banner in flows that involve Bitcoin Cash to anticipate the incoming hard fork.

- The warning appears on Portfolio. as soon as you have at least one Bitcoin Cash account.
- There is a link that points to https://www.ledger.com/bitcoin-cash-fork-15-november-2020-what-it-means-for-you
- The warning will be displayed for an unlimited amount of time, until we do another Live release that removes it.
- The warning will always be displayed even when our explorers start to get down, we will have the usual "Synchronisation error" in the general Sync icon and on the BCH account / flows (on top of seeing the warning)
- In all other flows (Add Account, Send, Receive, Buy, Swap) you will also see the banner as soon as you select Bitcoin Cash currency.

<img width="1136" alt="Capture d’écran 2020-10-16 à 12 17 15" src="https://user-images.githubusercontent.com/211411/96246953-b37aef00-0fa9-11eb-93f4-ac3ffe28c3ec.png">
<img width="1136" alt="Capture d’écran 2020-10-16 à 12 17 24" src="https://user-images.githubusercontent.com/211411/96246956-b4ac1c00-0fa9-11eb-84ba-48d7e4f7f955.png">
<img width="1136" alt="Capture d’écran 2020-10-16 à 12 17 32" src="https://user-images.githubusercontent.com/211411/96246959-b4ac1c00-0fa9-11eb-8919-57ee92bc9a35.png">
<img width="1136" alt="Capture d’écran 2020-10-16 à 12 17 40" src="https://user-images.githubusercontent.com/211411/96246962-b544b280-0fa9-11eb-98a6-64d98fb0651f.png">
<img width="1136" alt="Capture d’écran 2020-10-16 à 12 17 46" src="https://user-images.githubusercontent.com/211411/96246963-b544b280-0fa9-11eb-8542-ce5ac1d025b6.png">
<img width="1136" alt="Capture d’écran 2020-10-16 à 12 18 09" src="https://user-images.githubusercontent.com/211411/96246964-b544b280-0fa9-11eb-9bb8-cdcad2479a81.png">
