### PR TITLE
Show time inside the tooltip on account charts when week range is selected

### DIFF
--- a/src/renderer/screens/account/BalanceSummary.js
+++ b/src/renderer/screens/account/BalanceSummary.js
@@ -75,10 +75,15 @@ export default function AccountBalanceSummary({
           <Box ff="Inter|Regular" color="palette.text.shade60" fontSize={3} mt={2}>
             {moment(d.date).format("LL")}
           </Box>
+          {range === "week" ? (
+            <Box ff="Inter|Regular" color="palette.text.shade60" fontSize={3}>
+              {moment(d.date).format("LT")}
+            </Box>
+          ) : null}
         </>
       );
     },
-    [account, counterValue.units, countervalueAvailable, countervalueFirst],
+    [account, counterValue.units, countervalueAvailable, countervalueFirst, range],
   );
 
   const renderTickYCryptoValue = useCallback(

--- a/src/renderer/screens/account/BalanceSummary.js
+++ b/src/renderer/screens/account/BalanceSummary.js
@@ -75,15 +75,13 @@ export default function AccountBalanceSummary({
           <Box ff="Inter|Regular" color="palette.text.shade60" fontSize={3} mt={2}>
             {moment(d.date).format("LL")}
           </Box>
-          {range === "week" ? (
-            <Box ff="Inter|Regular" color="palette.text.shade60" fontSize={3}>
-              {moment(d.date).format("LT")}
-            </Box>
-          ) : null}
+          <Box ff="Inter|Regular" color="palette.text.shade60" fontSize={3}>
+            {moment(d.date).format("LT")}
+          </Box>
         </>
       );
     },
-    [account, counterValue.units, countervalueAvailable, countervalueFirst, range],
+    [account, counterValue.units, countervalueAvailable, countervalueFirst],
   );
 
   const renderTickYCryptoValue = useCallback(

--- a/src/renderer/screens/dashboard/GlobalSummary.js
+++ b/src/renderer/screens/dashboard/GlobalSummary.js
@@ -87,15 +87,7 @@ export default function PortfolioBalanceSummary({
   );
 }
 
-function Tooltip({
-  data,
-  counterValue,
-  range,
-}: {
-  data: BalanceHistoryData,
-  counterValue: Currency,
-  range: PortfolioRange,
-}) {
+function Tooltip({ data, counterValue }: { data: BalanceHistoryData, counterValue: Currency }) {
   return (
     <>
       <FormattedVal
@@ -109,11 +101,9 @@ function Tooltip({
       <Box ff="Inter|Regular" color="palette.text.shade60" fontSize={3} mt={2}>
         {moment(data.date).format("LL")}
       </Box>
-      {range === "week" ? (
-        <Box ff="Inter|Regular" color="palette.text.shade60" fontSize={3}>
-          {moment(data.date).format("LT")}
-        </Box>
-      ) : null}
+      <Box ff="Inter|Regular" color="palette.text.shade60" fontSize={3}>
+        {moment(data.date).format("LT")}
+      </Box>
     </>
   );
 }


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
Time was missing in the tooltip just on Account page so I added.

### Type
Bug Fix
<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan
Account page -> hover on the chart to see tooltip. It should be the same to the one on Portfolio.
<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
