### PR TITLE
Open path to user data instead of parent folder

### DIFF
--- a/src/renderer/components/OpenUserDataDirectoryBtn.js
+++ b/src/renderer/components/OpenUserDataDirectoryBtn.js
@@ -13,7 +13,7 @@ const OpenUserDataDirectoryBtn = (props: $Shape<ButtonProps>) => {
   const handleOpenUserDataDirectory = useCallback(() => {
     const userDataDirectory = resolveUserDataDirectory();
     logger.log(`Opening user data directory: ${userDataDirectory}`);
-    shell.showItemInFolder(userDataDirectory);
+    shell.openPath(userDataDirectory);
   }, []);
 
   return (


### PR DESCRIPTION
Without this, when we click on open user data folder, we are taken to the parent folder and the finder|explorer  will have selected the electron|live folder. With this change, we will open the finder inside the user data folder.

## How to test
- Go to settings/help and click on the open user folder cta.
- Test on Mac, Linux and Windows, ideally in dev + prod to see it works with all cases