### PR TITLE
LL-3455 Avoid having to accept TOS for every swap

### DIFF
--- a/src/renderer/actions/settings.js
+++ b/src/renderer/actions/settings.js
@@ -62,6 +62,11 @@ export const blacklistToken = (tokenId: string) => ({
   payload: tokenId,
 });
 
+export const swapAcceptProviderTOS = (providerId: string) => ({
+  type: "SWAP_ACCEPT_PROVIDER_TOS",
+  payload: providerId,
+});
+
 export const showToken = (tokenId: string) => ({
   type: "SHOW_TOKEN",
   payload: tokenId,

--- a/src/renderer/modals/Swap/SwapBody.js
+++ b/src/renderer/modals/Swap/SwapBody.js
@@ -124,6 +124,7 @@ const SwapBody = ({
           <StepDeviceFooter onClose={onClose} />
         ) : activeStep === "summary" ? (
           <StepSummaryFooter
+            provider={swap.exchangeRate.provider}
             setError={setError}
             onContinue={onAcceptTOS}
             onClose={onClose}

--- a/src/renderer/modals/Swap/steps/StepSummary.js
+++ b/src/renderer/modals/Swap/steps/StepSummary.js
@@ -1,5 +1,6 @@
 // @flow
 
+import React, { useCallback } from "react";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
 import { Trans } from "react-i18next";
@@ -10,10 +11,11 @@ import {
   getAccountName,
   getAccountUnit,
 } from "@ledgerhq/live-common/lib/account";
+import { swapAcceptedProviderIdsSelector } from "~/renderer/reducers/settings";
+import { useDispatch, useSelector } from "react-redux";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import ArrowSeparator from "~/renderer/components/ArrowSeparator";
 import CheckBox from "~/renderer/components/CheckBox";
-import React from "react";
 import type { Exchange, ExchangeRate } from "@ledgerhq/live-common/lib/swap/types";
 import { SwapGenericAPIError } from "@ledgerhq/live-common/lib/errors";
 import type { Transaction } from "@ledgerhq/live-common/lib/types";
@@ -29,6 +31,7 @@ import FakeLink from "~/renderer/components/FakeLink";
 import { CountdownTimerWrapper } from "~/renderer/screens/swap/Form/Footer";
 import IconClock from "~/renderer/icons/Clock";
 import CountdownTimer from "~/renderer/components/CountdownTimer";
+import { swapAcceptProviderTOS } from "~/renderer/actions/settings";
 
 const IconWrapper = styled(Box)`
   background: ${colors.pillActiveBackground};
@@ -46,6 +49,12 @@ const ProviderWrapper = styled(Box)`
   border-radius: 4px;
 `;
 
+const Terms = styled(Text)`
+  > span {
+    text-transform: capitalize;
+  }
+`;
+
 const StepSummary = ({
   swap,
   transaction,
@@ -57,7 +66,10 @@ const StepSummary = ({
   checkedDisclaimer: boolean,
   onSwitchAccept: () => any,
 }) => {
+  const swapAcceptedproviderIds = useSelector(swapAcceptedProviderIdsSelector);
   const { exchange, exchangeRate } = swap;
+  const { provider, magnitudeAwareRate } = exchangeRate;
+  const alreadyAcceptedTerms = swapAcceptedproviderIds.includes(swap.exchangeRate.provider);
   const { fromAccount, toAccount } = exchange;
   const fromAmount = transaction.amount;
   if (!fromAccount || !toAccount || !fromAmount) return null;
@@ -67,8 +79,8 @@ const StepSummary = ({
   const fromUnit = getAccountUnit(fromAccount);
   const toUnit = getAccountUnit(toAccount);
 
-  const toAmount = fromAmount.times(exchangeRate.magnitudeAwareRate);
-  const { main, tos } = urls.swap.providers[exchangeRate.provider];
+  const toAmount = fromAmount.times(magnitudeAwareRate);
+  const { main, tos } = urls.swap.providers[provider];
 
   return (
     <Box mx={2}>
@@ -146,21 +158,32 @@ const StepSummary = ({
           iconFirst
           style={{ textTransform: "capitalize" }}
         >
-          {exchangeRate.provider}
+          {provider}
           <Box ml={1}>
             <IconExternalLink size={12} />
           </Box>
         </FakeLink>
       </ProviderWrapper>
       <Box mt={6} horizontal alignItems={"center"} onClick={onSwitchAccept}>
-        <CheckBox onChange={onSwitchAccept} isChecked={checkedDisclaimer} />
-        <Text
+        {!alreadyAcceptedTerms ? (
+          <CheckBox onChange={onSwitchAccept} isChecked={checkedDisclaimer} />
+        ) : null}
+        <Terms
           ff="Inter|Regular"
           fontSize={3}
           color="palette.text.shade50"
-          style={{ marginLeft: 12, flex: 1 }}
+          style={{ marginLeft: alreadyAcceptedTerms ? 0 : 12, flex: 1 }}
         >
-          <Trans i18nKey="swap.modal.steps.summary.disclaimer.description" />
+          <Trans
+            i18nKey={
+              alreadyAcceptedTerms
+                ? "swap.modal.steps.summary.disclaimer.acceptedDescription"
+                : "swap.modal.steps.summary.disclaimer.description"
+            }
+            values={{ provider }}
+          >
+            <span>{provider}</span>
+          </Trans>
           <FakeLink
             underline
             fontSize={3}
@@ -179,7 +202,7 @@ const StepSummary = ({
             </Box>
           </FakeLink>
           {"."}
-        </Text>
+        </Terms>
       </Box>
     </Box>
   );
@@ -190,40 +213,52 @@ export const StepSummaryFooter = ({
   onClose,
   disabled,
   ratesExpiration,
+  provider,
   setError,
 }: {
   onContinue: any,
   onClose: any,
   disabled: boolean,
   ratesExpiration: Date,
+  provider: string,
   setError: Error => void,
-}) => (
-  <Box horizontal flex={1} justifyContent={"flex-end"} alignItems={"center"}>
-    <CountdownTimerWrapper horizontal>
-      <Box mr={1}>
-        <IconClock size={14} />
+}) => {
+  const dispatch = useDispatch();
+  const swapAcceptedproviderIds = useSelector(swapAcceptedProviderIdsSelector);
+  const alreadyAcceptedTerms = swapAcceptedproviderIds.includes(provider);
+  const onBeforeContinue = useCallback(() => {
+    dispatch(swapAcceptProviderTOS(provider));
+    onContinue();
+  }, [dispatch, onContinue, provider]);
+
+  return (
+    <Box horizontal flex={1} justifyContent={"flex-end"} alignItems={"center"}>
+      <CountdownTimerWrapper horizontal>
+        <Box mr={1}>
+          <IconClock size={14} />
+        </Box>
+        <CountdownTimer
+          key={`rates-${ratesExpiration.getTime()}`}
+          end={ratesExpiration}
+          callback={() => setError(new SwapGenericAPIError())}
+        />
+      </CountdownTimerWrapper>
+      <Box horizontal flex={1} justifyContent={"flex-end"}>
+        <Button onClick={onClose} secondary data-e2e="modal_buttonClose_swap">
+          <Trans i18nKey="common.close" />
+        </Button>
+        <Button
+          ml={1}
+          onClick={onBeforeContinue}
+          disabled={disabled && !alreadyAcceptedTerms}
+          primary
+          data-e2e="modal_buttonContinue_swap"
+        >
+          <Trans i18nKey="common.confirm" />
+        </Button>
       </Box>
-      <CountdownTimer
-        key={`rates-${ratesExpiration.getTime()}`}
-        end={ratesExpiration}
-        callback={() => setError(new SwapGenericAPIError())}
-      />
-    </CountdownTimerWrapper>
-    <Box horizontal flex={1} justifyContent={"flex-end"}>
-      <Button onClick={onClose} secondary data-e2e="modal_buttonClose_swap">
-        <Trans i18nKey="common.close" />
-      </Button>
-      <Button
-        ml={1}
-        onClick={onContinue}
-        disabled={disabled}
-        primary
-        data-e2e="modal_buttonContinue_swap"
-      >
-        <Trans i18nKey="common.confirm" />
-      </Button>
     </Box>
-  </Box>
-);
+  );
+};
 
 export default StepSummary;

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -105,6 +105,7 @@ export type SettingsState = {
   carouselVisibility: number,
   starredAccountIds?: string[],
   blacklistedTokenIds: string[],
+  swapAcceptedProviderIds: string[],
   deepLinkUrl: ?string,
   firstTimeLend: boolean,
   swapProviders?: AvailableProvider[],
@@ -148,6 +149,7 @@ const INITIAL_STATE: SettingsState = {
   hasAcceptedSwapKYC: false,
   lastSeenDevice: null,
   blacklistedTokenIds: [],
+  swapAcceptedProviderIds: [],
   deepLinkUrl: null,
   firstTimeLend: false,
   swapProviders: [],
@@ -225,6 +227,13 @@ const handlers: Object = {
     return {
       ...state,
       blacklistedTokenIds: [...ids, tokenId],
+    };
+  },
+  SWAP_ACCEPT_PROVIDER_TOS: (state: SettingsState, { payload: providerId }) => {
+    const ids = state.swapAcceptedProviderIds;
+    return {
+      ...state,
+      swapAcceptedProviderIds: [...ids, providerId],
     };
   },
   LAST_SEEN_DEVICE_INFO: (
@@ -363,6 +372,8 @@ export const hasInstalledAppsSelector = (state: State) => state.settings.hasInst
 export const carouselVisibilitySelector = (state: State) => state.settings.carouselVisibility;
 export const hasAcceptedSwapKYCSelector = (state: State) => state.settings.hasAcceptedSwapKYC;
 export const blacklistedTokenIdsSelector = (state: State) => state.settings.blacklistedTokenIds;
+export const swapAcceptedProviderIdsSelector = (state: State) =>
+  state.settings.swapAcceptedProviderIds;
 export const hasCompletedOnboardingSelector = (state: State) =>
   state.settings.hasCompletedOnboarding;
 

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -212,7 +212,8 @@
           "terms": "Terms & Conditions",
           "disclaimer": {
             "header": "Details",
-            "description": "By clicking \"Confirm\", I acknowledge and accept that this service is exclusively governed by Changelly's"
+            "description": "By clicking \"Confirm\", I acknowledge and accept that this service is exclusively governed by <0>{{provider}}</0>'s",
+            "acceptedDescription": "This service is exclusively governed by <0>{{provider}}</0>'s"
           },
           "details": {
             "provider": "Provider",


### PR DESCRIPTION

<img width="1136" alt="Screenshot 2020-11-03 at 16 12 39" src="https://user-images.githubusercontent.com/4631227/98004611-6f347f00-1df0-11eb-82b2-2819d66cc5b2.png">
<img width="1136" alt="Screenshot 2020-11-03 at 16 10 33" src="https://user-images.githubusercontent.com/4631227/98004632-73f93300-1df0-11eb-95f6-e49e2f7960b2.png">

For a first swap with a given provider (changelly for now) we need to show the first screenshot, and the user needs to actively check the box and continue. After that initial acceptance we will display the second screenshot, so the user can still access the TOS of the provider but doesn't have to manually accept again. This ux change is based on the feedback from the users asking why they had to accept every time, well, now they don't.

### How to test again after accepting
<img width="1664" alt="Screenshot 2020-11-03 at 16 13 19" src="https://user-images.githubusercontent.com/4631227/98004648-778cba00-1df0-11eb-8241-146f87e93c0e.png">
You can open the dev tools, and dispatch the action `{ type: 'SAVE_SETTINGS', payload: { swapAcceptedProviderIds: [] } } ` which will reset the list of accepted provider ids, allowing you to see the checkbox step again. Or you can edit the app.json and manually change it if you want to go the long route.


### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-3455

### Parts of the app affected / Test plan

- Access the swap feature
- Fill the form to a valid state
- Click on continue to open the modal
- If it's the first time, you should see the checkbox
- If it's not the first time, you should not see the checkbox
- The acceptance is made effective when the user clicks on confirm on the summary step, not on clicking the checkbox itself, since the text states that clicking on `Confirm` means the user accepts.
