### PR TITLE
LL-3445 Navigate to Swap history after completing a swap

### DIFF
--- a/src/renderer/modals/Swap/SwapBody.js
+++ b/src/renderer/modals/Swap/SwapBody.js
@@ -21,6 +21,7 @@ const SwapBody = ({
   transaction,
   onClose,
   onStepChange,
+  onCompleteSwap,
   activeStep,
   ratesExpiration,
 }: {
@@ -28,6 +29,7 @@ const SwapBody = ({
   transaction: any, // FIXME
   onClose: any,
   onStepChange: SwapSteps => void,
+  onCompleteSwap: () => void,
   activeStep: SwapSteps,
   ratesExpiration: Date,
 }) => {
@@ -65,8 +67,9 @@ const SwapBody = ({
       );
       setResult(result);
       onStepChange("finished");
+      onCompleteSwap();
     },
-    [dispatch, fromAccount, fromParentAccount, onStepChange, swap, transaction],
+    [dispatch, fromAccount, fromParentAccount, onCompleteSwap, onStepChange, swap, transaction],
   );
 
   const items = [

--- a/src/renderer/modals/Swap/index.js
+++ b/src/renderer/modals/Swap/index.js
@@ -17,6 +17,7 @@ const Swap = () => {
           swap={data.swap}
           transaction={data.transaction}
           ratesExpiration={data.ratesExpiration}
+          onCompleteSwap={data.onCompleteSwap}
           onStepChange={setStepId}
           activeStep={stepId}
           onClose={onClose}

--- a/src/renderer/screens/swap/Form/index.js
+++ b/src/renderer/screens/swap/Form/index.js
@@ -49,9 +49,16 @@ type Props = {
   defaultCurrency?: ?(CryptoCurrency | TokenCurrency),
   defaultAccount?: ?AccountLike,
   defaultParentAccount?: ?Account,
+  setTabIndex: number => void,
 };
 
-const Form = ({ installedApps, defaultCurrency, defaultAccount, defaultParentAccount }: Props) => {
+const Form = ({
+  installedApps,
+  defaultCurrency,
+  defaultAccount,
+  defaultParentAccount,
+  setTabIndex,
+}: Props) => {
   const accounts = useSelector(shallowAccountsSelector);
   const selectableCurrencies = useSelector(swapSupportedCurrenciesSelector);
   const modalsState = useSelector(modalsStateSelector);
@@ -102,10 +109,11 @@ const Form = ({ installedApps, defaultCurrency, defaultAccount, defaultParentAcc
     [ratesTimestamp],
   );
 
+  const onCompleteSwap = useCallback(() => setTabIndex(1), [setTabIndex]);
   const onStartSwap = useCallback(() => {
     setTimerVisibility(false);
-    reduxDispatch(openModal("MODAL_SWAP", { swap, transaction, ratesExpiration }));
-  }, [ratesExpiration, reduxDispatch, swap, transaction]);
+    reduxDispatch(openModal("MODAL_SWAP", { swap, transaction, ratesExpiration, onCompleteSwap }));
+  }, [onCompleteSwap, ratesExpiration, reduxDispatch, swap, transaction]);
 
   const { magnitudeAwareRate } = exchangeRate || {};
 

--- a/src/renderer/screens/swap/Swap.js
+++ b/src/renderer/screens/swap/Swap.js
@@ -23,9 +23,10 @@ type Props = {
   defaultCurrency?: ?(CryptoCurrency | TokenCurrency),
   defaultAccount?: ?AccountLike,
   defaultParentAccount?: ?Account,
+  setTabIndex: number => void,
 };
 
-const Swap = ({ defaultCurrency, defaultAccount, defaultParentAccount }: Props) => {
+const Swap = ({ defaultCurrency, defaultAccount, defaultParentAccount, setTabIndex }: Props) => {
   const providers = useSelector(swapProvidersSelector);
   const hasAcceptedSwapKYC = useSelector(hasAcceptedSwapKYCSelector);
 
@@ -78,6 +79,7 @@ const Swap = ({ defaultCurrency, defaultAccount, defaultParentAccount }: Props) 
       defaultCurrency={defaultCurrency}
       defaultAccount={defaultAccount}
       defaultParentAccount={defaultParentAccount}
+      setTabIndex={setTabIndex}
     />
   );
 };

--- a/src/renderer/screens/swap/index.js
+++ b/src/renderer/screens/swap/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import { useLocation } from "react-router-dom";
 import TabBar from "~/renderer/components/TabBar";
 import Swap from "~/renderer/screens/swap/Swap";
@@ -12,10 +12,6 @@ import History from "~/renderer/screens/swap/History";
 const SwapOrSwapHistory = () => {
   const [tabIndex, setTabIndex] = useState(0);
   const location = useLocation();
-
-  const onIndexChange = useCallback(index => {
-    setTabIndex(index);
-  }, []);
 
   return (
     <Box flex={1} pb={6}>
@@ -31,8 +27,12 @@ const SwapOrSwapHistory = () => {
           <Trans i18nKey="swap.title" />
         </Box>
       </Box>
-      <TabBar tabs={["swap.tabs.exchange", "swap.tabs.history"]} onIndexChange={onIndexChange} />
-      {tabIndex === 0 ? <Swap {...location?.state} /> : <History />}
+      <TabBar
+        tabs={["swap.tabs.exchange", "swap.tabs.history"]}
+        onIndexChange={setTabIndex}
+        index={tabIndex}
+      />
+      {tabIndex === 0 ? <Swap {...location?.state} setTabIndex={setTabIndex} /> : <History />}
     </Box>
   );
 };


### PR DESCRIPTION
After completing a swap the user currently closes the modal and remains in the form, prefilled, staring back at him and making the user doubt if the swap actually happened or not. This is confusing, and to stop confusing our users this pr introduces an automatic navigation to the history tab as soon as the modal reaches the finished step. So when they close the modal, they can see the history.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-3445

### Parts of the app affected / Test plan

- Make a swap
- See if the app is in the history tab when you close the modal (it should happen in the bg).
- **Extra** Test this on an empty app if possible to see if we immediately have the record in the history or it still shows empty. It _should_ automatically reflect the new swap.
