### PR TITLE
LLD will now try to fetch TERMS-{$language}.md and fallback to TERMS.md on 404 error

### DIFF
--- a/src/renderer/terms.js
+++ b/src/renderer/terms.js
@@ -2,8 +2,13 @@
 import { useEffect, useState } from "react";
 
 import network from "@ledgerhq/live-common/lib/network";
+import { useSelector } from "react-redux";
+import { languageSelector } from "~/renderer/reducers/settings";
 
-const rawURL = "https://raw.githubusercontent.com/LedgerHQ/ledger-live-desktop/master/TERMS.md";
+const getRawLanguageURL = (language: string) =>
+  `https://raw.githubusercontent.com/LedgerHQ/ledger-live-desktop/master/TERMS-${language}.md`;
+const rawDefaultURL =
+  "https://raw.githubusercontent.com/LedgerHQ/ledger-live-desktop/master/TERMS.md";
 export const url = "https://github.com/LedgerHQ/ledger-live-desktop/blob/master/TERMS.md";
 
 const currentTermsRequired = "2019-12-04";
@@ -25,18 +30,27 @@ export function acceptLendingTerms() {
   return global.localStorage.setItem("acceptedLendingTermsVersion", currentLendingTermsRequired);
 }
 
-export async function load() {
-  const { data } = await network({ url: rawURL });
-  return data;
+export async function load(language: string) {
+  try {
+    const { data } = await network({ url: getRawLanguageURL(language) });
+    return data;
+  } catch (error) {
+    if (error.status === 404) {
+      const { data } = await network({ url: rawDefaultURL });
+      return data;
+    }
+    throw error;
+  }
 }
 
 export const useTerms = () => {
   const [terms, setTerms] = useState(null);
   const [error, setError] = useState(null);
 
+  const language = useSelector(languageSelector);
   useEffect(() => {
-    load().then(setTerms, setError);
-  }, []);
+    load(language).then(setTerms, setError);
+  }, [language]);
 
   return [terms, error];
 };


### PR DESCRIPTION
QA: translated terms are not available yet, but you can test this by looking for a 404 in the console while the terms modal is open