### PR TITLE
LL-3853 Remove Amount available from amount step deposit lend modal

### DIFF
--- a/src/renderer/screens/lend/modals/Supply/steps/StepAmount.js
+++ b/src/renderer/screens/lend/modals/Supply/steps/StepAmount.js
@@ -124,23 +124,8 @@ function StepAmount({
         <SupplyBanner account={account} parentAccount={parentAccount} />
       ) : null}
       <Box vertical mt={4}>
-        <Box horizontal style={{ justifyContent: "space-between" }}>
+        <Box>
           <Label>{t("lend.supply.steps.amount.amountToSupply")}</Label>
-          {supplyMax.gt(0) ? (
-            <Box horizontal>
-              <Label style={{ paddingLeft: 8 }}>{t("lend.supply.steps.amount.available")}</Label>
-              <Label style={{ paddingLeft: 4 }}>~</Label>
-              <Label style={{ paddingLeft: 2 }}>
-                <FormattedVal
-                  style={{ width: "auto" }}
-                  color="palette.text.shade100"
-                  val={supplyMax}
-                  unit={unit}
-                  showCode
-                />
-              </Label>
-            </Box>
-          ) : null}
         </Box>
         <InputCurrency
           autoFocus={false}


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-3853

### Parts of the app affected / Test plan

Go to the flow, make sure the "Available balance" part on the right of "Amount to deposit" is gone.
