### PR TITLE
Hide onboarding lang picker

### DIFF
--- a/src/config/languages.js
+++ b/src/config/languages.js
@@ -23,7 +23,7 @@ export const allLanguages = [
   "zh",
 ];
 
-export const prodStableLanguages = ["en", "fr", "ru", "zh", "es"];
+export const prodStableLanguages = ["en", "fr"];
 
 export const getLanguages = () =>
   getEnv("EXPERIMENTAL_LANGUAGES") ? allLanguages : prodStableLanguages;

--- a/src/renderer/components/Onboarding/Screens/Welcome/index.js
+++ b/src/renderer/components/Onboarding/Screens/Welcome/index.js
@@ -62,9 +62,7 @@ export function Welcome({ sendEvent }: Props) {
 
   return (
     <WelcomeContainer>
-      <TopRightContainer>
-        <LangSwitcher />
-      </TopRightContainer>
+      <TopRightContainer>{null /* LL-4236 */ && <LangSwitcher />}</TopRightContainer>
       <WaveContainer>
         <AnimatedWave height={600} color={theme === "dark" ? "#587ED4" : "#4385F016"} />
       </WaveContainer>


### PR DESCRIPTION
we didn't get the langs at time so we decided to disable the Onboarding lang selection.

The "stable" langs are back to be just EN and FR in the lang selection of settings.