### PR TITLE
DOT: Add errors translates

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -3308,8 +3308,14 @@
     "PolkadotNoNominations": {
       "title": "You have no nominations"
     },
-    "PolkadotBondAllFundsWarning": {
-      "title": "You will not have available balance for future transactions"
+    "PolkadotAllFundsWarning": {
+      "title": "You will not have any available balance for future transactions"
+    },
+    "PolkadotReapingAccountWarning": {
+      "title": "After Send max, only the receive operation is possible"
+    },
+    "PolkadotDoMaxSendInstead": {
+      "title": "The outcome of this operation will be too low if it is done manually. Please use Send max instead"
     },
     "PolkadotBondMinimumAmount": {
       "title": "You must bond at least 1 DOT"


### PR DESCRIPTION
### Type

New Translations

### Context

When an user want to SEND MAX:
* If the user has bonded balance -  all remaining funds will put the available balance to zero, not allowing it to pay fees for future transactions. It must display a **warning** for `PolkadotAllFundsWarning`
* If the user has no bonded balance, we will now do a "transfer" without keep alive. ~It must display a **warning** about reaping for `PolkadotReapingAccountWarning`.~ It should not display any warning.

When an user want to SEND (not max):
* if user has bonded funds, but enters an amount putting the available balance below a defined threshold (we set 0.1 DOT), he may not be able to pay fees for future transactions. It must also display a **warning** for `PolkadotAllFundsWarning`
* if user don't have bonded balance, but enters an amount putting remaining balance below the existential, it would burn the remaining funds. It must prevent the transaction and display an **error** for `PolkadotDoMaxSendInstead`

### TODO

Wording is not definitive.

* PolkadotAllFundsWarning: TO BE DEFINED
* PolkadotReapingAccountWarning: TO BE DEFINED
* PolkadotDoMaxSendInstead: TO BE DEFINED

### Parts of the app affected / Test plan

The Send flow for Polkadot.

Check all possible use case defined above, but also working use cases too since existential deposit logic is no longer used.
