### PR TITLE
remove BCH warnings

### DIFF
--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -99,8 +99,6 @@ export const urls = {
     CantOpenDevice: "https://support.ledger.com/hc/en-us/articles/115005165269",
     WrongDeviceForAccount: "https://support.ledger.com/hc/en-us/articles/360025321733",
     SyncError: "https://support.ledger.com/hc/en-us/articles/360012109220",
-    BitcoinCashHardforkOct2020Warning:
-      "https://www.ledger.com/bitcoin-cash-fork-15-november-2020-what-it-means-for-you",
   },
   compound: "https://support.ledger.com/hc/en-us/articles/360017215099",
   compoundTnC: "https://shop.ledger.com/pages/ledger-live-terms-of-use",

--- a/src/renderer/components/CurrencyDownStatusAlert.js
+++ b/src/renderer/components/CurrencyDownStatusAlert.js
@@ -1,21 +1,11 @@
 // @flow
-import React from "react";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import type { TokenCurrency, CryptoCurrency } from "@ledgerhq/live-common/lib/types";
-import ErrorBanner from "./ErrorBanner";
 
 type Props = {
   currencies: Array<CryptoCurrency | TokenCurrency>,
 };
 
-const BitcoinCashHardforkOct2020Warning = createCustomErrorClass(
-  "BitcoinCashHardforkOct2020Warning",
-);
-
 const CurrencyDownStatusAlert = ({ currencies }: Props) => {
-  if (currencies.some(c => c.id === "bitcoin_cash")) {
-    return <ErrorBanner error={new BitcoinCashHardforkOct2020Warning()} warning />;
-  }
   return null;
 };
 

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -2215,10 +2215,6 @@
     "AmountRequired": {
       "title": "Amount required"
     },
-    "BitcoinCashHardforkOct2020Warning": {
-      "title": "",
-      "description": "Bitcoin Cash is currently undergoing a hard fork without replay protection. We will temporarily interrupt the Bitcoin Cash service until the network has stabilized."
-    },
     "NoAccessToCamera": {
       "title": "Please ensure your system has a camera, that it is not in use by another application and that Ledger Live has permission to use it.",
       "description": ""


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

rollback temporary banner measure

### Context

upon internal request, we will resume BCH services and no longer need the banner.

### Parts of the app affected / Test plan

not sure if testable but if you have BCH no warning will appear.