### PR TITLE
LL-2887 Show clear cache banner after dirty experimental setting changes

### DIFF
--- a/src/renderer/actions/settings.js
+++ b/src/renderer/actions/settings.js
@@ -44,6 +44,8 @@ export const setCounterValue = (counterValue: string) =>
 export const setLanguage = (language: ?string) => saveSettings({ language });
 export const setTheme = (theme: ?string) => saveSettings({ theme });
 export const setRegion = (region: ?string) => saveSettings({ region });
+export const setShowClearCacheBanner = (showClearCacheBanner: boolean) =>
+  saveSettings({ showClearCacheBanner });
 export const setHideEmptyTokenAccounts = (hideEmptyTokenAccounts: boolean) => async (
   dispatch: *,
 ) => {

--- a/src/renderer/components/ClearCacheBanner.js
+++ b/src/renderer/components/ClearCacheBanner.js
@@ -1,0 +1,54 @@
+// @flow
+
+import React, { useState, useCallback } from "react";
+import { useSelector, useDispatch } from "react-redux";
+
+import TopBanner from "~/renderer/components/TopBanner";
+import TriangleWarning from "~/renderer/icons/TriangleWarning";
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import { showClearCacheBannerSelector } from "~/renderer/reducers/settings";
+import Spinner from "~/renderer/components/Spinner";
+import { softReset } from "~/renderer/reset";
+import { cleanAccountsCache } from "~/renderer/actions/accounts";
+import { setShowClearCacheBanner } from "~/renderer/actions/settings";
+
+const Link = styled.span`
+  color: ${p => p.theme.colors.palette.primary.contrastText};
+  text-decoration: underline;
+  cursor: pointer;
+`;
+
+const ClearCacheBanner = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const showClearCacheBanner = useSelector(showClearCacheBannerSelector);
+  const dispatch = useDispatch();
+  const onClick = useCallback(() => {
+    try {
+      setIsLoading(true);
+      softReset({ cleanAccountsCache: () => dispatch(cleanAccountsCache()) });
+      dispatch(setShowClearCacheBanner(false));
+    } catch (err) {
+      setIsLoading(false);
+    }
+  }, [dispatch]);
+
+  if (!showClearCacheBanner && !isLoading) return null;
+  return (
+    <TopBanner
+      status="orange"
+      content={{
+        message: <Trans i18nKey="banners.cleanCache.title" />,
+        Icon: TriangleWarning,
+        right: (
+          <Link id="modal-migrate-accounts-button" onClick={onClick}>
+            {isLoading ? <Spinner size={16} /> : <Trans i18nKey="banners.cleanCache.cta" />}
+          </Link>
+        ),
+      }}
+      bannerId={"migrate"}
+    />
+  );
+};
+
+export default ClearCacheBanner;

--- a/src/renderer/experimental.js
+++ b/src/renderer/experimental.js
@@ -9,6 +9,7 @@ export type FeatureCommon = {
   title: string,
   description: string,
   shadow?: boolean,
+  dirty?: boolean, // NB Will trigger a clear cache if changed
 };
 
 export type FeatureToggle =
@@ -76,6 +77,7 @@ export const experimentalFeatures: Feature[] = [
       "Custom gap limit for all accounts. Increasing this value above its default value (20) scans more unused public addresses for coins. Advanced users only, this may break compatibility when restoring your accounts.",
     minValue: 20,
     maxValue: 999,
+    dirty: true,
   },
   {
     type: "integer",

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -107,6 +107,7 @@ export type SettingsState = {
   blacklistedTokenIds: string[],
   deepLinkUrl: ?string,
   swapProviders?: AvailableProvider[],
+  showClearCacheBanner: boolean,
 };
 
 const defaultsForCurrency: Currency => CurrencySettings = crypto => {
@@ -148,6 +149,7 @@ const INITIAL_STATE: SettingsState = {
   blacklistedTokenIds: [],
   deepLinkUrl: null,
   swapProviders: [],
+  showClearCacheBanner: false,
 };
 
 const pairHash = (from, to) => `${from.ticker}_${to.ticker}`;
@@ -372,6 +374,8 @@ export const hideEmptyTokenAccountsSelector = (state: State) =>
 export const lastSeenDeviceSelector = (state: State) => state.settings.lastSeenDevice;
 
 export const swapProvidersSelector = (state: Object) => state.settings.swapProviders;
+
+export const showClearCacheBannerSelector = (state: Object) => state.settings.showClearCacheBanner;
 
 export const swapSupportedCurrenciesSelector: OutputSelector<
   State,

--- a/src/renderer/screens/dashboard/index.js
+++ b/src/renderer/screens/dashboard/index.js
@@ -20,6 +20,7 @@ import OperationsList from "~/renderer/components/OperationsList";
 import Carousel from "~/renderer/components/Carousel";
 import AssetDistribution from "~/renderer/components/AssetDistribution";
 import MigrationBanner from "~/renderer/modals/MigrateAccounts/Banner";
+import ClearCacheBanner from "~/renderer/components/ClearCacheBanner";
 import UpdateBanner from "~/renderer/components/Updater/Banner";
 import { saveSettings } from "~/renderer/actions/settings";
 import { connect, useSelector } from "react-redux";
@@ -76,6 +77,7 @@ const DashboardPage = ({ saveSettings }: Props) => {
       <TopBannerContainer>
         <UpdateBanner />
         <MigrationBanner />
+        <ClearCacheBanner />
         <CurrencyDownStatusAlert currencies={currencies} />
       </TopBannerContainer>
       {showCarousel ? <Carousel /> : null}

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -354,6 +354,10 @@
     "hideCTA": "Hide token"
   },
   "banners": {
+    "cleanCache": {
+      "title":"Modification of experimental settings require a clear cache",
+      "cta":"Clear cache"
+    },
     "migrate": "Ledger Live accounts update available",
     "genericTerminatedCrypto": "{{coinName}} is not supported anymore",
     "ledgerAcademy": {


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
For experimental settings that are marked as `dirty` trigger a show of a banner that indicates to the user the need to run a clear cache in order to see the changes from the new setting value.

![image](https://user-images.githubusercontent.com/4631227/96873745-9fd1fb80-1475-11eb-8e42-8f798dda36e3.png)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-2887

### Parts of the app affected / Test plan
- Go to settings, experimental
- Change the custom gap limit setting
- Go to portfolio, see the banner
- Trigger the clear cache
- See the app reload and banner gone