### PR TITLE
Add missing wording incorrectly dropped on cleanup

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -918,6 +918,9 @@
       "noOperationOnLastAccount": "Can't add a new account before you've received assets on your <1><0>{{accountName}}</0></1> account",
       "noAccountToCreate": "No <1><0>{{currencyName}}</0></1> account was found to be created"
     },
+    "supportLinks": {
+      "segwit_or_native_segwit": "Segwit or Native Segwit?"
+    }
     "cta": {
       "addMore": "Add more",
       "add": "Add account",


### PR DESCRIPTION
During the pr for dropping all unused literals we regularly do, this was incorrectly dropped (even though I manually went over all wordings) since it comes from a live-common. I missed it, we missed it. It's there.

https://ledgerhq.atlassian.net/browse/LL-4882