### PR TITLE
LL-4170 (Onboarding): add pin code icons in description text

### DIFF
--- a/src/renderer/components/Onboarding/Screens/Tutorial/screens/PinCodeHowTo.js
+++ b/src/renderer/components/Onboarding/Screens/Tutorial/screens/PinCodeHowTo.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
 import Lottie from "react-lottie";
@@ -16,6 +16,7 @@ import NanoSAnim from "../assets/animations/nanoS/pin-code.json";
 import NanoXAnim from "../assets/animations/nanoX/pin-code.json";
 import NanoDeviceCheckIcon from "~/renderer/icons/NanoDeviceCheckIcon";
 import NanoDeviceCancelIcon from "~/renderer/icons/NanoDeviceCancelIcon";
+import useTheme from "~/renderer/hooks/useTheme";
 
 const ScreenContainer: ThemedComponent<*> = styled.div`
   display: flex;
@@ -113,13 +114,13 @@ const StepList = styled.div`
   }
 `;
 
-const steps = [
+const steps = (color: string) => [
   {
     titleKey: <Trans i18nKey="onboarding.screens.tutorial.screens.pinCodeHowTo.setUp.title" />,
     descrKey: (
       <Trans i18nKey="onboarding.screens.tutorial.screens.pinCodeHowTo.setUp.descr">
-        <NanoDeviceCheckIcon />
-        <NanoDeviceCancelIcon />
+        <NanoDeviceCheckIcon color={color} />
+        <NanoDeviceCancelIcon color={color} />
       </Trans>
     ),
   },
@@ -138,6 +139,8 @@ type Props = {
 
 export function PinCodeHowTo({ sendEvent, context }: Props) {
   const { deviceId } = context;
+  const colors = useTheme("colors");
+  const allSteps = useMemo(() => steps(colors.wallet), [colors]);
 
   const onClickHelp = useCallback(() => sendEvent("HELP"), [sendEvent]);
   const onClickPrev = useCallback(() => sendEvent("PREV"), [sendEvent]);
@@ -165,7 +168,7 @@ export function PinCodeHowTo({ sendEvent, context }: Props) {
         </HeaderContainer>
         <Lottie options={defaultOptions} height={130} />
         <StepList>
-          {steps.map((step, index) => (
+          {allSteps.map((step, index) => (
             <Step key={index} title={step.titleKey} descr={step.descrKey} index={index + 1} />
           ))}
         </StepList>

--- a/src/renderer/components/Onboarding/Screens/Tutorial/screens/PinCodeHowTo.js
+++ b/src/renderer/components/Onboarding/Screens/Tutorial/screens/PinCodeHowTo.js
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from "react";
 import styled from "styled-components";
-import { useTranslation } from "react-i18next";
+import { Trans } from "react-i18next";
 import Lottie from "react-lottie";
 import type { DeviceModelId } from "@ledgerhq/devices";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
@@ -14,6 +14,8 @@ import InfoCircle from "~/renderer/icons/InfoCircle";
 import { HeaderContainer } from "~/renderer/components/Onboarding/Screens/Tutorial/shared";
 import NanoSAnim from "../assets/animations/nanoS/pin-code.json";
 import NanoXAnim from "../assets/animations/nanoX/pin-code.json";
+import NanoDeviceCheckIcon from "~/renderer/icons/NanoDeviceCheckIcon";
+import NanoDeviceCancelIcon from "~/renderer/icons/NanoDeviceCancelIcon";
 
 const ScreenContainer: ThemedComponent<*> = styled.div`
   display: flex;
@@ -63,8 +65,8 @@ const StepTextContainer = styled.div`
 `;
 
 type StepProps = {
-  title: string,
-  descr: string,
+  title: React$Node,
+  descr: React$Node,
   index: number,
 };
 
