### PR TITLE
disable analytics on mock or spectron runs

### DIFF
--- a/src/renderer/analytics/inject-in-window.js
+++ b/src/renderer/analytics/inject-in-window.js
@@ -1,4 +1,41 @@
 /* eslint-disable no-unused-expressions */
-// prettier-ignore
-!function(){const analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){const e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(let t=0;t<analytics.methods.length;t++){const e=analytics.methods[t];analytics[e]=analytics.factory(e)};analytics.SNIPPET_VERSION="4.1.0";
-}}();
+!(function() {
+  const analytics = (window.analytics = window.analytics || []);
+  if (!analytics.initialize)
+    if (analytics.invoked)
+      window.console && console.error && console.error("Segment snippet included twice.");
+    else {
+      analytics.invoked = !0;
+      analytics.methods = [
+        "trackSubmit",
+        "trackClick",
+        "trackLink",
+        "trackForm",
+        "pageview",
+        "identify",
+        "reset",
+        "group",
+        "track",
+        "ready",
+        "alias",
+        "debug",
+        "page",
+        "once",
+        "off",
+        "on",
+      ];
+      analytics.factory = function(t) {
+        return function() {
+          const e = Array.prototype.slice.call(arguments);
+          e.unshift(t);
+          analytics.push(e);
+          return analytics;
+        };
+      };
+      for (let t = 0; t < analytics.methods.length; t++) {
+        const e = analytics.methods[t];
+        analytics[e] = analytics.factory(e);
+      }
+      analytics.SNIPPET_VERSION = "4.1.0";
+    }
+})();

--- a/src/renderer/analytics/segment.js
+++ b/src/renderer/analytics/segment.js
@@ -69,7 +69,7 @@ const extraProperties = store => {
 let storeInstance; // is the redux store. it's also used as a flag to know if analytics is on or off.
 
 export const start = async (store: *) => {
-  if (!user) return;
+  if (!user || process.env.MOCK || process.env.SPECTRON_RUN) return;
   const { id } = await user();
   logger.analyticsStart(id, extraProperties(store));
   storeInstance = store;


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
disable analytics on mock or spectron runs
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug fix
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
slack reported
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
analytics on test run should no longer be initialized and send events
