### PR TITLE
LL-4448 Disable beginAtZero for the chart

### DIFF
--- a/src/renderer/components/Chart/index.js
+++ b/src/renderer/components/Chart/index.js
@@ -159,7 +159,7 @@ export default function Chart({
               zeroLineColor: theme.text.shade10,
             },
             ticks: {
-              beginAtZero: true,
+              beginAtZero: false,
               suggestedMax: 10 ** Math.max(magnitude - 4, 1),
               maxTicksLimit: 4,
               fontColor: theme.text.shade60,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/105865422-35d86d80-5ff3-11eb-9a8d-3895d1687a82.png)


### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-4448
closes #3507 

### Parts of the app affected / Test plan

For the chart of a given account / portfolio, it should only start on zero if the selected period contains a data point with a value of zero. So if I select Week and I only fluctuate between 0.5 and 0.6, the scale of the Y axis should be constrained to these values and any fluctuations will be a lot more visible (second screenshot)