### PR TITLE
Validators toggle assets display

### DIFF
--- a/src/renderer/components/Delegation/ValidatorListHeader.js
+++ b/src/renderer/components/Delegation/ValidatorListHeader.js
@@ -22,7 +22,7 @@ type ValidatorListHeaderProps = {
   maxVotes: number,
   totalValidators: number,
   notEnoughVotes: boolean,
-  displayVotes?: boolean,
+  hideVotes?: boolean,
 };
 
 const ValidatorListHeader = ({
@@ -33,7 +33,7 @@ const ValidatorListHeader = ({
   maxVotes,
   totalValidators,
   notEnoughVotes,
-  displayVotes = true,
+  hideVotes = false,
 }: ValidatorListHeaderProps) => (
   <Box horizontal alignItems="center" justifyContent="space-between" py={2} px={3}>
     <Text fontSize={3} ff="Inter|Medium">
@@ -49,7 +49,7 @@ const ValidatorListHeader = ({
           <Trans i18nKey="vote.steps.castVotes.selected" values={{ total: votesSelected }} />
         </Text>
       )}
-      {displayVotes && (
+      {!hideVotes && (
         <>
           <Separator />
           {max > 0 ? (

--- a/src/renderer/components/Delegation/ValidatorListHeader.js
+++ b/src/renderer/components/Delegation/ValidatorListHeader.js
@@ -43,10 +43,12 @@ const ValidatorListHeader = ({
       {votesSelected === maxVotes ? (
         <Text fontSize={3} ff="Inter|Medium">
           <Trans i18nKey="vote.steps.castVotes.maxSelected" values={{ total: maxVotes }} />
+          {` / ${maxVotes}`}
         </Text>
       ) : (
         <Text fontSize={3} ff="Inter|Medium">
           <Trans i18nKey="vote.steps.castVotes.selected" values={{ total: votesSelected }} />
+          {` / ${maxVotes}`}
         </Text>
       )}
       {!hideVotes && (

--- a/src/renderer/components/Delegation/ValidatorListHeader.js
+++ b/src/renderer/components/Delegation/ValidatorListHeader.js
@@ -22,6 +22,7 @@ type ValidatorListHeaderProps = {
   maxVotes: number,
   totalValidators: number,
   notEnoughVotes: boolean,
+  displayVotes?: boolean,
 };
 
 const ValidatorListHeader = ({
@@ -32,6 +33,7 @@ const ValidatorListHeader = ({
   maxVotes,
   totalValidators,
   notEnoughVotes,
+  displayVotes = true,
 }: ValidatorListHeaderProps) => (
   <Box horizontal alignItems="center" justifyContent="space-between" py={2} px={3}>
     <Text fontSize={3} ff="Inter|Medium">
@@ -47,29 +49,36 @@ const ValidatorListHeader = ({
           <Trans i18nKey="vote.steps.castVotes.selected" values={{ total: votesSelected }} />
         </Text>
       )}
-      <Separator />
-      {max > 0 ? (
-        <Text fontSize={3} ff="Inter|Medium">
-          <Trans i18nKey="vote.steps.castVotes.votes" values={{ total: maxText || max }} />
-        </Text>
-      ) : notEnoughVotes ? (
-        <Box horizontal alignItems="center" color="alertRed">
-          <ExclamationCircle size={13} />
-          <Box ml={1}>
+      {displayVotes && (
+        <>
+          <Separator />
+          {max > 0 ? (
             <Text fontSize={3} ff="Inter|Medium">
-              <Trans i18nKey="vote.steps.castVotes.maxUsed" values={{ total: votesAvailable }} />
+              <Trans i18nKey="vote.steps.castVotes.votes" values={{ total: maxText || max }} />
             </Text>
-          </Box>
-        </Box>
-      ) : (
-        <Box horizontal alignItems="center" color="positiveGreen">
-          <Check size={13} />
-          <Box ml={1}>
-            <Text fontSize={3} ff="Inter|Medium">
-              <Trans i18nKey="vote.steps.castVotes.allVotesAreUsed" />
-            </Text>
-          </Box>
-        </Box>
+          ) : notEnoughVotes ? (
+            <Box horizontal alignItems="center" color="alertRed">
+              <ExclamationCircle size={13} />
+              <Box ml={1}>
+                <Text fontSize={3} ff="Inter|Medium">
+                  <Trans
+                    i18nKey="vote.steps.castVotes.maxUsed"
+                    values={{ total: votesAvailable }}
+                  />
+                </Text>
+              </Box>
+            </Box>
+          ) : (
+            <Box horizontal alignItems="center" color="positiveGreen">
+              <Check size={13} />
+              <Box ml={1}>
+                <Text fontSize={3} ff="Inter|Medium">
+                  <Trans i18nKey="vote.steps.castVotes.allVotesAreUsed" />
+                </Text>
+              </Box>
+            </Box>
+          )}
+        </>
       )}
     </Box>
   </Box>

--- a/src/renderer/components/ScrollLoadingList.js
+++ b/src/renderer/components/ScrollLoadingList.js
@@ -33,10 +33,15 @@ const ScrollLoadingList = ({
 }: ScrollLoadingListProps) => {
   const scrollRef = useRef();
   const [scrollOffset, setScrollOffset] = useState(bufferSize);
-
   const handleScroll = useCallback(() => {
     const target = scrollRef && scrollRef.current;
     if (
+      // the offset was off when :
+      // - do a first search with few results and scroll on the bottom of it
+      // - then do one more search but with no result
+      // - and redo a research with a result, no items will be display in the scrollContainer
+      // we don't allow the value 0 to be able to set the offset to prevent this
+      data.length !== 0 &&
       target &&
       // $FlowFixMe
       target.scrollTop + target.offsetHeight >= target.scrollHeight - scrollEndThreshold


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
### Type

Bug-fix:  
the offset was off when we :
      - do a first search with few results and scroll on the bottom of it
      - then do one more search but with no result
        and redo a research with a result, no items will be display in the scrollContainer

Features : 
- @rjarasson-ledger add a `/maxVotes` to the number of selected voted
- For Polkadot Purpose we do not need the display of "All assets are distributed" because to delegate to a validator in this blockchain you only need to add the address, the blockchain will automatically distributed your locked assets.


### Parts of the app affected / Test plan

Validators list