### PR TITLE
Release notes modal to filter out invalid tag names

### DIFF
--- a/src/renderer/modals/ReleaseNotes/ReleaseNotesBody.js
+++ b/src/renderer/modals/ReleaseNotes/ReleaseNotesBody.js
@@ -54,12 +54,14 @@ class ReleaseNotesBody extends PureComponent<Props, State> {
       if (!v) throw new Error(`can't parse semver ${version}`);
       const notes = data.filter(
         d =>
+          semver.valid(d.tag_name) &&
           semver.gte(
             d.tag_name,
             v.prerelease.length
               ? `${v.major}.${v.minor}.${v.patch}-${v.prerelease[0]}`
               : `${v.major}.${v.minor}.0`,
-          ) && semver.lte(d.tag_name, version),
+          ) &&
+          semver.lte(d.tag_name, version),
       );
       this.setState({ notes });
     } catch (error) {


### PR DESCRIPTION
Fixes a situation that recently ocurred due to introducing a semver invalid tag "countervalues-beta-0" in /releases
even if it was a prerelease, Live would try to get the release notes to display it in the logic of the release notes modal (as it tries to basically display all release notes of 2.15.x if you are on 2.15.10 where x is <=10)
we are now filtering out the non semver versions

**This issue was fixed by renaming the version to 2.16.0-countervalues-beta-0** but this PR allows this to no longer occur in future.

### Type

bugfix

### Context

https://old.reddit.com/r/ledgerwallet/comments/jj861o/ledger_live_invalid_version_countervaluesbeta0/

![](https://i.imgur.com/7VdTF2w.png)

### Parts of the app affected / Test plan

just test that if you build the app as 2.15.0 you see the release notes of 2.15.0 and there is no crash on the release notes modal.