### PR TITLE
Mock swap spectron

### DIFF
--- a/src/renderer/components/DebugMock.js
+++ b/src/renderer/components/DebugMock.js
@@ -6,6 +6,7 @@ import { getEnv } from "@ledgerhq/live-common/lib/env";
 import Text from "~/renderer/components/Text";
 import { ReplaySubject } from "rxjs";
 import { deserializeError } from "@ledgerhq/errors";
+import { fromTransactionRaw } from "@ledgerhq/live-common/lib/transaction";
 import { deviceInfo155, mockListAppsResult } from "@ledgerhq/live-common/lib/apps/mock";
 import useInterval from "~/renderer/hooks/useInterval";
 import Box from "~/renderer/components/Box";
@@ -100,6 +101,17 @@ const swapEvents = [
     },
   },
   {
+    name: "result with outdated Exchange",
+    event: {
+      type: "result",
+      result: mockListAppsResult(
+        "Bitcoin,Tron,Litecoin,Ethereum,Ripple,Stellar,Exchange",
+        "Exchange(outdated),Tron,Bitcoin,Ethereum",
+        deviceInfo155,
+      ),
+    },
+  },
+  {
     name: "result with Exchange",
     event: {
       type: "result",
@@ -130,6 +142,51 @@ const swapEvents = [
         "Exchange,Bitcoin",
         deviceInfo155,
       ),
+    },
+  },
+  {
+    name: "init-swap-requested",
+    event: {
+      type: "init-swap-requested",
+    },
+  },
+  {
+    name: "init-swap-error",
+    event: {
+      type: "init-swap-error",
+      error: { name: "SwapGenericAPIError" },
+    },
+  },
+  {
+    name: "init-swap-result",
+    event: {
+      type: "init-swap-result",
+      initSwapResult: {
+        transaction: fromTransactionRaw({
+          family: "bitcoin",
+          recipient: "1Cz2ZXb6Y6AacXJTpo4RBjQMLEmscuxD8e",
+          amount: "1",
+          feePerByte: "1",
+          networkInfo: {
+            family: "bitcoin",
+            feeItems: {
+              items: [
+                { key: "0", speed: "high", feePerByte: "3" },
+                { key: "1", speed: "standard", feePerByte: "2" },
+                { key: "2", speed: "low", feePerByte: "1" },
+              ],
+              defaultFeePerByte: "1",
+            },
+          },
+          rbf: false,
+          utxoStrategy: {
+            strategy: 0,
+            pickUnconfirmedRBF: false,
+            excludeUTXOs: [],
+          },
+        }),
+        swapId: "12345",
+      },
     },
   },
 ];

