### PR TITLE
fix(Polkadot): Nominations - useDiscreetMode and round value to avoid leak

### DIFF
--- a/src/renderer/families/polkadot/Nomination/Header.js
+++ b/src/renderer/families/polkadot/Nomination/Header.js
@@ -20,13 +20,13 @@ export const TableLine: ThemedComponent<{}> = styled(Box).attrs(() => ({
   alignItems: "center",
   justifyContent: "flex-start",
   fontSize: 3,
-  flex: 1.125,
+  flex: 1,
+  shrink: 1,
   pr: 2,
 }))`
   box-sizing: border-box;
   &:last-child {
     justify-content: flex-end;
-    flex: 0.5;
     text-align: right;
     white-space: nowrap;
   }

--- a/src/renderer/families/polkadot/Nomination/Row.js
+++ b/src/renderer/families/polkadot/Nomination/Row.js
@@ -1,5 +1,4 @@
 // @flow
-
 import React, { useCallback, useMemo } from "react";
 import styled from "styled-components";
 import { Trans } from "react-i18next";
@@ -19,6 +18,7 @@ import type { Account } from "@ledgerhq/live-common/lib/types";
 
 import { TableLine } from "./Header";
 
+import { useDiscreetMode } from "~/renderer/components/Discreet";
 import Box from "~/renderer/components/Box/Box";
 import CheckCircle from "~/renderer/icons/CheckCircle";
 import ClockIcon from "~/renderer/icons/Clock";
@@ -93,6 +93,7 @@ export function Row({
   validator,
   onExternalLink,
 }: Props) {
+  const discreet = useDiscreetMode();
   const name = validator?.identity || address;
   const total = validator?.totalBonded ?? null;
   const commission = validator?.commission ?? null;
@@ -102,12 +103,13 @@ export function Row({
     () =>
       value && (status === "active" || status === "inactive")
         ? formatCurrencyUnit(unit, value, {
-            disableRounding: true,
+            disableRounding: false,
             alwaysShowSign: false,
             showCode: true,
+            discreet: discreet && status === "active",
           })
         : "-",
-    [status, unit, value],
+    [status, unit, value, discreet],
   );
 
   const formattedTotal = useMemo(


### PR DESCRIPTION
fixes https://ledgerhq.atlassian.net/browse/LL-4691 and https://ledgerhq.atlassian.net/browse/LL-4689

### Type

UI Polish

### Context
On Polkadot Nominations list, if a nomination is active, bonded amount should be *** if discreet mode is active.
If nomination is inactive, bonded amount = 0 DOT, so it's displayed (not ***-ed) to give information about why it is inactive.

Also fixes Amount leaking on other column by allowing rounding (bonded amount is not useful to be precise).

### Parts of the app affected / Test plan

In Polkadot, Nominations list but if there are active nominations.
