### PR TITLE
fix(Cosmos): show units in AccountBalanceSummaryFooter balances

### DIFF
--- a/src/renderer/families/cosmos/AccountBalanceSummaryFooter.js
+++ b/src/renderer/families/cosmos/AccountBalanceSummaryFooter.js
@@ -76,7 +76,7 @@ const AccountBalanceSummaryFooter = ({ account, countervalue }: Props) => {
   const formatConfig = {
     disableRounding: true,
     alwaysShowSign: false,
-    showCode: false,
+    showCode: true,
     discreet,
     locale,
   };


### PR DESCRIPTION
For consistency with TRON integration, adds the coin Code to balances in AccountBalanceSummaryFooter.

Reference: https://github.com/LedgerHQ/ledger-live-desktop/blob/develop/src/renderer/families/tron/AccountBalanceSummaryFooter.js#L65-L71

Note: i can't find any reason for COSMOS to have been implemented without the unit.