--- a/src/renderer/components/DeviceAction/rendering.js
+++ b/src/renderer/components/DeviceAction/rendering.js
@@ -378,7 +378,7 @@ export const renderSwapDeviceConfirmation = ({
       <Trans i18nKey="DeviceAction.swap.notice" />
     </InfoBox>
     {renderVerifyUnwrapped({ modelId, type })}
-    <Box alignItems={"center"}>
+    <Box id="swap-modal-device-confirm" alignItems={"center"}>
       <Text textAlign="center" ff="Inter|SemiBold" color="palette.text.shade100" fontSize={5}>
         <Trans i18nKey="DeviceAction.swap.confirm" />
       </Text>

--- a/src/renderer/components/SelectCurrency.js
+++ b/src/renderer/components/SelectCurrency.js
@@ -23,6 +23,7 @@ type Props<C: Currency> = {
   width?: number,
   rowHeight?: number,
   isDisabled?: Currency => boolean,
+  id?: string,
   renderOptionOverride?: (option: Option) => any,
 };
 
@@ -40,6 +41,7 @@ const SelectCurrency = <C: Currency>({
   rowHeight = 47,
   renderOptionOverride,
   isDisabled,
+  id,
 }: Props<C>) => {
   const { t } = useTranslation();
   const devMode = useEnv("MANAGER_DEV_MODE");
@@ -86,6 +88,7 @@ const SelectCurrency = <C: Currency>({
   const filteredOptions = manualFilter();
   return (
     <Select
+      id={id}
       autoFocus={autoFocus}
       value={value}
       options={filteredOptions}

--- a/src/renderer/components/TopBanner.js
+++ b/src/renderer/components/TopBanner.js
@@ -95,7 +95,7 @@ const TopBanner = ({ content, status = "", dismissable = false, bannerId }: Prop
       {message}
       <RightContainer>{right}</RightContainer>
       {dismissable && (
-        <CloseContainer onClick={onDismiss}>
+        <CloseContainer id={`dismiss-${bannerId || ""}-banner`} onClick={onDismiss}>
           <IconCross size={14} />
         </CloseContainer>
       )}

--- a/src/renderer/components/banners/OngoingScams.js
+++ b/src/renderer/components/banners/OngoingScams.js
@@ -22,12 +22,12 @@ const OngoingScams = () => (
       message: <Trans i18nKey="banners.ongoingScams" />,
       Icon: TriangleWarning,
       right: (
-        <Link id="modal-migrate-accounts-button" onClick={() => openURL(urls.banners.ongoingScams)}>
+        <Link id="modal-ongoing-scams-button" onClick={() => openURL(urls.banners.ongoingScams)}>
           <Trans i18nKey="common.learnMore" />
         </Link>
       ),
     }}
-    bannerId={"ongoingScams"}
+    bannerId={"ongoing-scams"}
   />
 );
 export default OngoingScams;

--- a/src/renderer/modals/Swap/steps/StepFinished.js
+++ b/src/renderer/modals/Swap/steps/StepFinished.js
@@ -162,10 +162,11 @@ export const StepFinishedFooter = ({
 
   return (
     <Box horizontal>
-      <Button onClick={onClose} secondary>
+      <Button id="swap-modal-finished-close-button" onClick={onClose} secondary>
         <Trans i18nKey="common.close" />
       </Button>
       <Button
+        id="swap-modal-finished-details-button"
         primary
         ml={2}
         event="Swap completed - Clicked on operation details CTA"

--- a/src/renderer/modals/Swap/steps/StepSummary.js
+++ b/src/renderer/modals/Swap/steps/StepSummary.js
@@ -153,7 +153,11 @@ const StepSummary = ({
         </FakeLink>
       </ProviderWrapper>
       <Box mt={6} horizontal alignItems={"center"} onClick={onSwitchAccept}>
-        <CheckBox onChange={onSwitchAccept} isChecked={checkedDisclaimer} />
+        <CheckBox
+          id="swap-modal-summary-provider-tos-checkbox"
+          onChange={onSwitchAccept}
+          isChecked={checkedDisclaimer}
+        />
         <Text
           ff="Inter|Regular"
           fontSize={3}
@@ -218,6 +222,7 @@ export const StepSummaryFooter = ({
         onClick={onContinue}
         disabled={disabled}
         primary
+        id="swap-modal-summary-continue-button"
         data-e2e="modal_buttonContinue_swap"
       >
         <Trans i18nKey="common.confirm" />

--- a/src/renderer/screens/swap/Form/Footer.js
+++ b/src/renderer/screens/swap/Form/Footer.js
@@ -68,7 +68,13 @@ const Footer = ({
             />
           </CountdownTimerWrapper>
         ) : null}
-        <Button onClick={onStartSwap} primary event="SwapFormOpenModal" disabled={!canContinue}>
+        <Button
+          id="swap-form-continue-button"
+          onClick={onStartSwap}
+          primary
+          event="SwapFormOpenModal"
+          disabled={!canContinue}
+        >
           <Trans i18nKey={"swap.form.exchange"} />
         </Button>
       </Box>

--- a/src/renderer/screens/swap/Form/From.js
+++ b/src/renderer/screens/swap/Form/From.js
@@ -141,6 +141,7 @@ const From = ({
           <Trans i18nKey={`swap.form.from.currency`} />
         </Label>
         <SelectCurrency
+          id="swap-form-from-currency"
           rowHeight={47}
           renderOptionOverride={renderOptionOverride}
           currencies={currencies}
@@ -155,6 +156,7 @@ const From = ({
           <Trans i18nKey={`swap.form.from.account`} />
         </Label>
         <SelectAccount
+          id="swap-form-from-account"
           isDisabled={!currency}
           accounts={availableAccounts}
           value={{ account, subAccount }}
@@ -182,6 +184,7 @@ const From = ({
         {unit ? (
           <>
             <InputCurrency
+              id="swap-form-from-amount"
               error={!hideError && amountError}
               loading={isLoading}
               key={unit.code}

--- a/src/renderer/screens/swap/Form/To.js
+++ b/src/renderer/screens/swap/Form/To.js
@@ -163,6 +163,7 @@ const SwapInputGroup = ({
           <Trans i18nKey={`swap.form.to.currency`} />
         </Label>
         <SelectCurrency
+          id="swap-form-to-currency"
           renderOptionOverride={renderOptionOverride}
           currencies={currencies}
           autoFocus={true}
@@ -178,6 +179,7 @@ const SwapInputGroup = ({
         </Label>
         {hasMaybeValidAccounts || !currency ? (
           <SelectAccount
+            id="swap-form-to-account"
             isDisabled={!currency}
             accounts={availableAccounts}
             value={{ account, subAccount }}

--- a/src/renderer/screens/swap/Landing.js
+++ b/src/renderer/screens/swap/Landing.js
@@ -95,7 +95,13 @@ const KYC = () => {
         <Disclaimer ff="Inter|Regular" onClick={() => setIsChecked(!isChecked)}>
           <Trans i18nKey={"swap.kyc.disclaimer"} />
         </Disclaimer>
-        <Button disabled={!isChecked} primary onClick={onAcceptSwapKYC} event={"SwapAcceptKYC"}>
+        <Button
+          id={"swap-landing-kyc-continue-button"}
+          disabled={!isChecked}
+          primary
+          onClick={onAcceptSwapKYC}
+          event={"SwapAcceptKYC"}
+        >
           <Trans i18nKey="common.continue" />
         </Button>
       </Footer>

--- a/tests/specs/bullrun.spec.js
+++ b/tests/specs/bullrun.spec.js
@@ -1,3 +1,4 @@
+/* eslint jest/expect-expect: 0 */
 import initialize, {
   app,
   deviceInfo,
@@ -11,6 +12,16 @@ import initialize, {
   // portfolioPage,
 } from "../common.js";
 import data from "../data/onboarding/";
+
+// When called like `yarn jest spectron -no-screenshots` we will skip the screenshot checks.
+const testScreenshots = process.argv[process.argv.length - 1] !== "-no-screenshots";
+const matchScreenAgainstSnapshot = async (customSnapshotIdentifier, countdown = 500) => {
+  if (testScreenshots) {
+    expect(await app.client.screenshot(countdown)).toMatchImageSnapshot({
+      customSnapshotIdentifier,
+    });
+  }
+};
 
 describe("Bullrun", () => {
   initialize();
@@ -32,23 +43,17 @@ describe("Bullrun", () => {
     const elem = await $("#onboarding-get-started-button");
     await elem.waitForDisplayed({ timeout: 20000 });
     await onboardingPage.getStarted();
-    expect(await app.client.screenshot()).toMatchImageSnapshot({
-      customSnapshotIdentifier: "onboarding-1-get-started",
-    });
+    await matchScreenAgainstSnapshot("onboarding-1-get-started");
   });
 
   it("go through onboarding-2", async () => {
     await onboardingPage.selectConfiguration("new");
     await app.client.pause(500);
-    expect(await app.client.screenshot()).toMatchImageSnapshot({
-      customSnapshotIdentifier: "onboarding-2-screen-new",
-    });
+    await matchScreenAgainstSnapshot("onboarding-2-screen-new");
   });
   it("go through onboarding-3", async () => {
     await onboardingPage.selectDevice("nanox");
-    expect(await app.client.screenshot()).toMatchImageSnapshot({
-      customSnapshotIdentifier: "onboarding-3-screen-nano-x",
-    });
+    await matchScreenAgainstSnapshot("onboarding-3-screen-nano-x");
   });
   it("go through onboarding-4", async () => {
     await onboardingPage.continue();
@@ -149,9 +154,7 @@ describe("Bullrun", () => {
   it("firmware update flow-1", async () => {
     const elem = await $("#manager-update-firmware-button");
     await elem.waitForDisplayed();
-    expect(await app.client.screenshot()).toMatchImageSnapshot({
-      customSnapshotIdentifier: "firmware-update-0-manager-page",
-    });
+    await matchScreenAgainstSnapshot("firmware-update-0-manager-page");
   });
 
   it("firmware update flow-2", async () => {
@@ -159,17 +162,13 @@ describe("Bullrun", () => {
     await button.click();
     const elem = await $("#firmware-update-disclaimer-modal-seed-ready-checkbox");
     await elem.waitForDisplayed();
-    expect(await app.client.screenshot()).toMatchImageSnapshot({
-      customSnapshotIdentifier: "firmware-update-1-disclaimer-modal",
-    });
+    await matchScreenAgainstSnapshot("firmware-update-1-disclaimer-modal");
   });
 
   it("firmware update flow-3", async () => {
     const elem = await $("#firmware-update-disclaimer-modal-seed-ready-checkbox");
     await elem.click();
-    expect(await app.client.screenshot()).toMatchImageSnapshot({
-      customSnapshotIdentifier: "firmware-update-2-disclaimer-modal-checkbox",
-    });
+    await matchScreenAgainstSnapshot("firmware-update-2-disclaimer-modal-checkbox");
   });
 
   it("firmware update flow-5", async () => {
@@ -177,43 +176,33 @@ describe("Bullrun", () => {
     await continueButton.click();
     const elem = await $("#firmware-update-download-mcu-title");
     await elem.waitForDisplayed();
-    expect(await app.client.screenshot()).toMatchImageSnapshot({
-      customSnapshotIdentifier: "firmware-update-4-download-mcu-modal",
-    });
+    await matchScreenAgainstSnapshot("firmware-update-4-download-mcu-modal");
   });
 
   it("firmware update flow-6", async () => {
     await mockDeviceEvent({}, { type: "complete" }); // .complete() install full firmware -> flash mcu
     const elem = await $("#firmware-update-flash-mcu-title");
     await elem.waitForDisplayed();
-    expect(await app.client.screenshot()).toMatchImageSnapshot({
-      customSnapshotIdentifier: "firmware-update-5-flash-mcu-start",
-    });
+    await matchScreenAgainstSnapshot("firmware-update-5-flash-mcu-start");
   });
 
   it("firmware update flow-7", async () => {
     await mockDeviceEvent({}, { type: "complete" }); // .complete() flash mcu -> completed
     const elem = await $("#firmware-update-completed-close-button");
     await elem.waitForDisplayed();
-    expect(await app.client.screenshot(6000)).toMatchImageSnapshot({
-      customSnapshotIdentifier: "firmware-update-6-flash-mcu-done",
-    });
+    await matchScreenAgainstSnapshot("firmware-update-6-flash-mcu-done", 6000);
   });
 
   it("firmware update flow-8", async () => {
     const elem = await $("#firmware-update-completed-close-button");
     await elem.click();
-    expect(await app.client.screenshot()).toMatchImageSnapshot({
-      customSnapshotIdentifier: "firmware-update-7-close-modal",
-    });
+    await matchScreenAgainstSnapshot("firmware-update-7-close-modal");
   });
 
   it("firmware update flow-9", async () => {
     const elem = await $("#drawer-dashboard-button");
     await elem.click();
-    expect(await app.client.screenshot()).toMatchImageSnapshot({
-      customSnapshotIdentifier: "firmware-update-8-back-to-dashboard",
-    });
+    await matchScreenAgainstSnapshot("firmware-update-8-back-to-dashboard");
   });
 
   describe("add accounts flow", () => {
@@ -251,35 +240,36 @@ describe("Bullrun", () => {
     }
   });
 
-  describe("account flows", () => {
-    it("account migration flow", async () => {
-      // Account migration flow
-      const drawerDashboardButton = await $("#drawer-dashboard-button");
-      await drawerDashboardButton.click();
-      const migrateAccountsButton = await $("#modal-migrate-accounts-button");
-      await migrateAccountsButton.waitForDisplayed();
-      await migrateAccountsButton.click();
-      const migrateOverViewStartButton = await $("#migrate-overview-start-button");
-      await migrateOverViewStartButton.waitForDisplayed();
-      await migrateOverViewStartButton.click();
-      await mockDeviceEvent({ type: "opened" });
-      const migrateCurrencyContinueButton = await $("#migrate-currency-continue-button");
-      await migrateCurrencyContinueButton.waitForDisplayed();
-      await migrateCurrencyContinueButton.click();
-      await mockDeviceEvent({ type: "opened" });
-      await migrateCurrencyContinueButton.waitForDisplayed();
-      await migrateCurrencyContinueButton.click();
-      const migrateOverviewExportButton = await $("#migrate-overview-export-button");
-      await migrateOverviewExportButton.waitForDisplayed();
-      await migrateOverviewExportButton.click();
-      const exportAccountsDoneButton = await $("#export-accounts-done-button");
-      await exportAccountsDoneButton.waitForDisplayed();
-      await exportAccountsDoneButton.click();
-      const migrateOverviewDoneButton = await $("#migrate-overview-done-button");
-      await migrateOverviewDoneButton.click();
-      expect(await modalPage.isDisplayed(true)).toBe(false);
-    });
+  it("naive discreet mode toggle and assorted screens", async () => {
+    // Toggle discreet mode twice
+    const discreetButton = await $("#topbar-discreet-button");
+    await discreetButton.click();
+    await discreetButton.click();
 
+    const dashboardButton = await $("#drawer-dashboard-button");
+    await dashboardButton.click();
+    const exchangeButton = await $("#drawer-exchange-button");
+    await exchangeButton.click();
+
+    // Open settings and navigate all tabs
+    const settingsButton = await $("#topbar-settings-button");
+    await settingsButton.click();
+
+    // Open settings and navigate all tabs
+    const currenciesTab = await $("#settings-currencies-tab");
+    await currenciesTab.click();
+    const accountsTab = await $("#settings-accounts-tab");
+    await accountsTab.click();
+    const aboutTab = await $("#settings-about-tab");
+    await aboutTab.click();
+    const helpTab = await $("#settings-help-tab");
+    await helpTab.click();
+    const experimentalTab = await $("#settings-experimental-tab");
+    await experimentalTab.click();
+    expect(await modalPage.isDisplayed(true)).toBe(false);
+  });
+
+  describe("account flows", () => {
     it("receive flow", async () => {
       // Receive flow without device
       const drawerReceiveButton = await $("#drawer-receive-button");
@@ -364,34 +354,5 @@ describe("Bullrun", () => {
       await modalPage.close();
       expect(await modalPage.isDisplayed(true)).toBe(false);
     });
-  });
-
-  it("naive discreet mode toggle and assorted screens", async () => {
-    // Toggle discreet mode twice
-    const discreetButton = await $("#topbar-discreet-button");
-    await discreetButton.click();
-    await discreetButton.click();
-
-    const dashboardButton = await $("#drawer-dashboard-button");
-    await dashboardButton.click();
-    const exchangeButton = await $("#drawer-exchange-button");
-    await exchangeButton.click();
-
-    // Open settings and navigate all tabs
-    const settingsButton = await $("#topbar-settings-button");
-    await settingsButton.click();
-
-    // Open settings and navigate all tabs
-    const currenciesTab = await $("#settings-currencies-tab");
-    await currenciesTab.click();
-    const accountsTab = await $("#settings-accounts-tab");
-    await accountsTab.click();
-    const aboutTab = await $("#settings-about-tab");
-    await aboutTab.click();
-    const helpTab = await $("#settings-help-tab");
-    await helpTab.click();
-    const experimentalTab = await $("#settings-experimental-tab");
-    await experimentalTab.click();
-    expect(await modalPage.isDisplayed(true)).toBe(false);
   });
 });

--- a/tests/specs/bullrun.spec.js
+++ b/tests/specs/bullrun.spec.js
@@ -12,6 +12,7 @@ import initialize, {
   // portfolioPage,
 } from "../common.js";
 import data from "../data/onboarding/";
+import { fromTransactionRaw } from "@ledgerhq/live-common/lib/transaction";
 
 // When called like `yarn jest spectron -no-screenshots` we will skip the screenshot checks.
 const testScreenshots = process.argv[process.argv.length - 1] !== "-no-screenshots";
@@ -23,336 +24,498 @@ const matchScreenAgainstSnapshot = async (customSnapshotIdentifier, countdown = 
   }
 };
 
-describe("Bullrun", () => {
-  initialize();
+// Comment out to skip them, make sure steps finish in compatible states
+const steps = [
+  "onboarding",
+  "manager",
+  "accounts",
+  "swap",
+  "discreetMode",
+  "send",
+  "receive",
+  "delegate",
+];
+const currencies = ["bitcoin", "ethereum", "xrp", "ethereum_classic", "tezos", "cosmos"];
 
-  const $ = selector => app.client.$(selector);
+describe(
+  "Bullrun\n    - Steps:\t" +
+    JSON.stringify(steps) +
+    "\n    - Currencies:\t" +
+    JSON.stringify(currencies),
+  () => {
+    initialize();
 
-  it("opens a window", async () => {
-    await app.client.waitUntilWindowLoaded();
-    await app.client.getWindowCount().then(count => expect(count).toBe(1));
-    await app.client.browserWindow.isMinimized().then(minimized => expect(minimized).toBe(false));
-    await app.client.browserWindow.isVisible().then(visible => expect(visible).toBe(true));
-    await app.client.browserWindow.isFocused().then(focused => expect(focused).toBe(true));
-    await app.client.getTitle().then(title => {
-      expect(title).toBe(data.appTitle);
+    const $ = selector => app.client.$(selector);
+
+    it("opens a window", async () => {
+      await app.client.waitUntilWindowLoaded();
+      await app.client.getWindowCount().then(count => expect(count).toBe(1));
+      await app.client.browserWindow.isMinimized().then(minimized => expect(minimized).toBe(false));
+      await app.client.browserWindow.isVisible().then(visible => expect(visible).toBe(true));
+      await app.client.browserWindow.isFocused().then(focused => expect(focused).toBe(true));
+      await app.client.getTitle().then(title => {
+        expect(title).toBe(data.appTitle);
+      });
     });
-  });
 
-  it("go through onboarding-1", async () => {
-    const elem = await $("#onboarding-get-started-button");
-    await elem.waitForDisplayed({ timeout: 20000 });
-    await onboardingPage.getStarted();
-    await matchScreenAgainstSnapshot("onboarding-1-get-started");
-  });
+    if (steps.includes("onboarding")) {
+      it("go through onboarding-1", async () => {
+        const elem = await $("#onboarding-get-started-button");
+        await elem.waitForDisplayed({ timeout: 20000 });
+        await onboardingPage.getStarted();
+        await matchScreenAgainstSnapshot("onboarding-1-get-started");
+      });
 
-  it("go through onboarding-2", async () => {
-    await onboardingPage.selectConfiguration("new");
-    await app.client.pause(500);
-    await matchScreenAgainstSnapshot("onboarding-2-screen-new");
-  });
-  it("go through onboarding-3", async () => {
-    await onboardingPage.selectDevice("nanox");
-    await matchScreenAgainstSnapshot("onboarding-3-screen-nano-x");
-  });
-  it("go through onboarding-4", async () => {
-    await onboardingPage.continue();
-    await onboardingPage.continue();
-    await onboardingPage.continue();
-    await genuinePage.checkPin(true);
-    await genuinePage.checkSeed(true);
-    await genuinePage.check();
-    await modalPage.close();
-    await onboardingPage.back();
-    await onboardingPage.back();
-    await onboardingPage.back();
-    await onboardingPage.back();
-    await onboardingPage.selectConfiguration("restore");
-    await onboardingPage.selectDevice("blue");
-    await onboardingPage.continue();
-    await onboardingPage.continue();
-    await onboardingPage.continue();
-    await genuinePage.checkPin(true);
-    await genuinePage.checkSeed(true);
-    await genuinePage.check();
-    await modalPage.close();
-    await onboardingPage.back();
-    await onboardingPage.back();
-    await onboardingPage.back();
-    await onboardingPage.back();
-    await onboardingPage.selectConfiguration("nodevice");
-    await onboardingPage.back();
-    await onboardingPage.selectConfiguration("initialized");
-    await onboardingPage.selectDevice("nanos");
-    await onboardingPage.continue();
-    await genuinePage.checkPin(false);
-    await onboardingPage.back();
-    await genuinePage.checkPin(true);
-    await genuinePage.checkSeed(false);
-    await onboardingPage.back();
-    await genuinePage.checkPin(true);
-    await genuinePage.checkSeed(true);
-    await genuinePage.check();
-    await mockDeviceEvent(
-      {
-        type: "listingApps",
-        deviceInfo,
-      },
-      {
-        type: "result",
-        result: mockListAppsResult("Bitcoin", "Bitcoin", deviceInfo),
-      },
-      { type: "complete" },
-    );
-    await app.client.pause(2000);
-    const onboardingContinueButton = await $("#onboarding-continue-button");
-    await onboardingContinueButton.waitForDisplayed();
-    await onboardingPage.continue();
-    await passwordPage.skip();
-    const analyticsDataFakeLinkElem = await analyticsPage.dataFakeLink;
-    await analyticsDataFakeLinkElem.click();
-    await modalPage.close();
-    const analyticsShareFakeLinkElem = await analyticsPage.shareFakeLink;
-    await analyticsShareFakeLinkElem.click();
-    await modalPage.close();
-    const analyticsShareSwitch = await analyticsPage.shareSwitch;
-    await analyticsShareSwitch.click();
-    await analyticsShareSwitch.click();
-    const analyticsLogsSwitch = await analyticsPage.logsSwitch;
-    await analyticsLogsSwitch.click();
-    await analyticsLogsSwitch.click();
-    await onboardingPage.continue();
-    await onboardingPage.open();
-    await modalPage.isDisplayed();
-    const modalTermsCheckbox = await modalPage.termsCheckbox;
-    await modalTermsCheckbox.click();
-    const modalConfirmButton = await $("#modal-confirm-button");
-    await modalConfirmButton.waitForEnabled();
-    await modalPage.confirm();
-
-    expect(await modalPage.isDisplayed(true)).toBe(false);
-  });
-
-  it("access manager", async () => {
-    // Access manager and go through firmware update
-    const elem = await $("#drawer-manager-button");
-    await elem.click();
-    await mockDeviceEvent(
-      {
-        type: "listingApps",
-        deviceInfo,
-      },
-      {
-        type: "result",
-        result: mockListAppsResult("Bitcoin, Ethereum, Stellar", "Bitcoin", deviceInfo),
-      },
-      { type: "complete" },
-    );
-    expect(true).toBeTruthy();
-  });
-
-  it("firmware update flow-1", async () => {
-    const elem = await $("#manager-update-firmware-button");
-    await elem.waitForDisplayed();
-    await matchScreenAgainstSnapshot("firmware-update-0-manager-page");
-  });
-
-  it("firmware update flow-2", async () => {
-    const button = await $("#manager-update-firmware-button");
-    await button.click();
-    const elem = await $("#firmware-update-disclaimer-modal-seed-ready-checkbox");
-    await elem.waitForDisplayed();
-    await matchScreenAgainstSnapshot("firmware-update-1-disclaimer-modal");
-  });
-
-  it("firmware update flow-3", async () => {
-    const elem = await $("#firmware-update-disclaimer-modal-seed-ready-checkbox");
-    await elem.click();
-    await matchScreenAgainstSnapshot("firmware-update-2-disclaimer-modal-checkbox");
-  });
-
-  it("firmware update flow-5", async () => {
-    const continueButton = await $("#firmware-update-disclaimer-modal-continue-button");
-    await continueButton.click();
-    const elem = await $("#firmware-update-download-mcu-title");
-    await elem.waitForDisplayed();
-    await matchScreenAgainstSnapshot("firmware-update-4-download-mcu-modal");
-  });
-
-  it("firmware update flow-6", async () => {
-    await mockDeviceEvent({}, { type: "complete" }); // .complete() install full firmware -> flash mcu
-    const elem = await $("#firmware-update-flash-mcu-title");
-    await elem.waitForDisplayed();
-    await matchScreenAgainstSnapshot("firmware-update-5-flash-mcu-start");
-  });
-
-  it("firmware update flow-7", async () => {
-    await mockDeviceEvent({}, { type: "complete" }); // .complete() flash mcu -> completed
-    const elem = await $("#firmware-update-completed-close-button");
-    await elem.waitForDisplayed();
-    await matchScreenAgainstSnapshot("firmware-update-6-flash-mcu-done", 6000);
-  });
-
-  it("firmware update flow-8", async () => {
-    const elem = await $("#firmware-update-completed-close-button");
-    await elem.click();
-    await matchScreenAgainstSnapshot("firmware-update-7-close-modal");
-  });
-
-  it("firmware update flow-9", async () => {
-    const elem = await $("#drawer-dashboard-button");
-    await elem.click();
-    await matchScreenAgainstSnapshot("firmware-update-8-back-to-dashboard");
-  });
-
-  describe("add accounts flow", () => {
-    // Add accounts for all currencies with special flows (delegate, vote, etc)
-    const currencies = ["dogecoin", "ethereum", "xrp", "ethereum_classic", "tezos", "cosmos"];
-    for (let i = 0; i < currencies.length; i++) {
-      it(`for ${currencies[i]}`, async () => {
-        const currency = currencies[i];
-        const addAccountId = !i
-          ? "#accounts-empty-state-add-account-button"
-          : "#accounts-add-account-button";
-        const elemAddAccountId = await $(addAccountId);
-        await elemAddAccountId.waitForDisplayed();
-        await elemAddAccountId.click();
-        const elemSelectControl = await $("#modal-container .select__control");
-        await elemSelectControl.click();
-        const elemSelectControlInput = await $("#modal-container .select__control input");
-        await elemSelectControlInput.addValue(currency);
-        const elemFirstOption = await $(".select-options-list .option:first-child");
-        await elemFirstOption.click();
-        const elemContinueButton = await $("#modal-continue-button");
-        await elemContinueButton.click();
-        await mockDeviceEvent({ type: "opened" });
-        const elemImportAddButton = await $("#add-accounts-import-add-button");
-        await elemImportAddButton.waitForDisplayed();
-        await elemImportAddButton.waitForEnabled();
-        await elemImportAddButton.click();
+      it("go through onboarding-2", async () => {
+        await onboardingPage.selectConfiguration("new");
+        await app.client.pause(500);
+        await matchScreenAgainstSnapshot("onboarding-2-screen-new");
+      });
+      it("go through onboarding-3", async () => {
+        await onboardingPage.selectDevice("nanox");
+        await matchScreenAgainstSnapshot("onboarding-3-screen-nano-x");
+      });
+      it("go through onboarding-4", async () => {
+        await onboardingPage.continue();
+        await onboardingPage.continue();
+        await onboardingPage.continue();
+        await genuinePage.checkPin(true);
+        await genuinePage.checkSeed(true);
+        await genuinePage.check();
         await modalPage.close();
-        if (!i) {
-          const elemDrawerAccountsButton = await $("#drawer-accounts-button");
-          await elemDrawerAccountsButton.click();
-        }
+        await onboardingPage.back();
+        await onboardingPage.back();
+        await onboardingPage.back();
+        await onboardingPage.back();
+        await onboardingPage.selectConfiguration("restore");
+        await onboardingPage.selectDevice("blue");
+        await onboardingPage.continue();
+        await onboardingPage.continue();
+        await onboardingPage.continue();
+        await genuinePage.checkPin(true);
+        await genuinePage.checkSeed(true);
+        await genuinePage.check();
+        await modalPage.close();
+        await onboardingPage.back();
+        await onboardingPage.back();
+        await onboardingPage.back();
+        await onboardingPage.back();
+        await onboardingPage.selectConfiguration("nodevice");
+        await onboardingPage.back();
+        await onboardingPage.selectConfiguration("initialized");
+        await onboardingPage.selectDevice("nanos");
+        await onboardingPage.continue();
+        await genuinePage.checkPin(false);
+        await onboardingPage.back();
+        await genuinePage.checkPin(true);
+        await genuinePage.checkSeed(false);
+        await onboardingPage.back();
+        await genuinePage.checkPin(true);
+        await genuinePage.checkSeed(true);
+        await genuinePage.check();
+        await mockDeviceEvent(
+          {
+            type: "listingApps",
+            deviceInfo,
+          },
+          {
+            type: "result",
+            result: mockListAppsResult("Bitcoin", "Bitcoin", deviceInfo),
+          },
+          { type: "complete" },
+        );
+        await app.client.pause(2000);
+        const onboardingContinueButton = await $("#onboarding-continue-button");
+        await onboardingContinueButton.waitForDisplayed();
+        await onboardingPage.continue();
+        await passwordPage.skip();
+        const analyticsDataFakeLinkElem = await analyticsPage.dataFakeLink;
+        await analyticsDataFakeLinkElem.click();
+        await modalPage.close();
+        const analyticsShareFakeLinkElem = await analyticsPage.shareFakeLink;
+        await analyticsShareFakeLinkElem.click();
+        await modalPage.close();
+        const analyticsShareSwitch = await analyticsPage.shareSwitch;
+        await analyticsShareSwitch.click();
+        await analyticsShareSwitch.click();
+        const analyticsLogsSwitch = await analyticsPage.logsSwitch;
+        await analyticsLogsSwitch.click();
+        await analyticsLogsSwitch.click();
+        await onboardingPage.continue();
+        await onboardingPage.open();
+        await modalPage.isDisplayed();
+        const modalTermsCheckbox = await modalPage.termsCheckbox;
+        await modalTermsCheckbox.click();
+        const modalConfirmButton = await $("#modal-confirm-button");
+        await modalConfirmButton.waitForEnabled();
+        await modalPage.confirm();
+
         expect(await modalPage.isDisplayed(true)).toBe(false);
       });
     }
-  });
 
-  it("naive discreet mode toggle and assorted screens", async () => {
-    // Toggle discreet mode twice
-    const discreetButton = await $("#topbar-discreet-button");
-    await discreetButton.click();
-    await discreetButton.click();
+    if (steps.includes("manager")) {
+      it("access manager", async () => {
+        // Access manager and go through firmware update
+        const elem = await $("#drawer-manager-button");
+        await elem.click();
+        await mockDeviceEvent(
+          {
+            type: "listingApps",
+            deviceInfo,
+          },
+          {
+            type: "result",
+            result: mockListAppsResult("Bitcoin, Ethereum, Stellar", "Bitcoin", deviceInfo),
+          },
+          { type: "complete" },
+        );
+        expect(true).toBeTruthy();
+      });
 
-    const dashboardButton = await $("#drawer-dashboard-button");
-    await dashboardButton.click();
-    const exchangeButton = await $("#drawer-exchange-button");
-    await exchangeButton.click();
+      it("firmware update flow-1", async () => {
+        const elem = await $("#manager-update-firmware-button");
+        await elem.waitForDisplayed();
+        await matchScreenAgainstSnapshot("firmware-update-0-manager-page");
+      });
 
-    // Open settings and navigate all tabs
-    const settingsButton = await $("#topbar-settings-button");
-    await settingsButton.click();
+      it("firmware update flow-2", async () => {
+        const button = await $("#manager-update-firmware-button");
+        await button.click();
+        const elem = await $("#firmware-update-disclaimer-modal-seed-ready-checkbox");
+        await elem.waitForDisplayed();
+        await matchScreenAgainstSnapshot("firmware-update-1-disclaimer-modal");
+      });
 
-    // Open settings and navigate all tabs
-    const currenciesTab = await $("#settings-currencies-tab");
-    await currenciesTab.click();
-    const accountsTab = await $("#settings-accounts-tab");
-    await accountsTab.click();
-    const aboutTab = await $("#settings-about-tab");
-    await aboutTab.click();
-    const helpTab = await $("#settings-help-tab");
-    await helpTab.click();
-    const experimentalTab = await $("#settings-experimental-tab");
-    await experimentalTab.click();
-    expect(await modalPage.isDisplayed(true)).toBe(false);
-  });
+      it("firmware update flow-3", async () => {
+        const elem = await $("#firmware-update-disclaimer-modal-seed-ready-checkbox");
+        await elem.click();
+        await matchScreenAgainstSnapshot("firmware-update-2-disclaimer-modal-checkbox");
+      });
 
-  describe("account flows", () => {
-    it("receive flow", async () => {
-      // Receive flow without device
-      const drawerReceiveButton = await $("#drawer-receive-button");
-      await drawerReceiveButton.click();
-      const receiveAccountContinueButton = await $("#receive-account-continue-button");
-      await receiveAccountContinueButton.waitForDisplayed();
-      await receiveAccountContinueButton.click();
-      await mockDeviceEvent({ type: "opened" }, { type: "complete" });
-      const receiveReceiveContinueButton = await $("#receive-receive-continue-button");
-      await receiveReceiveContinueButton.waitForDisplayed();
-      await receiveReceiveContinueButton.waitForEnabled();
-      await receiveReceiveContinueButton.click();
-      expect(await modalPage.isDisplayed(true)).toBe(false);
+      it("firmware update flow-5", async () => {
+        const continueButton = await $("#firmware-update-disclaimer-modal-continue-button");
+        await continueButton.click();
+        const elem = await $("#firmware-update-download-mcu-title");
+        await elem.waitForDisplayed();
+        await matchScreenAgainstSnapshot("firmware-update-4-download-mcu-modal");
+      });
+
+      it("firmware update flow-6", async () => {
+        await mockDeviceEvent({}, { type: "complete" }); // .complete() install full firmware -> flash mcu
+        const elem = await $("#firmware-update-flash-mcu-title");
+        await elem.waitForDisplayed();
+        await matchScreenAgainstSnapshot("firmware-update-5-flash-mcu-start");
+      });
+
+      it("firmware update flow-7", async () => {
+        await mockDeviceEvent({}, { type: "complete" }); // .complete() flash mcu -> completed
+        const elem = await $("#firmware-update-completed-close-button");
+        await elem.waitForDisplayed();
+        await matchScreenAgainstSnapshot("firmware-update-6-flash-mcu-done", 6000);
+      });
+
+      it("firmware update flow-8", async () => {
+        const elem = await $("#firmware-update-completed-close-button");
+        await elem.click();
+        await matchScreenAgainstSnapshot("firmware-update-7-close-modal");
+      });
+
+      it("firmware update flow-9", async () => {
+        const elem = await $("#drawer-dashboard-button");
+        await elem.click();
+        await matchScreenAgainstSnapshot("firmware-update-8-back-to-dashboard");
+      });
+    }
+
+    if (steps.includes("accounts")) {
+      describe("add accounts flow", () => {
+        // Add accounts for all currencies with special flows (delegate, vote, etc)
+        for (let i = 0; i < currencies.length; i++) {
+          it(`for ${currencies[i]}`, async () => {
+            const currency = currencies[i];
+            const addAccountId = !i
+              ? "#accounts-empty-state-add-account-button"
+              : "#accounts-add-account-button";
+            const elemAddAccountId = await $(addAccountId);
+            await elemAddAccountId.waitForDisplayed();
+            await elemAddAccountId.click();
+            const elemSelectControl = await $("#modal-container .select__control");
+            await elemSelectControl.click();
+            const elemSelectControlInput = await $("#modal-container .select__control input");
+            await elemSelectControlInput.addValue(currency);
+            const elemFirstOption = await $(".select-options-list .option:first-child");
+            await elemFirstOption.click();
+            const elemContinueButton = await $("#modal-continue-button");
+            await elemContinueButton.click();
+            await mockDeviceEvent({ type: "opened" });
+            const elemImportAddButton = await $("#add-accounts-import-add-button");
+            await elemImportAddButton.waitForDisplayed();
+            await elemImportAddButton.waitForEnabled();
+            await elemImportAddButton.click();
+            await modalPage.close();
+            if (!i) {
+              const elemDrawerAccountsButton = await $("#drawer-accounts-button");
+              await elemDrawerAccountsButton.click();
+            }
+            expect(await modalPage.isDisplayed(true)).toBe(false);
+          });
+        }
+      });
+    }
+
+    if (steps.includes("swap")) {
+      describe("swap flow", () => {
+        it("access the feature", async () => {
+          // Access manager and go through firmware update
+          const elem = await $("#drawer-swap-button");
+          await elem.click();
+          await mockDeviceEvent(
+            {
+              type: "listingApps",
+              deviceInfo,
+            },
+            {
+              type: "result",
+              result: mockListAppsResult(
+                "Bitcoin,Tron,Litecoin,Ethereum,Ripple,Stellar,Exchange",
+                "Exchange,Tron,Bitcoin,Ethereum",
+                deviceInfo,
+              ),
+            },
+            { type: "complete" },
+          );
+        });
+        it("pass KYC landing", async () => {
+          const KYCCheckbox = await $("#swap-landing-kyc-tos");
+          await KYCCheckbox.waitForDisplayed();
+          await KYCCheckbox.click();
+
+          const KYCContinueButton = await $("#swap-landing-kyc-continue-button");
+          await KYCContinueButton.waitForEnabled();
+          await KYCContinueButton.click();
+        });
+
+        it("fill the form and get rates", async () => {
+          const fromCurrency = await $("#swap-form-from-currency .select__control");
+          await fromCurrency.click();
+          const fromCurrencyInput = await $("#swap-form-from-currency .select__control input");
+          await fromCurrencyInput.addValue("bitcoin");
+          const fromCurrencyFirstOption = await $(".select-options-list .option:first-child");
+          await fromCurrencyFirstOption.click();
+          await app.client.pause(1000);
+
+          // Fill the amount
+          const amount = await $("#swap-form-from-amount");
+          await amount.waitForDisplayed();
+          await amount.addValue(["0.5", "Tab"]);
+
+          const toCurrency = await $("#swap-form-to-currency .select__control");
+          await toCurrency.click();
+          const toCurrencyInput = await $("#swap-form-to-currency .select__control input");
+          await toCurrencyInput.addValue("ethereum");
+          const toCurrencyFirstOption = await $(".select-options-list .option:first-child");
+          await toCurrencyFirstOption.click();
+          await app.client.pause(1000);
+
+          // Open the modal
+          const continueButton = await $("#swap-form-continue-button");
+          await continueButton.waitForEnabled();
+          await continueButton.click();
+        });
+
+        it("confirm summary step", async () => {
+          const summaryProviderCheckbox = await $("#swap-modal-summary-provider-tos-checkbox");
+          await summaryProviderCheckbox.waitForDisplayed();
+          await summaryProviderCheckbox.click();
+
+          const summaryContinueButton = await $("#swap-modal-summary-continue-button");
+          await summaryContinueButton.waitForEnabled();
+          await summaryContinueButton.click();
+        });
+
+        it("confirm swap on device and broadcast step", async () => {
+          await mockDeviceEvent({ type: "opened" }, { type: "complete" });
+          // init-swap command (Extra pauses because otherwise the UI will not be visible)
+          await mockDeviceEvent({ type: "opened" });
+          await mockDeviceEvent({ type: "init-swap-requested" });
+          await app.client.pause(2000);
+          const confirmationStep = await $("#swap-modal-device-confirm");
+          await confirmationStep.waitForDisplayed();
+          await app.client.pause(1000);
+          await mockDeviceEvent(
+            {
+              type: "init-swap-result",
+              initSwapResult: {
+                transaction: fromTransactionRaw({
+                  family: "bitcoin",
+                  recipient: "1Cz2ZXb6Y6AacXJTpo4RBjQMLEmscuxD8e",
+                  amount: "1",
+                  feePerByte: "1",
+                  networkInfo: {
+                    family: "bitcoin",
+                    feeItems: {
+                      items: [
+                        { key: "0", speed: "high", feePerByte: "3" },
+                        { key: "1", speed: "standard", feePerByte: "2" },
+                        { key: "2", speed: "low", feePerByte: "1" },
+                      ],
+                      defaultFeePerByte: "1",
+                    },
+                  },
+                  rbf: false,
+                  utxoStrategy: {
+                    strategy: 0,
+                    pickUnconfirmedRBF: false,
+                    excludeUTXOs: [],
+                  },
+                }),
+                swapId: "12345",
+              },
+            },
+            { type: "complete" },
+          );
+
+          // Silent signing, then automatic broadcasting triggered.
+          await mockDeviceEvent({ type: "opened" }, { type: "complete" });
+          await app.client.pause(5000); // Signing step takes time
+
+          const finishedStep = await $("#swap-modal-finished-close-button");
+          await finishedStep.waitForDisplayed();
+          await app.client.pause(1000);
+          await finishedStep.click();
+
+          // Go back to the dashboard
+          const elem = await $("#drawer-dashboard-button");
+          await elem.click();
+        });
+      });
+    }
+
+    if (steps.includes("discreetMode")) {
+      it("naive discreet mode toggle and assorted screens", async () => {
+        // Toggle discreet mode twice
+        const discreetButton = await $("#topbar-discreet-button");
+        await discreetButton.click();
+        await discreetButton.click();
+
+        const dashboardButton = await $("#drawer-dashboard-button");
+        await dashboardButton.click();
+        const exchangeButton = await $("#drawer-exchange-button");
+        await exchangeButton.click();
+
+        // Open settings and navigate all tabs
+        const settingsButton = await $("#topbar-settings-button");
+        await settingsButton.click();
+
+        // Open settings and navigate all tabs
+        const currenciesTab = await $("#settings-currencies-tab");
+        await currenciesTab.click();
+        const accountsTab = await $("#settings-accounts-tab");
+        await accountsTab.click();
+        const aboutTab = await $("#settings-about-tab");
+        await aboutTab.click();
+        const helpTab = await $("#settings-help-tab");
+        await helpTab.click();
+        const experimentalTab = await $("#settings-experimental-tab");
+        await experimentalTab.click();
+        expect(await modalPage.isDisplayed(true)).toBe(false);
+      });
+    }
+
+    describe("account flows", () => {
+      if (steps.includes("receive")) {
+        it("receive flow", async () => {
+          // Receive flow without device
+          const drawerReceiveButton = await $("#drawer-receive-button");
+          await drawerReceiveButton.click();
+          const receiveAccountContinueButton = await $("#receive-account-continue-button");
+          await receiveAccountContinueButton.waitForDisplayed();
+          await receiveAccountContinueButton.click();
+          await mockDeviceEvent({ type: "opened" }, { type: "complete" });
+          const receiveReceiveContinueButton = await $("#receive-receive-continue-button");
+          await receiveReceiveContinueButton.waitForDisplayed();
+          await receiveReceiveContinueButton.waitForEnabled();
+          await receiveReceiveContinueButton.click();
+          expect(await modalPage.isDisplayed(true)).toBe(false);
+        });
+      }
+
+      if (steps.includes("send")) {
+        it("send flow", async () => {
+          // Send flow
+          const sendButton = await $("#drawer-send-button");
+          await sendButton.click();
+          const recipientInput = await $("#send-recipient-input");
+          await recipientInput.click();
+          await recipientInput.addValue("1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA");
+          const recipientContinueButton = await $("#send-recipient-continue-button");
+          await recipientContinueButton.waitForEnabled();
+          await recipientContinueButton.click();
+          const amountContinueButton = await $("#send-amount-continue-button");
+          await amountContinueButton.click();
+          const summaryContinueButton = await $("#send-summary-continue-button");
+          await summaryContinueButton.click();
+          await mockDeviceEvent({ type: "opened" });
+          const confirmationOPCButton = await $("#send-confirmation-opc-button");
+          await confirmationOPCButton.waitForDisplayed({ timeout: 10000 });
+          await confirmationOPCButton.waitForEnabled();
+          await confirmationOPCButton.click();
+          await modalPage.close();
+          expect(await modalPage.isDisplayed(true)).toBe(false);
+        });
+      }
+
+      if (steps.includes("delegate") && currencies.includes("cosmos")) {
+        it("cosmos delegate flow", async () => {
+          // Cosmos delegate flow
+          const accountsButton = await $("#drawer-accounts-button");
+          await accountsButton.click();
+          const searchInput = await $("#accounts-search-input");
+          await searchInput.addValue("cosmos");
+          const firstAccountRowItme = await $(".accounts-account-row-item:first-child");
+          await firstAccountRowItme.waitForDisplayed();
+          await firstAccountRowItme.click();
+          const delegateButton = await $("#account-delegate-button");
+          await delegateButton.waitForDisplayed();
+          await delegateButton.click();
+          const delegateListFirstInput = await $("#delegate-list input:first-child");
+          await delegateListFirstInput.waitForDisplayed();
+          await delegateListFirstInput.addValue("1.5");
+          const delegateContinueButton = await $("#delegate-continue-button");
+          await delegateContinueButton.waitForDisplayed();
+          await delegateContinueButton.waitForEnabled();
+          await delegateContinueButton.click();
+          await mockDeviceEvent({ type: "opened" });
+          await modalPage.close();
+          expect(await modalPage.isDisplayed(true)).toBe(false);
+        });
+      }
+
+      if (steps.includes("delegate") && currencies.includes("tezos")) {
+        it("tezos delegate flow", async () => {
+          // Tezos delegate flow'
+          const accountsButton = await $("#drawer-accounts-button");
+          await accountsButton.click();
+          const searchInput = await $("#accounts-search-input");
+          await searchInput.addValue("tezos");
+          const accountRowFirstItem = await $(".accounts-account-row-item:first-child");
+          await accountRowFirstItem.waitForDisplayed();
+          await accountRowFirstItem.click();
+          const delegatebutton = await $("#account-delegate-button");
+          await delegatebutton.waitForDisplayed();
+          await delegatebutton.click();
+          const starterContinueButton = await $("#delegate-starter-continue-button");
+          await starterContinueButton.click();
+          const summaryContinueButton = await $("#delegate-summary-continue-button");
+          await summaryContinueButton.waitForDisplayed();
+          await summaryContinueButton.waitForEnabled();
+          await summaryContinueButton.click();
+          await mockDeviceEvent({ type: "opened" });
+          await modalPage.close();
+          expect(await modalPage.isDisplayed(true)).toBe(false);
+        });
+      }
     });
-
-    it("send flow", async () => {
-      // Send flow
-      const sendButton = await $("#drawer-send-button");
-      await sendButton.click();
-      const recipientInput = await $("#send-recipient-input");
-      await recipientInput.click();
-      await recipientInput.addValue("1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA");
-      const recipientContinueButton = await $("#send-recipient-continue-button");
-      await recipientContinueButton.waitForEnabled();
-      await recipientContinueButton.click();
-      const amountContinueButton = await $("#send-amount-continue-button");
-      await amountContinueButton.click();
-      const summaryContinueButton = await $("#send-summary-continue-button");
-      await summaryContinueButton.click();
-      await mockDeviceEvent({ type: "opened" });
-      const confirmationOPCButton = await $("#send-confirmation-opc-button");
-      await confirmationOPCButton.waitForDisplayed({ timeout: 10000 });
-      await confirmationOPCButton.waitForEnabled();
-      await confirmationOPCButton.click();
-      await modalPage.close();
-      expect(await modalPage.isDisplayed(true)).toBe(false);
-    });
-
-    it("cosmos delegate flow", async () => {
-      // Cosmos delegate flow
-      const accountsButton = await $("#drawer-accounts-button");
-      await accountsButton.click();
-      const searchInput = await $("#accounts-search-input");
-      await searchInput.addValue("cosmos");
-      const firstAccountRowItme = await $(".accounts-account-row-item:first-child");
-      await firstAccountRowItme.waitForDisplayed();
-      await firstAccountRowItme.click();
-      const delegateButton = await $("#account-delegate-button");
-      await delegateButton.waitForDisplayed();
-      await delegateButton.click();
-      const delegateListFirstInput = await $("#delegate-list input:first-child");
-      await delegateListFirstInput.waitForDisplayed();
-      await delegateListFirstInput.addValue("1.5");
-      const delegateContinueButton = await $("#delegate-continue-button");
-      await delegateContinueButton.waitForDisplayed();
-      await delegateContinueButton.waitForEnabled();
-      await delegateContinueButton.click();
-      await mockDeviceEvent({ type: "opened" });
-      await modalPage.close();
-      expect(await modalPage.isDisplayed(true)).toBe(false);
-    });
-
-    it("tezos delegate flow", async () => {
-      // Tezos delegate flow'
-      const accountsButton = await $("#drawer-accounts-button");
-      await accountsButton.click();
-      const searchInput = await $("#accounts-search-input");
-      await searchInput.addValue("tezos");
-      const accountRowFirstItem = await $(".accounts-account-row-item:first-child");
-      await accountRowFirstItem.waitForDisplayed();
-      await accountRowFirstItem.click();
-      const delegatebutton = await $("#account-delegate-button");
-      await delegatebutton.waitForDisplayed();
-      await delegatebutton.click();
-      const starterContinueButton = await $("#delegate-starter-continue-button");
-      await starterContinueButton.click();
-      const summaryContinueButton = await $("#delegate-summary-continue-button");
-      await summaryContinueButton.waitForDisplayed();
-      await summaryContinueButton.waitForEnabled();
-      await summaryContinueButton.click();
-      await mockDeviceEvent({ type: "opened" });
-      await modalPage.close();
-      expect(await modalPage.isDisplayed(true)).toBe(false);
-    });
-  });
-});
+  },
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,11 +1979,6 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/color-name@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
-  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
 "@types/debug@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
@@ -2045,11 +2040,16 @@
     "@types/node" "*"
 
 "@types/lodash@^4.14.85":
-  version "4.14.157"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.157.tgz#fdac1c52448861dfde1a2e1515dbc46e54926dc8"
-  integrity sha512-Ft5BNFmv2pHDgxV5JDsndOWTRJ+56zte0ZpYLowp03tW+K+t8u8YMOzAnpuqPgzX6WO1XpDIUm7u04M8vdDiVQ==
+  version "4.14.164"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.164.tgz#52348bcf909ac7b4c1bcbeda5c23135176e5dfa0"
+  integrity sha512-fXCEmONnrtbYUc5014avwBeMdhHHO8YJCkOBflUL9EoJBSKZ1dei+VO74fA7JkTHZ1GvZack2TyIw5U+1lT8jg==
 
-"@types/node@*", "@types/node@>= 8":
+"@types/node@*":
+  version "14.14.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.6.tgz#146d3da57b3c636cc0d1769396ce1cfa8991147f"
+  integrity sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==
+
+"@types/node@>= 8":
   version "14.0.23"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.23.tgz#676fa0883450ed9da0bb24156213636290892806"
   integrity sha512-Z4U8yDAl5TFkmYsZdFPdjeMa57NOvnaf1tljHzhouaPEp7LCj2JKkejpI1ODviIAQuW4CcQmxkQ77rnLsOOoKw==
@@ -2070,9 +2070,9 @@
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/pbkdf2@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/pbkdf2/-/pbkdf2-3.0.0.tgz#5d9ca5f12a78a08cc89ad72883ad4a30af359229"
-  integrity sha512-6J6MHaAlBJC/eVMy9jOwj9oHaprfutukfW/Dyt0NEnpQ/6HN6YQrpvLwzWdWDeWZIdenjGHlbYDzyEODO5Z+2Q==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@types/pbkdf2/-/pbkdf2-3.1.0.tgz#039a0e9b67da0cdc4ee5dab865caa6b267bb66b1"
+  integrity sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==
   dependencies:
     "@types/node" "*"
 
@@ -2139,7 +2139,14 @@
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
 
-"@types/yargs@^15.0.0", "@types/yargs@^15.0.5":
+"@types/yargs@^15.0.0":
+  version "15.0.9"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.9.tgz#524cd7998fe810cdb02f26101b699cccd156ff19"
+  integrity sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^15.0.5":
   version "15.0.5"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
   integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
@@ -2559,11 +2566,10 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
     color-convert "^1.9.0"
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
-  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
-    "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
 any-observable@^0.3.0:
@@ -3371,9 +3377,9 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.3, bn.js@^
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
 
 bn.js@^5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.2.tgz#c9686902d3c9a27729f43ab10f9d79c2004da7b0"
-  integrity sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
+  integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
 
 body-parser@1.19.0:
   version "1.19.0"
@@ -4913,9 +4919,9 @@ decamelize@^1.2.0:
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decimal.js@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.0.tgz#39466113a9e036111d02f82489b5fd6b0b5ed231"
-  integrity sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
+  integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
 
 decimal.js@^5.0.8:
   version "5.0.8"
@@ -8688,9 +8694,9 @@ keccak@^1.3.0:
     safe-buffer "^5.1.0"
 
 keccak@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.0.tgz#420d1de4a38a04f33ff8401f0535fb93756861d4"
-  integrity sha512-/4h4FIfFEpTEuySXi/nVFM5rqSKPnnhI7cL4K3MFSwoI3VyM7AhPSq3SsysARtnEBEeIKMBUWD8cTh9nHE8AkA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/keccak/-/keccak-3.0.1.tgz#ae30a0e94dbe43414f741375cff6d64c8bea0bff"
+  integrity sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==
   dependencies:
     node-addon-api "^2.0.0"
     node-gyp-build "^4.2.0"
@@ -9548,10 +9554,15 @@ ms@2.1.2, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-nan@^2.12.1, nan@^2.13.2, nan@^2.14.0, nan@^2.14.1, nan@^2.2.1:
+nan@^2.12.1, nan@^2.13.2, nan@^2.14.0, nan@^2.14.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+
+nan@^2.2.1:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
 nanoassert@^1.0.0:
   version "1.1.0"
@@ -9634,9 +9645,9 @@ node-fetch@^2.1.1, node-fetch@^2.1.2, node-fetch@^2.3.0, node-fetch@^2.6.1:
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-gyp-build@^4.2.0:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.2.tgz#3f44b65adaafd42fb6c3d81afd630e45c847eb66"
-  integrity sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
+  integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
 node-gyp@^7.1.0:
   version "7.1.0"
@@ -11640,7 +11651,7 @@ ripple-address-codec@^3.0.4:
     base-x "3.0.4"
     create-hash "^1.1.2"
 
-ripple-address-codec@^4.0.0:
+ripple-address-codec@^4.0.0, ripple-address-codec@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ripple-address-codec/-/ripple-address-codec-4.1.1.tgz#48e5d76b00b6b9752b1d376646d5abbcd3c8bd67"
   integrity sha512-mcVD8f7+CH6XaBnLkRcmw4KyHMufa0HTJE3TYeaecwleIQASLYVenjQmVJLgmJQcDUS2Ldh/EltqktmiFMFgkg==
@@ -11661,7 +11672,20 @@ ripple-binary-codec@0.2.0:
     lodash "^4.12.0"
     ripple-address-codec "^2.0.1"
 
-ripple-binary-codec@^0.2.0, ripple-binary-codec@^0.2.4, ripple-binary-codec@^0.2.6:
+ripple-binary-codec@^0.2.0, ripple-binary-codec@^0.2.4:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/ripple-binary-codec/-/ripple-binary-codec-0.2.7.tgz#c5390e97e4072747a3ff386ee99558b496c6e5ab"
+  integrity sha512-VD+sHgZK76q3kmO765klFHPDCEveS5SUeg/bUNVpNrj7w2alyDNkbF17XNbAjFv+kSYhfsUudQanoaSs2Y6uzw==
+  dependencies:
+    babel-runtime "^6.26.0"
+    bn.js "^5.1.1"
+    create-hash "^1.2.0"
+    decimal.js "^10.2.0"
+    inherits "^2.0.4"
+    lodash "^4.17.15"
+    ripple-address-codec "^4.1.0"
+
+ripple-binary-codec@^0.2.6:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/ripple-binary-codec/-/ripple-binary-codec-0.2.6.tgz#a8c45c905c12d5dc6fa7e179c3584d56fb8bdb07"
   integrity sha512-k0efyjpcde7p+rJ9PXW9tJSYsUDdlC9Z9xU7OPM7fJiHVKlR1E7nfu0jqw9vVXtTG3tujqKeEgtcb8yaa7rMXA==
@@ -12658,10 +12682,17 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/98370322-ae561080-203a-11eb-90ca-6c87bd5a147d.png)

## Changes to the bullrun
This pr introduces two changes to the bullrun that should make local testing easier for devs and qa. 
- The ability to run the bullrun with disabled screenshots, meaning the run should be faster and not fail in those checks. To run without screenshots simply call `yarn spectron -no-screenshots`. This should have no impact whatsoever in the github actions run, which would still take screenshots by running without the `-no-screenshots` flag.
- The possibility to filter some currencies or steps by editing the `currencies` and `steps` variables respectively, this is particularly useful to test a specific flow, or develop it, by just running through the mvp steps instead of the full run. For instance for the swap I just needed ETH and BTC, and the onboarding, and add accounts steps, which means the run would complete without manager, send, receive, delegate, discreet, etc. You get the point.

## About the swap flow
We also now have the swap flow covered. It's just a bullish run, as it should be, so no error handling, no history even (this could be easily added by clicking on the tab I would assume). The swap generated is obviously not real since we don't want to be moving funds around and paying fees on every pr.

### Type

Feature