@@ -113,12 +115,17 @@ const StepList = styled.div`
 
 const steps = [
   {
-    titleKey: "onboarding.screens.tutorial.screens.pinCodeHowTo.setUp.title",
-    descrKey: "onboarding.screens.tutorial.screens.pinCodeHowTo.setUp.descr",
+    titleKey: <Trans i18nKey="onboarding.screens.tutorial.screens.pinCodeHowTo.setUp.title" />,
+    descrKey: (
+      <Trans i18nKey="onboarding.screens.tutorial.screens.pinCodeHowTo.setUp.descr">
+        <NanoDeviceCheckIcon />
+        <NanoDeviceCancelIcon />
+      </Trans>
+    ),
   },
   {
-    titleKey: "onboarding.screens.tutorial.screens.pinCodeHowTo.confirm.title",
-    descrKey: "onboarding.screens.tutorial.screens.pinCodeHowTo.confirm.descr",
+    titleKey: <Trans i18nKey="onboarding.screens.tutorial.screens.pinCodeHowTo.confirm.title" />,
+    descrKey: <Trans i18nKey="onboarding.screens.tutorial.screens.pinCodeHowTo.confirm.descr" />,
   },
 ];
 
@@ -130,7 +137,6 @@ type Props = {
 };
 
 export function PinCodeHowTo({ sendEvent, context }: Props) {
-  const { t } = useTranslation();
   const { deviceId } = context;
 
   const onClickHelp = useCallback(() => sendEvent("HELP"), [sendEvent]);
@@ -152,7 +158,7 @@ export function PinCodeHowTo({ sendEvent, context }: Props) {
         <HeaderContainer>
           <Button color="palette.primary.main" onClick={onClickHelp}>
             <Text mr="8px" ff="Inter|Bold" fontSize={3} lineHeight="18px">
-              {t("onboarding.screens.tutorial.screens.pinCodeHowTo.buttons.help")}
+              <Trans i18nKey="onboarding.screens.tutorial.screens.pinCodeHowTo.buttons.help" />
             </Text>
             <InfoCircle size={22} />
           </Button>
@@ -160,7 +166,7 @@ export function PinCodeHowTo({ sendEvent, context }: Props) {
         <Lottie options={defaultOptions} height={130} />
         <StepList>
           {steps.map((step, index) => (
-            <Step key={index} title={t(step.titleKey)} descr={t(step.descrKey)} index={index + 1} />
+            <Step key={index} title={step.titleKey} descr={step.descrKey} index={index + 1} />
           ))}
         </StepList>
       </ContentContainer>
@@ -168,12 +174,12 @@ export function PinCodeHowTo({ sendEvent, context }: Props) {
         <Button color="palette.text.shade30" onClick={onClickPrev}>
           <ArrowLeft />
           <Text ml="9px" ff="Inter|Bold" fontSize={3} lineHeight="18px">
-            {t("onboarding.screens.tutorial.screens.pinCodeHowTo.buttons.prev")}
+            <Trans i18nKey="onboarding.screens.tutorial.screens.pinCodeHowTo.buttons.prev" />
           </Text>
         </Button>
         <Button id="pincode-howto-cta" primary onClick={onClickNext}>
           <Text mr="12px" ff="Inter|Bold" fontSize={3} lineHeight="18px">
-            {t("onboarding.screens.tutorial.screens.pinCodeHowTo.buttons.next")}
+            <Trans i18nKey="onboarding.screens.tutorial.screens.pinCodeHowTo.buttons.next" />
           </Text>
           <ChevronRight size={13} />
         </Button>

--- a/src/renderer/icons/NanoDeviceCancelIcon.js
+++ b/src/renderer/icons/NanoDeviceCancelIcon.js
@@ -1,0 +1,21 @@
+// @flow
+import React from "react";
+
+type Props = {
+  size?: number,
+  color?: string,
+};
+
+export default function NanoDeviceCancelIcon({ size = 16, color = "currentColor" }: Props) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 12 12" fill="none">
+      <rect width="12" height="12" rx="1" fill={color} fillOpacity="0.2" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M10 3H4V4H3V5H2V7H3V8H4V9H10V3ZM9 4H8V5H6V4H5V5H6V7H5V8H6V7H8V8H9V7H8V5H9V4Z"
+        fill={color}
+      />
+    </svg>
+  );
+}

--- a/src/renderer/icons/NanoDeviceCheckIcon.js
+++ b/src/renderer/icons/NanoDeviceCheckIcon.js
@@ -1,0 +1,43 @@
+// @flow
+import React from "react";
+
+type Props = {
+  size?: number,
+  color?: string,
+};
+
+export default function NanoDeviceCheckIcon({ size = 16, color = "currentColor" }: Props) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 12 12" fill="none">
+      <rect width="12" height="12" rx="1" fill={color} fillOpacity="0.2" />
+      <rect x="9" y="3" width="1" height="1" fill={color} />
+      <rect x="8" y="4" width="1" height="1" fill={color} />
+      <rect x="7" y="5" width="1" height="1" fill={color} />
+      <rect x="6" y="6" width="1" height="1" fill={color} />
+      <rect x="5" y="7" width="1" height="1" fill={color} />
+      <rect x="4" y="6" width="1" height="1" fill={color} />
+      <rect x="3" y="5" width="1" height="1" fill={color} />
+      <rect x="8" y="3" width="1" height="1" fill={color} />
+      <rect x="7" y="4" width="1" height="1" fill={color} />
+      <rect x="6" y="5" width="1" height="1" fill={color} />
+      <rect x="5" y="6" width="1" height="1" fill={color} />
+      <rect x="4" y="7" width="1" height="1" fill={color} />
+      <rect x="3" y="6" width="1" height="1" fill={color} />
+      <rect x="2" y="5" width="1" height="1" fill={color} />
+      <rect x="8" y="4" width="1" height="1" fill={color} />
+      <rect x="7" y="5" width="1" height="1" fill={color} />
+      <rect x="6" y="6" width="1" height="1" fill={color} />
+      <rect x="5" y="7" width="1" height="1" fill={color} />
+      <rect x="4" y="8" width="1" height="1" fill={color} />
+      <rect x="3" y="7" width="1" height="1" fill={color} />
+      <rect x="2" y="6" width="1" height="1" fill={color} />
+      <rect x="9" y="4" width="1" height="1" fill={color} />
+      <rect x="8" y="5" width="1" height="1" fill={color} />
+      <rect x="7" y="6" width="1" height="1" fill={color} />
+      <rect x="6" y="7" width="1" height="1" fill={color} />
+      <rect x="5" y="8" width="1" height="1" fill={color} />
+      <rect x="4" y="7" width="1" height="1" fill={color} />
+      <rect x="3" y="6" width="1" height="1" fill={color} />
+    </svg>
+  );
+}

--- a/static/i18n/de/app.json
+++ b/static/i18n/de/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/el/app.json
+++ b/static/i18n/el/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -2284,7 +2284,8 @@
               "prev": "Previous step",
               "help": "Need help"
             }
-          },          "pinCode": {
+          },
+          "pinCode": {
             "title": "PIN code",
             "paragraph": "Your PIN code is the first layer of security. It physically secures access to your private key and your Nano. Your PIN code must be 4 to 8 digits long.",
             "disclaimer": "I understand that I must choose my PIN code myself and keep it private.",
@@ -2314,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/es/app.json
+++ b/static/i18n/es/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/fi/app.json
+++ b/static/i18n/fi/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/fr/app.json
+++ b/static/i18n/fr/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/hu/app.json
+++ b/static/i18n/hu/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/it/app.json
+++ b/static/i18n/it/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/ja/app.json
+++ b/static/i18n/ja/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/ko/app.json
+++ b/static/i18n/ko/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/nl/app.json
+++ b/static/i18n/nl/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/no/app.json
+++ b/static/i18n/no/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/pl/app.json
+++ b/static/i18n/pl/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/pt/app.json
+++ b/static/i18n/pt/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/ru/app.json
+++ b/static/i18n/ru/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/sr/app.json
+++ b/static/i18n/sr/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/sv/app.json
+++ b/static/i18n/sv/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/tr/app.json
+++ b/static/i18n/tr/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",

--- a/static/i18n/zh/app.json
+++ b/static/i18n/zh/app.json
@@ -2315,7 +2315,7 @@
           "pinCodeHowTo": {
             "setUp": {
               "title": "Choose PIN code",
-              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select ✔ to confirm your PIN code. Select ⌫ to erase a digit."
+              "descr": "Press the left or right button to change digits. Press both buttons to validate a digit. Select <0></0> to confirm your PIN code. Select <1></1> to erase a digit."
             },
             "confirm": {
               "title": "Confirm PIN code",


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(Onboarding): add pin code icons in description text

![localhost_8080_webpack_index html_theme=null](https://user-images.githubusercontent.com/11752937/102787966-2d609780-43a2-11eb-8bf3-994d74a528d6.png)

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
UI Polish
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-4170
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Onboarding pin code text.
