### PR TITLE
feat(ReadOnlyAddressField): ensure address last line has MINLENGTH (5 chars) - LL-4656

### DIFF
--- a/src/renderer/components/ReadOnlyAddressField.js
+++ b/src/renderer/components/ReadOnlyAddressField.js
@@ -6,6 +6,8 @@ import styled from "styled-components";
 import Box from "~/renderer/components/Box";
 import IconCopy from "~/renderer/icons/Copy";
 
+const LINE_MINLENGTH = 5; // Minimum of chars for the last line (if multiline)
+
 const Address = styled(Box).attrs(() => ({
   bg: "palette.background.default",
   borderRadius: 1,
@@ -24,11 +26,19 @@ const Address = styled(Box).attrs(() => ({
   border-bottom-right-radius: 0;
 `
       : ""}
-  cursor: text;
-  user-select: text;
+
   text-align: center;
   flex: 1;
+`;
+
+const AddressWrapper = styled.span`
+  cursor: text;
+  user-select: text;
   word-break: break-all;
+
+  span:last-child {
+    word-break: keep-all;
+  }
 `;
 
 const CopyFeedback = styled(Box).attrs(() => ({
@@ -96,6 +106,12 @@ function ReadOnlyAddressField({ address, allowCopy = true }: Props) {
     };
   }, []);
 
+  // Split address into multiple segments - last can't breakline.
+  const addressSegments = [
+    address.substr(0, address.length - LINE_MINLENGTH),
+    address.substr(-LINE_MINLENGTH),
+  ];
+
   return (
     <Box vertical>
       {clibboardChanged ? (
@@ -110,7 +126,10 @@ function ReadOnlyAddressField({ address, allowCopy = true }: Props) {
               <Trans i18nKey="common.addressCopied" />
             </CopyFeedback>
           )}
-          {address}
+          <AddressWrapper>
+            <span>{addressSegments[0]}</span>
+            <span>{addressSegments[1]}</span>
+          </AddressWrapper>
         </Address>
         {allowCopy ? (
           <CopyBtn onClick={onCopy}>


### PR DESCRIPTION
### Type

UI Polish

### Context

When displaying the device address in the Receive Flow (also used in Exchange Device Confirm), long address can break line arbitrarily.

We want to avoid adresses to break line with too fews characters on a second line (can be misleading or look like a bug).

This fix ensures at least 5 chars are display if address breaks line. It won't break at all if there is enough room.

### Parts of the app affected / Test plan

On Receive Flow:
* address with enough room
![image](https://user-images.githubusercontent.com/70533374/110002515-c3575d80-7d15-11eb-9364-cfae487729ef.png)

* address breaking line
![image](https://user-images.githubusercontent.com/70533374/110002310-88552a00-7d15-11eb-87bb-6ecd8b744f06.png)

* address breaking line (simulate very long address):
![image](https://user-images.githubusercontent.com/70533374/110002721-031e4500-7d16-11eb-93ce-9956e23e5779.png)
