### PR TITLE
LL-4016 Move full node to accounts settings screen

### DIFF
--- a/src/renderer/screens/settings/sections/Accounts/FullNode.js
+++ b/src/renderer/screens/settings/sections/Accounts/FullNode.js
@@ -4,9 +4,9 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
-import { SettingsSectionRow } from "~/renderer/screens/settings/SettingsSection";
-// import { SettingsSectionHeader as Header } from "~/renderer/screens/settings/SettingsSection";
-// import IconServer from "~/renderer/icons/Server";
+import { SettingsSectionHeader as Header } from "~/renderer/screens/settings/SettingsSection";
+
+import IconServer from "~/renderer/icons/Server";
 import Box from "~/renderer/components/Box";
 import FullNodeButton from "./FullNodeButton";
 import FullNodeStatus from "./FullNodeStatus";
@@ -16,23 +16,17 @@ export const HideIfEmptyBox: ThemedComponent<{}> = styled(Box)`
     display: none;
   }
 `;
-/* <Header
-  icon={<IconServer />}
-  title={t("settings.accounts.fullNode.title")}
-  desc={t("settings.accounts.fullNode.desc")}
-  renderRight={<FullNodeButton />}
-/> */
 
 const FullNode = () => {
   const { t } = useTranslation();
   return (
     <>
-      <SettingsSectionRow
+      <Header
+        icon={<IconServer />}
         title={t("settings.accounts.fullNode.title")}
         desc={t("settings.accounts.fullNode.desc")}
-      >
-        <FullNodeButton />
-      </SettingsSectionRow>
+        renderRight={<FullNodeButton />}
+      />
       <HideIfEmptyBox p={2}>
         <FullNodeStatus />
       </HideIfEmptyBox>

--- a/src/renderer/screens/settings/sections/Accounts/index.js
+++ b/src/renderer/screens/settings/sections/Accounts/index.js
@@ -9,6 +9,7 @@ import HideEmptyTokenAccountsToggle from "./HideEmptyTokenAccountsToggle";
 import SectionExport from "./Export";
 import Currencies from "./Currencies";
 import BlacklistedTokens from "./BlacklistedTokens";
+import FullNode from "~/renderer/screens/settings/sections/Accounts/FullNode";
 
 export default function SectionAccounts() {
   const { t } = useTranslation();
@@ -25,6 +26,7 @@ export default function SectionAccounts() {
           desc={t("settings.accounts.hideEmptyTokens.desc")}
           renderRight={<HideEmptyTokenAccountsToggle />}
         />
+        <FullNode />
         <BlacklistedTokens />
       </Section>
     </>

--- a/src/renderer/screens/settings/sections/Experimental/index.js
+++ b/src/renderer/screens/settings/sections/Experimental/index.js
@@ -23,7 +23,6 @@ import {
 } from "../../SettingsSection";
 import ExperimentalSwitch from "./ExperimentalSwitch";
 import ExperimentalInteger from "./ExperimentalInteger";
-import FullNode from "~/renderer/screens/settings/sections/Accounts/FullNode";
 
 const experimentalTypesMap = {
   toggle: ExperimentalSwitch,
@@ -128,7 +127,6 @@ const SectionExperimental = () => {
           ) : null,
         )}
         {__DEV__ ? <EthereumBridgeRow /> : null}
-        <FullNode />
       </Body>
     </Section>
   );


### PR DESCRIPTION
Pending the work on https://github.com/LedgerHQ/ledger-live-desktop/pull/3366 this pr will move the block back to the accounts screen. Made a separate pr in case we want further releases while still keeping it experimental.