### PR TITLE
LL-4582 (EthInput): error and warning messages ellipsis issue

### DIFF
--- a/src/renderer/components/FeeSliderField.js
+++ b/src/renderer/components/FeeSliderField.js
@@ -34,6 +34,17 @@ const ErrorWrapper: ThemedComponent<{}> = styled.div`
   }
 `;
 
+const ErrorContainer = styled(Box)`
+  margin-top: 0px;
+  font-size: 12px;
+  width: 100%;
+  transition: all 0.4s ease-in-out;
+  will-change: max-height;
+  max-height: ${p => (p.hasError ? 60 : 0)}px;
+  min-height: ${p => (p.hasError ? 20 : 0)}px;
+  overflow: hidden;
+`;
+
 const Holder = styled.div`
   font-family: Inter;
   font-weight: 500;
@@ -101,14 +112,16 @@ const FeeSliderField = ({ range, value, onChange, unit, error, defaultValue }: P
           <Trans i18nKey="fees.fast" />
         </Text>
       </Box>
-      {error && (
-        <ErrorWrapper>
-          <IconExclamationCircle size={12} />
-          <Box color="alertRed" ff="Inter|Regular" fontSize={4} textAlign="center">
-            <TranslatedError error={error} />
-          </Box>
-        </ErrorWrapper>
-      )}
+      <ErrorContainer hasError={error}>
+        {error ? (
+          <ErrorWrapper>
+            <IconExclamationCircle size={12} />
+            <Box flex="1" color="alertRed" ff="Inter|Regular" fontSize={4} textAlign="left">
+              <TranslatedError error={error} />
+            </Box>
+          </ErrorWrapper>
+        ) : null}
+      </ErrorContainer>
     </GenericContainer>
   );
 };

--- a/src/renderer/components/Input.js
+++ b/src/renderer/components/Input.js
@@ -7,7 +7,6 @@ import noop from "lodash/noop";
 import fontFamily from "~/renderer/styles/styled/fontFamily";
 import Spinner from "~/renderer/components/Spinner";
 import Box from "~/renderer/components/Box";
-import Ellipsis from "~/renderer/components/Ellipsis";
 import TranslatedError from "~/renderer/components/TranslatedError";
 import Text from "~/renderer/components/Text";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
@@ -77,13 +76,23 @@ const Container = styled(Box).attrs(() => ({
     }`}
 `;
 
-const ErrorDisplay = styled(Box)`
-  position: absolute;
-  bottom: -20px;
-  left: 0px;
+const ErrorContainer = styled(Box)`
+  margin-top: 0px;
   font-size: 12px;
   width: 100%;
+  transition: all 0.4s ease-in-out;
+  will-change: max-height;
+  max-height: ${p => (p.hasError ? 60 : 0)}px;
+  min-height: ${p => (p.hasError ? 20 : 0)}px;
+  overflow: hidden;
+`;
+
+const ErrorDisplay = styled(Box)`
   color: ${p => p.theme.colors.pearl};
+`;
+
+const WarningDisplay = styled(Box)`
+  color: ${p => p.theme.colors.warning};
 `;
 
 const LoadingDisplay = styled(Box)`
@@ -101,10 +110,6 @@ const LoadingDisplay = styled(Box)`
   > :first-child {
     margin-right: 10px;
   }
-`;
-
-const WarningDisplay = styled(ErrorDisplay)`
-  color: ${p => p.theme.colors.warning};
 `;
 
 const Base = styled.input.attrs(() => ({
@@ -244,21 +249,20 @@ const Input = React.forwardRef(function Input(
           onChange={handleChange}
           onKeyDown={handleKeyDown}
         />
-        {!hideErrorMessage ? (
-          error ? (
-            <ErrorDisplay id="input-error">
-              <Ellipsis>
+
+        <ErrorContainer hasError={!hideErrorMessage && (error || warning)}>
+          {!hideErrorMessage ? (
+            error ? (
+              <ErrorDisplay id="input-error">
                 <TranslatedError error={error} />
-              </Ellipsis>
-            </ErrorDisplay>
-          ) : warning ? (
-            <WarningDisplay id="input-warning">
-              <Ellipsis>
+              </ErrorDisplay>
+            ) : warning ? (
+              <WarningDisplay id="input-warning">
                 <TranslatedError error={warning} />
-              </Ellipsis>
-            </WarningDisplay>
-          ) : null
-        ) : null}
+              </WarningDisplay>
+            ) : null
+          ) : null}
+        </ErrorContainer>
         {loading && !isFocus ? (
           <LoadingDisplay>
             <Spinner size={16} color="palette.text.shade50" />

--- a/src/renderer/families/ethereum/GasLimitField.js
+++ b/src/renderer/families/ethereum/GasLimitField.js
@@ -46,7 +46,7 @@ const AdvancedOptions = ({ onChange, account, transaction, status }: Props) => {
           </span>
         </Label>
       </Box>
-      <Box grow>
+      <Box flex="1">
         <Input
           ff="Inter"
           warning={gasLimitWarning}


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(EthInput): error and warning messages ellipsis issue

![localhost_8080_webpack_index html_theme=null](https://user-images.githubusercontent.com/11752937/109507932-8eda6c00-7a9f-11eb-8027-6df1bb44b1da.png)


### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
UI Polish
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-4582
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Eth gas limit and gas price warning messages should not be cropped anymore.
