### PR TITLE
Integrate latest ethjs evolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ledgerhq/hw-transport-http": "^5.26.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.26.0",
     "@ledgerhq/ledger-core": "6.9.1",
-    "@ledgerhq/live-common": "^15.5.0-ethjs.5",
+    "@ledgerhq/live-common": "^15.5.0-ethjs.6",
     "@ledgerhq/logs": "^5.26.0",
     "@tippyjs/react": "^4.0.2",
     "@trust/keyto": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@ledgerhq/hw-transport-http": "^5.26.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.26.0",
     "@ledgerhq/ledger-core": "6.9.1",
-    "@ledgerhq/live-common": "^15.5.0",
+    "@ledgerhq/live-common": "^15.5.0-ethjs.5",
     "@ledgerhq/logs": "^5.26.0",
     "@tippyjs/react": "^4.0.2",
     "@trust/keyto": "^1.0.1",

--- a/src/renderer/components/FeeSliderField.js
+++ b/src/renderer/components/FeeSliderField.js
@@ -1,16 +1,13 @@
 // @flow
 
-import React, { useMemo, useCallback } from "react";
+import React, { useCallback } from "react";
 import styled from "styled-components";
 import { BigNumber } from "bignumber.js";
 import { Trans } from "react-i18next";
 import type { Unit } from "@ledgerhq/live-common/lib/types";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
-import {
-  inferDynamicRange,
-  reverseRangeIndex,
-  projectRangeIndex,
-} from "@ledgerhq/live-common/lib/range";
+import type { Range } from "@ledgerhq/live-common/lib/range";
+import { reverseRangeIndex, projectRangeIndex } from "@ledgerhq/live-common/lib/range";
 import IconExclamationCircle from "~/renderer/icons/ExclamationCircle";
 import Box from "./Box";
 import Text from "./Text";
