### PR TITLE
LL-4282 Onboarding from Settings back issue

### DIFF
--- a/src/renderer/components/Onboarding/Screens/Welcome/index.js
+++ b/src/renderer/components/Onboarding/Screens/Welcome/index.js
@@ -46,9 +46,10 @@ const TopRightContainer = styled.div`
 
 type Props = {
   sendEvent: string => void,
+  onboardingRelaunched: boolean,
 };
 
-export function Welcome({ sendEvent }: Props) {
+export function Welcome({ sendEvent, onboardingRelaunched }: Props) {
   const { t } = useTranslation();
   const theme = useTheme();
 
@@ -62,7 +63,14 @@ export function Welcome({ sendEvent }: Props) {
 
   return (
     <WelcomeContainer>
-      <TopRightContainer>{null /* LL-4236 */ && <LangSwitcher />}</TopRightContainer>
+      <TopRightContainer>
+        {null /* LL-4236 */ && <LangSwitcher />}
+        {onboardingRelaunched && (
+          <Button small onClick={() => sendEvent("PREV")}>
+            Previous
+          </Button>
+        )}
+      </TopRightContainer>
       <WaveContainer>
         <AnimatedWave height={600} color={theme === "dark" ? "#587ED4" : "#4385F016"} />
       </WaveContainer>

--- a/src/renderer/components/Onboarding/index.js
+++ b/src/renderer/components/Onboarding/index.js
@@ -68,6 +68,7 @@ const onboardingMachine = Machine({
         NEXT: {
           target: "selectDevice",
         },
+        PREV: { target: "onboardingComplete" },
       },
     },
     selectDevice: {
@@ -184,7 +185,7 @@ const ScreenContainer = styled.div`
   }
 `;
 
-export function Onboarding() {
+export function Onboarding({ onboardingRelaunched }: { onboardingRelaunched: boolean }) {
   const dispatch = useDispatch();
 
   const [state, sendEvent, service] = useMachine(onboardingMachine, {
@@ -222,7 +223,11 @@ export function Onboarding() {
       <OnboardingContainer>
         <CSSTransition in appear key={state.value} timeout={DURATION} classNames="page-switch">
           <ScreenContainer>
-            <CurrentScreen sendEvent={sendEvent} context={state.context} />
+            <CurrentScreen
+              sendEvent={sendEvent}
+              context={state.context}
+              onboardingRelaunched={onboardingRelaunched}
+            />
           </ScreenContainer>
         </CSSTransition>
       </OnboardingContainer>

--- a/src/renderer/components/OnboardingOrElse.js
+++ b/src/renderer/components/OnboardingOrElse.js
@@ -15,7 +15,7 @@ const OnboardingOrElse = ({ children }: Props) => {
   const onboardingRelaunched = useSelector(onboardingRelaunchedSelector);
 
   if (!hasCompletedOnboarding || onboardingRelaunched) {
-    return <Onboarding />;
+    return <Onboarding onboardingRelaunched={onboardingRelaunched} />;
   }
 
   return children;

--- a/src/renderer/components/OnboardingOrElse.js
+++ b/src/renderer/components/OnboardingOrElse.js
@@ -15,7 +15,7 @@ const OnboardingOrElse = ({ children }: Props) => {
   const onboardingRelaunched = useSelector(onboardingRelaunchedSelector);
 
   if (!hasCompletedOnboarding || onboardingRelaunched) {
-    return <Onboarding onboardingRelaunched={onboardingRelaunched} />;
+    return <Onboarding onboardingRelaunched={!!onboardingRelaunched} />;
   }
 
   return children;


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(Onboarding): relaunch of onboarding now has a previous button to go back into settings

![localhost_8080_webpack_index html_theme=null](https://user-images.githubusercontent.com/11752937/103541952-7b929200-4e9c-11eb-911e-a7172fe9fb32.png)

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
UI Polish
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-4282
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Onboarding launched from settings page with setup new device.
