### PR TITLE
fix(CheckBox): use defaultChecked to avoid react complaining

### DIFF
--- a/src/renderer/components/CheckBox.js
+++ b/src/renderer/components/CheckBox.js
@@ -59,7 +59,7 @@ function CheckBox(props: Props) {
         onChange && onChange(!isChecked);
       }}
     >
-      <input type="checkbox" disabled={disabled || null} checked={isChecked || null} />
+      <input type="checkbox" disabled={disabled || null} defaultChecked={isChecked || false} />
       <Check size={12} />
     </Base>
   );


### PR DESCRIPTION
Reacts complains with the following error on CheckBox component if it's mounted with `isChecked=true`:

```Warning: You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.```

### Type

Minor Bug Fix

### Parts of the app affected / Test plan

When CheckBox is provided with props `isChecked = false`, component should render with an input as:
```<input type="checkbox" />```

onChange should be called when User clicks on component with mouse, or user <tab> then <space>

When CheckBox is provided with props `isChecked = true`, component should render with an input as:
```<input type="checkbox"  checked />```
React should no longer complains with previous warning.

onChange should be called when User clicks on component with mouse, or user <tab> then <space>.

isChecked state should visually be reflected in both cases.
