### PR TITLE
COIN-1349 Update one help page URL for Polkadot

### DIFF
--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -102,7 +102,7 @@ export const urls = {
   algorandStakingRewards:
     "https://support.ledger.com/hc/en-us/articles/360015897740?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=algorand",
   polkadotFeesInfo:
-    "https://support.ledger.com/hc/en-us/articles/360018131220?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=polkadot",
+    "https://support.ledger.com/hc/en-us/articles/360016289919?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=polkadot",
   xpubLearnMore:
     "https://support.ledger.com/hc/en-us/articles/360011069619?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=edit_account",
 


### PR DESCRIPTION
Just a help page link update, according to change here : https://ledgerhq.atlassian.net/wiki/spaces/LCH/pages/2457665696/%5BDOT%5D+-+Links