### PR TITLE
LL-4603 [Windows] Fix `ledgerlive://` URI handling

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,13 @@
+!macro customInstall
+  DeleteRegKey SHELL_CONTEXT "Software\Classes\ledgerlive"
+  WriteRegStr SHELL_CONTEXT "Software\Classes\ledgerlive" "" "Ledger Live"
+  WriteRegStr SHELL_CONTEXT "Software\Classes\ledgerlive" "URL Protocol" ""
+  WriteRegStr SHELL_CONTEXT "Software\Classes\ledgerlive\DefaultIcon" "" "$appExe,0"
+  WriteRegStr SHELL_CONTEXT "Software\Classes\ledgerlive\shell" "" ""
+  WriteRegStr SHELL_CONTEXT "Software\Classes\ledgerlive\shell\open" "" ""
+  WriteRegStr SHELL_CONTEXT "Software\Classes\ledgerlive\shell\open\command" "" "$appExe %1"
+!macroend
+
+!macro customUnInstall
+  DeleteRegKey SHELL_CONTEXT "Software\Classes\ledgerlive"
+!macroend

--- a/src/renderer/hooks/useDeeplinking.js
+++ b/src/renderer/hooks/useDeeplinking.js
@@ -48,7 +48,7 @@ export function useDeepLinkHandler() {
     (event: any, deeplink: string) => {
       const { pathname, searchParams } = new URL(deeplink);
       const query = Object.fromEntries(searchParams);
-      const url = pathname.replace(/^\/+/, "");
+      const url = pathname.replace(/(^\/+|\/+$)/g, "");
 
       switch (url) {
         case "accounts":


### PR DESCRIPTION
Deep linking is not working on Windows, thus breaking the websocket bridge flow, because of the following:

- The `electron-builder` documentation is, surprising no-one, wrong and omits to say that the `protocol` configuration *only works on Mac* (you have to dig into their code to find out), so, as-is, the URI scheme doesn't get registered on the system at all.
- Our code fails to catch the deep links calls on Windows when the system sends them.
- The URI formatting, as sent by the system, is inconsistent between Mac and Windows as the latter adds a trailing slash.

This PR fixes these issues by adding a new NSIS script registering `ledgerlive://` URI scheme on install (and unregister it on uninstall), and rewriting deep link catching for win32.

### Beyond this PR

Digging through this issue, I found out deep linking is not implemented at all for Linux.
The handling part in our code should be trivial (same as win32 AFAIK), but registering the URI to an AppImage could be tricky though.

### Type

Bug Fix
(Feature?)

### Context

https://ledgerhq.atlassian.net/browse/LL-4603

### Parts of the app affected

- Windows installer and uninstaller
- Deep linking

### Test plan

Deep linking can only be tested on a _packaged_ application, and the scheme registration is done at install time, so the app has to be installed to be tested.

- [ ] https://ledger-live-tools.now.sh/bridgetest should _now_ work on Windows
- [ ] https://ledger-live-tools.now.sh/bridgetest should _still_ work on Mac

