### PR TITLE
Fixes errors to be visible again in Sync state

### DIFF
--- a/src/renderer/bridge/BridgeSyncContext.js
+++ b/src/renderer/bridge/BridgeSyncContext.js
@@ -34,6 +34,7 @@ export const BridgeSyncProvider = ({ children }: { children: React$Node }) => {
       onUnusualInternalProcessError();
     }
     logger.critical(error);
+    return error;
   }, []);
 
   return (

--- a/src/renderer/components/Tooltip.js
+++ b/src/renderer/components/Tooltip.js
@@ -81,6 +81,7 @@ const ToolTip = ({
       placement={placement}
       flip={flip}
       hideOnClick={hideOnClick}
+      className={`bg-${tooltipBg}`}
     >
       {disableWrapper ? (
         children

--- a/src/renderer/styles/global.js
+++ b/src/renderer/styles/global.js
@@ -33,6 +33,10 @@ export const GlobalStyle = createGlobalStyle`
     fill: ${p => p.theme.colors.palette.text.shade100};
   }
 
+  .tippy-box[data-theme~='ledger'].bg-alertRed > .tippy-svg-arrow {
+    fill: ${p => p.theme.colors.alertRed};
+  }
+
   .tippy-tooltip.ledger-theme .tippy-svg-arrow {
     fill: ${p => p.theme.colors.palette.text.shade100};
   }


### PR DESCRIPTION
**remaining:**

- [x] fixes triangle black issue
- [ ] add small test to cover this: it can run a specific app.json which have one account, and using MOCK=crash_123 it should show an error on the portfolio header as well as on the accounts screen.

## What is this?

We have a regression in which all errors in sync would no longer appear in Synchronization error but would be displayed as **🕐 Paused**, which is only supposed to be legit for bad cases or cases where you are doing Send flow and the sync is actively "paused".

## How to test

- You can cut your network
- You can use mock with `MOCK=crash_123`

NB: an error is **designed** to be hidden for the user until the algorithm consider the last successful sync was too old. So turning network off **will not instantly show the error**, this is the normal behavior. See https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/651460609/High+level+states+of+the+app+synchronized+sync+error+