### PR TITLE
LL-4576 (AccountScreen): header name overflowing issue

### DIFF
--- a/src/renderer/screens/account/AccountHeader.js
+++ b/src/renderer/screens/account/AccountHeader.js
@@ -76,6 +76,7 @@ const Wrapper = styled(Box)`
 `;
 
 const AccountNameBox = styled(Box)`
+  width: 100%;
   position: relative;
   left: -11px;
 `;
@@ -90,10 +91,11 @@ const AccountName = styled.input`
   border-radius: 4px;
   padding: 1px 9px 2px;
   max-width: 250px !important;
+  width: 100%;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  display: block;
+  display: inline-block;
   background-color: transparent;
 
   + svg {
@@ -113,7 +115,6 @@ const AccountName = styled.input`
     max-width: 190px !important;
     border-color: ${p => p.theme.colors.wallet};
     background: ${p => (p.theme.colors.palette.type === "light" ? "#fff" : "none")};
-    width: 250px;
 
     + svg {
       display: none;
@@ -219,7 +220,7 @@ const AccountHeader: React$ComponentType<Props> = React.memo(function AccountHea
         ) : (
           <CurName>{currency.name}</CurName>
         )}
-        <AccountNameBox horizontal alignItems="center" flow={2}>
+        <AccountNameBox horizontal alignItems="center" pr={3} flow={2}>
           <AccountName
             color="palette.text.shade100"
             disabled={account.type !== "Account"}

--- a/src/renderer/screens/account/AccountHeader.js
+++ b/src/renderer/screens/account/AccountHeader.js
@@ -220,7 +220,7 @@ const AccountHeader: React$ComponentType<Props> = React.memo(function AccountHea
         ) : (
           <CurName>{currency.name}</CurName>
         )}
-        <AccountNameBox horizontal alignItems="center" pr={3} flow={2}>
+        <AccountNameBox horizontal alignItems="center" pr={8} flow={2}>
           <AccountName
             color="palette.text.shade100"
             disabled={account.type !== "Account"}


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(AccountScreen): header name overflowing issue

![localhost_8080_webpack_index html_theme=null](https://user-images.githubusercontent.com/11752937/109311512-33617180-7846-11eb-8d8f-b4987c09718e.png)

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
UI Polish
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-4576
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Using french and a smaller screen you could have the name of the account overflow on the buttons next to it in the account page header. it should be fixed now event with long text buttons
