### PR TITLE
reset scroll offset when data change on validator list

### DIFF
--- a/src/renderer/components/ScrollLoadingList.js
+++ b/src/renderer/components/ScrollLoadingList.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useCallback, useState, useRef, memo } from "react";
+import React, { useCallback, useState, useRef, memo, useEffect } from "react";
 import debounce from "lodash/debounce";
 import styled from "styled-components";
 
@@ -33,6 +33,17 @@ const ScrollLoadingList = ({
 }: ScrollLoadingListProps) => {
   const scrollRef = useRef();
   const [scrollOffset, setScrollOffset] = useState(bufferSize);
+
+  /**
+   * We are reseting scroll after each change of data
+   * to the top position
+   */
+  useEffect(() => {
+    // $FlowFixMe
+    scrollRef.current.scrollTop = 0;
+    setScrollOffset(bufferSize);
+  }, [data, scrollRef, bufferSize]);
+
   const handleScroll = useCallback(() => {
     const target = scrollRef && scrollRef.current;
     if (
@@ -41,7 +52,6 @@ const ScrollLoadingList = ({
       // - then do one more search but with no result
       // - and redo a research with a result, no items will be display in the scrollContainer
       // we don't allow the value 0 to be able to set the offset to prevent this
-      data.length !== 0 &&
       target &&
       // $FlowFixMe
       target.scrollTop + target.offsetHeight >= target.scrollHeight - scrollEndThreshold


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug fix

### Context

https://github.com/LedgerHQ/ledger-live-desktop/pull/3369

We have fix one bug but discovered an another one.
When you scroll down with a few result like 19 and then you search a list with less than 3 (when there's no scrollbar) then going back to the previous result or any new result 
It will only be lock with 3 results until you reset the modal.

### Parts of the app affected / Test plan

Validator list, and any element that use ScrollLoadingList with search