@@ -20,6 +17,7 @@ import GenericContainer from "./FeesContainer";
 import TranslatedError from "./TranslatedError";
 
 type Props = {
+  range: Range,
   value: BigNumber,
   onChange: BigNumber => void,
   unit: Unit,
@@ -47,15 +45,16 @@ const Holder = styled.div`
 `;
 
 export function useDynamicRange({
+  range,
   value,
   defaultValue,
   onChange,
 }: {
+  range: Range,
   value: BigNumber,
   defaultValue: BigNumber,
   onChange: BigNumber => void,
 }) {
-  const range = useMemo(() => inferDynamicRange(defaultValue), [defaultValue]);
   const index = reverseRangeIndex(range, value);
   const setValueIndex = useCallback((i: number) => onChange(projectRangeIndex(range, i)), [
     range,
@@ -65,8 +64,9 @@ export function useDynamicRange({
   return { range, index, constraintValue, setValueIndex };
 }
 
-const FeeSliderField = ({ value, onChange, unit, error, defaultValue }: Props) => {
-  const { range, index, constraintValue, setValueIndex } = useDynamicRange({
+const FeeSliderField = ({ range, value, onChange, unit, error, defaultValue }: Props) => {
+  const { index, constraintValue, setValueIndex } = useDynamicRange({
+    range,
     value,
     defaultValue,
     onChange,

--- a/src/renderer/experimental.js
+++ b/src/renderer/experimental.js
@@ -87,15 +87,6 @@ export const experimentalFeatures: Feature[] = [
       "Changing the app provider in the Manager may make it impossible to install or uninstall apps on your Ledger device.",
     minValue: 1,
   },
-  {
-    type: "toggle",
-    name: "EXPERIMENTAL_CURRENCIES_JS_BRIDGE",
-    valueOn: "ethereum",
-    valueOff: "",
-    title: "Experimental Ethereum implementation",
-    description:
-      "Switch to a new JavaScript implementation of Ethereum. This should improve performance and fix a few bugs, as well as display token operations as fee operations instead of send transactions.",
-  },
 ];
 
 const lsKey = "experimentalFlags";

--- a/src/renderer/families/ethereum/GasPriceField.js
+++ b/src/renderer/families/ethereum/GasPriceField.js
@@ -6,6 +6,7 @@ import invariant from "invariant";
 import type { Account, Transaction, TransactionStatus } from "@ledgerhq/live-common/lib/types";
 import { getAccountBridge } from "@ledgerhq/live-common/lib/bridge";
 import FeeSliderField from "~/renderer/components/FeeSliderField";
+import { inferDynamicRange } from "@ledgerhq/live-common/lib/range";
 
 type Props = {
   account: Account,
@@ -14,7 +15,7 @@ type Props = {
   onChange: Transaction => void,
 };
 
-const fallbackGasPrice = BigNumber(10e9);
+const fallbackGasPrice = inferDynamicRange(BigNumber(10e9));
 let lastNetworkGasPrice; // local cache of last value to prevent extra blinks
 
 const FeesField = ({ onChange, account, transaction, status }: Props) => {
@@ -33,13 +34,14 @@ const FeesField = ({ onChange, account, transaction, status }: Props) => {
   if (!lastNetworkGasPrice && networkGasPrice) {
     lastNetworkGasPrice = networkGasPrice;
   }
-  const defaultGasPrice = networkGasPrice || lastNetworkGasPrice || fallbackGasPrice;
-  const gasPrice = transaction.gasPrice || defaultGasPrice;
+  const range = networkGasPrice || lastNetworkGasPrice || fallbackGasPrice;
+  const gasPrice = transaction.gasPrice || range.initial;
   const { units } = account.currency;
 
   return (
     <FeeSliderField
-      defaultValue={defaultGasPrice}
+      range={range}
+      defaultValue={range.initial}
       value={gasPrice}
       onChange={onGasPriceChange}
       unit={units.length > 1 ? units[1] : units[0]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1364,10 +1364,10 @@
   dependencies:
     commander "^2.20.0"
 
-"@ledgerhq/cryptoassets@5.27.1", "@ledgerhq/cryptoassets@^5.27.1":
-  version "5.27.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-5.27.1.tgz#9bc2e822fb8ab954b81d6eb1fb2401fb0529c6f9"
-  integrity sha512-DGKTjJ/+rMBk+Hk+Pyr9PH5DVbPtpBoMsxxdLYvgdZ7HgEIOOxNFA4GK2QcWhadkaNApAzYqATIXGbR6NRjlyA==
+"@ledgerhq/cryptoassets@5.27.2", "@ledgerhq/cryptoassets@^5.27.2":
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-5.27.2.tgz#8f6cfc9cd0ac90b6389f73ca7d5126b663b0dd93"
+  integrity sha512-3AMzLPpqK7ldVGwNzggPpgRB3ZhhhLz+FB+bQQSCBzk1knBR1JZmuw1i9cG6W+28vQsQkQUTWpH6nXKTjhwbRg==
   dependencies:
     invariant "2"
 
@@ -1412,12 +1412,12 @@
     semver "^7.3.2"
     sha.js "2"
 
-"@ledgerhq/hw-app-eth@5.27.1":
-  version "5.27.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-5.27.1.tgz#c442a643fd3032c02b8ca946b8bd185e155bc600"
-  integrity sha512-mR3NsHBQ5DKCutWZP00IrhRlYpOjgLbBVYM3NKr0P3q0LrcmYRpTp0JM3B3OSZF/6j4HwZDWVp2E/2GIksqZ8Q==
+"@ledgerhq/hw-app-eth@5.27.2":
+  version "5.27.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-5.27.2.tgz#65a2ed613a69340e0cd69c942147455ec513d006"
+  integrity sha512-llNdrE894cCN8j6yxJEUniciyLVcLmu5N0UmIJLOObztG+5rOF4bX54h4SreTWK+E10Z0CzHSeyE5Lz/tVcqqQ==
   dependencies:
-    "@ledgerhq/cryptoassets" "^5.27.1"
+    "@ledgerhq/cryptoassets" "^5.27.2"
     "@ledgerhq/errors" "^5.26.0"
     "@ledgerhq/hw-transport" "^5.26.0"
     bignumber.js "^9.0.1"
@@ -1523,17 +1523,17 @@
     node-pre-gyp "^0.15.0"
     node-pre-gyp-github "^1.4.3"
 
-"@ledgerhq/live-common@^15.5.0":
-  version "15.5.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-15.5.0.tgz#519c7ceea96d81939adb0651865f1695a6534122"
-  integrity sha512-qCFXOrMgIKJGT1G1a7C9x9jel3IJhO7QGSQ7yThp1L5PVm91H1s6NmdEPfzDQ8x6lx4tqJrH2rjYHV8BUCfoew==
+"@ledgerhq/live-common@^15.5.0-ethjs.5":
+  version "15.5.0-ethjs.5"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-15.5.0-ethjs.5.tgz#24892fa0cfe8cbe2187a8e90dae99dcb1e99004f"
+  integrity sha512-2H5Y4s+NaYyFIKyrWaiX2i1VoSClQAAqqwqhl9MJqf2C5gMzwom8BLKmoFbY/eHzUbgmNhSwfzAOXoWhZ5Qx5Q==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
-    "@ledgerhq/cryptoassets" "5.27.1"
+    "@ledgerhq/cryptoassets" "5.27.2"
     "@ledgerhq/devices" "5.26.0"
     "@ledgerhq/errors" "5.26.0"
     "@ledgerhq/hw-app-btc" "^5.26.0"
-    "@ledgerhq/hw-app-eth" "5.27.1"
+    "@ledgerhq/hw-app-eth" "5.27.2"
     "@ledgerhq/hw-app-str" "^5.26.0"
     "@ledgerhq/hw-app-trx" "5.26.0"
     "@ledgerhq/hw-app-xrp" "5.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,10 +1523,10 @@
     node-pre-gyp "^0.15.0"
     node-pre-gyp-github "^1.4.3"
 
-"@ledgerhq/live-common@^15.5.0-ethjs.5":
-  version "15.5.0-ethjs.5"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-15.5.0-ethjs.5.tgz#24892fa0cfe8cbe2187a8e90dae99dcb1e99004f"
-  integrity sha512-2H5Y4s+NaYyFIKyrWaiX2i1VoSClQAAqqwqhl9MJqf2C5gMzwom8BLKmoFbY/eHzUbgmNhSwfzAOXoWhZ5Qx5Q==
+"@ledgerhq/live-common@^15.5.0-ethjs.6":
+  version "15.5.0-ethjs.6"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-15.5.0-ethjs.6.tgz#aaf4cf2fed11c298da6a371e135c88a41e7fd776"
+  integrity sha512-8mWuqQzAX0l+F0OfCTLnFcEwT16jL7r8z14mk/TotLGyv7pV5IfS0OlqFPYThwKpzmx6YybsUDiYn5DfGrljfQ==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/cryptoassets" "5.27.2"


### PR DESCRIPTION
- This works fully migrate ETH to use the JS implementation.
- It also uses latest work of the ETH api (staging, which is testable with Experimental Explorers) but is still backward compatible with production (which is without Experimental Explorers).
- reworked the gas price component to use the range provided by network (if experimental on)

it is great to confirm this is good to go so we can merge the live-common PR.

### Type

update

### Context

https://github.com/LedgerHQ/ledger-live-common/pull/912

### Parts of the app affected / Test plan

all accounts are migrated to ETHjs.
gas price works and you can do ETH/ERC20 tx without an issue.