### PR TITLE
webpack: add support for mjs files

### DIFF
--- a/preloader.webpack.config.js
+++ b/preloader.webpack.config.js
@@ -67,6 +67,11 @@ module.exports = {
           },
         },
       },
+      {
+        type: 'javascript/auto',
+        test: /\.mjs$/,
+        use: []
+      }
     ],
   },
   resolve: {

--- a/renderer.webpack.config.js
+++ b/renderer.webpack.config.js
@@ -85,6 +85,11 @@ module.exports = {
           },
         },
       },
+      {
+        type: 'javascript/auto',
+        test: /\.mjs$/,
+        use: []
+      }
     ],
   },
   resolve: {


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug fix

### Context

We are needed to use Polkadot.js new lib, but it's seems that they are using some mjs that wasn't compatible with LLD.
(cf. https://ledger.slack.com/archives/C011AEKR21Z/p1611656602028500)

We tried once to update the lib on LLC but didn't test it on LLD. It was 
### Parts of the app affected / Test plan

refer to the screen it shouldn't be able to launch the app
