### PR TITLE
Fix regression in Price component

### DIFF
--- a/src/renderer/components/Price.js
+++ b/src/renderer/components/Price.js
@@ -46,6 +46,7 @@ export default function Price({
   iconSize,
   showAllDigits = true,
   withIcon = true,
+  rate,
 }: Props) {
   const effectiveUnit = unit || from.units[0];
   const valueNum = 10 ** effectiveUnit.magnitude;
@@ -57,8 +58,12 @@ export default function Price({
     value: valueNum,
     disableRounding: true,
   });
-  const counterValue =
-    typeof rawCounterValue !== "undefined" ? BigNumber(rawCounterValue) : rawCounterValue;
+
+  const counterValue = rate
+    ? rate.times(valueNum) // NB Allow to override the rate for swap
+    : typeof rawCounterValue !== "undefined"
+    ? BigNumber(rawCounterValue)
+    : rawCounterValue;
 
   const bgColor = useTheme("colors.palette.background.paper");
   if (!counterValue || counterValue.isZero()) return placeholder || null;


### PR DESCRIPTION
During the recent rework for countervalues we lost the ability to provide a fixed rate for the `Price` component, a feature used by Swap since we need to provide the rate from Changelly or the appropriate provider.

### Type

Bug fix

### Context

Slack

### Parts of the app affected / Test plan

- Enter swap
- Get a rate
- Confirm we get a conversion under the To currency 

![image](https://user-images.githubusercontent.com/4631227/100285713-a9b5b580-2f71-11eb-8e8f-1a6cbf6b772b.png)

