### PR TITLE
Make unavailable swap error more generic

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -157,7 +157,7 @@
       "title": "Swap your assets",
       "continue": "Continue",
       "link": "More about Swap",
-      "sorry": "Swap feature is not available in your country"
+      "sorry": "Service temporarily unavailable, or not available in your country"
     },
     "missingApp": {
       "title": "Please install the Exchange app on your device",


### PR DESCRIPTION
Due to the unforeseen outage by the provider side yesterday evening, and until we have a way to diferentiate between the service not being available due to IP restrictions and the service being temporarily disrupted, we are making the wording for the swap feature's unavailability more generic.

![image](https://user-images.githubusercontent.com/4631227/100723212-c7e04300-33c1-11eb-8f84-4825616d7f38.png)

