### PR TITLE
fix(EarnRewardsInfoModal): add margin between footer buttons

### DIFF
--- a/src/renderer/components/EarnRewardsInfoModal.js
+++ b/src/renderer/components/EarnRewardsInfoModal.js
@@ -81,10 +81,10 @@ export default function EarnRewardsInfoModal({
           renderFooter={() => (
             <Box horizontal grow>
               <Box grow>{footerLeft}</Box>
-              <Button secondary onClick={onClose}>
+              <Button ml={2} secondary onClick={onClose}>
                 <Trans i18nKey="common.cancel" />
               </Button>
-              <Button primary onClick={onNext}>
+              <Button ml={2} primary onClick={onNext}>
                 {nextLabel || <Trans i18nKey="common.continue" />}
               </Button>
             </Box>


### PR DESCRIPTION
Feedback from Chris
JIRA TICKET: https://ledgerhq.atlassian.net/browse/COINTEMP-384

### Type

Minor UI Bug Fix

### Context

On the Earn Modal, buttons in footer are too close to each other.
Add margin to both to ensure nothing is too close.