### PR TITLE
cmd AccountSyncSet: internal reconcile with latest account during sync

### DIFF
--- a/src/renderer/bridge/BridgeSyncContext.js
+++ b/src/renderer/bridge/BridgeSyncContext.js
@@ -1,7 +1,8 @@
 // @flow
 
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { BridgeSync } from "@ledgerhq/live-common/lib/bridge/react";
+import { toAccountRaw } from "@ledgerhq/live-common/lib/account";
 import { useSelector, useDispatch } from "react-redux";
 import logger from "~/logger";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
@@ -10,16 +11,30 @@ import { recentlyChangedExperimental } from "~/renderer/experimental";
 import { recentlyKilledInternalProcess, onUnusualInternalProcessError } from "~/renderer/reset";
 import { track } from "~/renderer/analytics/segment";
 import { prepareCurrency, hydrateCurrency } from "./cache";
+import { hasOngoingSync } from "./proxy";
 import { blacklistedTokenIdsSelector } from "~/renderer/reducers/settings";
+import { command } from "~/renderer/commands";
 
 export const BridgeSyncProvider = ({ children }: { children: React$Node }) => {
   const accounts = useSelector(accountsSelector);
+  const accountsRef = useRef(accounts);
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
   const dispatch = useDispatch();
   const updateAccount = useCallback(
     (accountId, updater) => dispatch(updateAccountWithUpdater(accountId, updater)),
     [dispatch],
   );
+
+  // during ongoing sync, if an account is changed, we inform the internal process of its latest state to the sync can properly reconciliate
+  useEffect(() => {
+    accounts.forEach(account => {
+      const prev = accountsRef.current.find(a => a.id === account.id);
+      if (prev !== account && hasOngoingSync(account.id)) {
+        command("AccountSyncSet")({ account: toAccountRaw(account) }).subscribe();
+      }
+    });
+    accountsRef.current = accounts;
+  }, [accounts]);
 
   const recoverError = useCallback(error => {
     const isInternalProcessError = error && error.message.includes("Internal process error");


### PR DESCRIPTION
This deliver the 2nd suggested solution for the problem discussed in #3510. The benefit of this solution is it's a bit safer to take and it prevent likelihood of race condition on all currencies we have today, in case an account get modified during a AccountSync.

![Sans titre](https://user-images.githubusercontent.com/211411/105989885-046aab00-60a2-11eb-96d0-fd9975d2bb20.png)


Essentially, we add a new renderer->internal command called "AccountSyncSet" that is called when a sync is ongoing and each time the local state of renderer have an Account reference change. that gives opportunity to let internal being up to date with latest account state. NB: race condition still possible, but very unlikely (cmd runs very fast)

![Capture d’écran 2021-01-27 à 12 18 57](https://user-images.githubusercontent.com/211411/105984472-73dc9c80-609a-11eb-8e53-ffa7bd422e9f.png)



### Type

Bug fix

### Context

discussion with @rjarasson-ledger 

### Parts of the app affected / Test plan

account synchronisation for all accounts.
the race condition were not really causing problem in existing coins (afaik) but it will be important for the future.