### PR TITLE
confirmationsNb min value should be 1

### DIFF
--- a/src/renderer/modals/OperationDetails/index.js
+++ b/src/renderer/modals/OperationDetails/index.js
@@ -51,6 +51,7 @@ import IconExternalLink from "~/renderer/icons/ExternalLink";
 import { openURL } from "~/renderer/linking";
 import { accountSelector } from "~/renderer/reducers/accounts";
 import {
+  CONFIRMATIONS_NB_MIN,
   confirmationsNbForCurrencySelector,
   marketIndicatorSelector,
 } from "~/renderer/reducers/settings";

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -38,13 +38,15 @@ type ConfirmationDefaults = {
   },
 };
 
+export const CONFIRMATIONS_NB_MIN = 1;
+
 export const currencySettingsDefaults = (c: Currency): ConfirmationDefaults => {
   let confirmationsNb;
   if (c.type === "CryptoCurrency") {
     const { blockAvgTime } = c;
     if (blockAvgTime) {
       const def = Math.ceil((30 * 60) / blockAvgTime); // 30 min approx validation
-      confirmationsNb = { min: 1, def, max: 3 * def };
+      confirmationsNb = { min: CONFIRMATIONS_NB_MIN, def, max: 3 * def };
     }
   }
   return {
@@ -112,7 +114,7 @@ export type SettingsState = {
 const defaultsForCurrency: Currency => CurrencySettings = crypto => {
   const defaults = currencySettingsDefaults(crypto);
   return {
-    confirmationsNb: defaults.confirmationsNb ? defaults.confirmationsNb.def : 0,
+    confirmationsNb: defaults.confirmationsNb ? defaults.confirmationsNb.def : CONFIRMATIONS_NB_MIN,
   };
 };
 
@@ -358,7 +360,7 @@ export const confirmationsNbForCurrencySelector = (
   const obj = state.settings.currenciesSettings[currency.ticker];
   if (obj) return obj.confirmationsNb;
   const defs = currencySettingsDefaults(currency);
-  return defs.confirmationsNb ? defs.confirmationsNb.def : 0;
+  return defs.confirmationsNb ? defs.confirmationsNb.def : CONFIRMATIONS_NB_MIN;
 };
 
 export const preferredDeviceModelSelector = (state: State) => state.settings.preferredDeviceModel;


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug fix

### Context

During the implementation of Polkadot, pending operation have a status as confirmed after the send flow (view details) instead of not confirmed
It appeared that a min value of the confirmationsNb is set to 0 by default instead of 1.

It was set like this by default but you can find the value was set as 0 in the pull request
`      confirmationsNb = { min: 1, def, max: 3 * def };`

### Parts of the app affected / Test plan

Well, it has a huge impact on every coins, everywhere where the status are set as confirmed or not.
