### PR TITLE
inject sentry url env when doing a release build

### DIFF
--- a/tools/dist/index.js
+++ b/tools/dist/index.js
@@ -81,7 +81,13 @@ const buildTasks = args => [
         commands.push("electron-builder-nightly.yml");
       }
 
-      await exec("yarn", commands);
+      await exec("yarn", commands, {
+        env: args.publish
+          ? {
+              SENTRY_URL: "https://db8f5b9b021048d4a401f045371701cb@sentry.io/274561",
+            }
+          : {},
+      });
     },
   },
 ];


### PR DESCRIPTION
Apparently we did not resume the SENTRY_URL in production builds since v1.19.x (v2 FTW)

Only sets it back when doing `yarn release`

### Type

Build