### PR TITLE
Prevent console error when parsin the svg path

### DIFF
--- a/src/renderer/components/Onboarding/Screens/Tutorial/assets/AnimatedWave.js
+++ b/src/renderer/components/Onboarding/Screens/Tutorial/assets/AnimatedWave.js
@@ -20,7 +20,7 @@ export function AnimatedWave({ height, color }: Props) {
             V 0
             H 0
             V 0
-            Z;"
+            Z"
       >
         {!process.env.SPECTRON_RUN ? (
           <animate


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/108495161-bd3e9700-72a8-11eb-81a2-ad8c60739c22.png)

A path can't finish with a semicolon, which caused this initial rendering of the wave to trigger that error, the subsequently render the animated path. It didn't seem to cause any rendering problems from what I see, but it does log that error any time the wave is present, so a bit of code cleanup.


### Type

Code cleanup