### PR TITLE
fix(OperationList): avoid AccountCell to be shrinked if no address - …

### DIFF
--- a/src/renderer/components/OperationsList/AddressCell.js
+++ b/src/renderer/components/OperationsList/AddressCell.js
@@ -71,6 +71,9 @@ export const Cell: ThemedComponent<{ px?: number }> = styled(Box).attrs(p => ({
   alignItems: "center",
 }))`
   width: 150px;
+  flex-grow: 1;
+  flex-shrink: 1;
+  display: block;
 `;
 
 type Props = {
@@ -81,18 +84,17 @@ class AddressCell extends PureComponent<Props> {
   render() {
     const { operation } = this.props;
 
-    return (
-      <Cell grow shrink style={{ display: "block" }}>
-        <Address
-          value={
-            operation.type === "IN" ||
-            operation.type === "REVEAL" ||
-            operation.type === "REWARD_PAYOUT"
-              ? operation.senders[0]
-              : operation.recipients[0]
-          }
-        />
+    const value =
+      operation.type === "IN" || operation.type === "REVEAL" || operation.type === "REWARD_PAYOUT"
+        ? operation.senders[0]
+        : operation.recipients[0];
+
+    return value ? (
+      <Cell>
+        <Address value={value} />
       </Cell>
+    ) : (
+      <Box flex={1} />
     );
   }
 }


### PR DESCRIPTION
fix https://ledgerhq.atlassian.net/browse/LL-4687

![image](https://user-images.githubusercontent.com/70533374/109632056-ee3f8700-7b46-11eb-9705-ef1885cba11a.png)

### Type

UI Polish

### Context

When no address is in operation (empty), the AddressCell takes a 150px minimum width, shrinking other columns like AccountCell.

This PR should avoid AddressCell to shrink other Columns (only take space if there is room to take for spacing).

![image](https://user-images.githubusercontent.com/70533374/109632423-51311e00-7b47-11eb-84a3-be681f169033.png)

### Parts of the app affected / Test plan

OperationList in Portfolio and on Account operation history.
