### PR TITLE
fix(Polkadot): remove transferAmount in OperationsList - LL-4435

### DIFF
--- a/src/renderer/families/polkadot/operationDetails.js
+++ b/src/renderer/families/polkadot/operationDetails.js
@@ -278,32 +278,6 @@ type Props = {
   unit: Unit,
 };
 
-const TransferAmountCell = ({ operation, currency, unit }: Props) => {
-  const amount = new BigNumber(operation.extra ? operation.extra.transferAmount : 0);
-
-  return (
-    !amount.isZero() && (
-      <>
-        <FormattedVal
-          val={amount}
-          unit={unit}
-          showCode
-          fontSize={4}
-          color={"palette.text.shade80"}
-        />
-
-        <CounterValue
-          color="palette.text.shade60"
-          fontSize={3}
-          date={operation.date}
-          currency={currency}
-          value={amount}
-        />
-      </>
-    )
-  );
-};
-
 const BondAmountCell = ({ operation, currency, unit }: Props) => {
   const amount = new BigNumber(operation.extra ? operation.extra.bondedAmount : 0);
 
@@ -399,7 +373,6 @@ const NominateAmountCell = ({ operation, currency, unit }: Props) => {
 };
 
 const amountCellExtra = {
-  OUT: TransferAmountCell,
   BOND: BondAmountCell,
   UNBOND: UnbondAmountCell,
   NOMINATE: NominateAmountCell,


### PR DESCRIPTION
### Type

UI/UX Fix

### Context

For Polkadot, OUT operations (send) used to have a transfer amount column with a positive value in the Operations List.

It's been acted that this is not consistent with other coins.

This removes the amounts, and only let the effective transaction amount.

### Parts of the app affected / Test plan

BEFORE
![image](https://user-images.githubusercontent.com/70533374/107391909-73f88580-6af9-11eb-91e3-b6c58fe2bca9.png)


AFTER
Transfer Amount should not be present in OperationsList.

![image](https://user-images.githubusercontent.com/70533374/107391870-6ba04a80-6af9-11eb-8cae-ce4ca8dfa77f.png)

