### PR TITLE
fix: Add missing comma in en i18n json file

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -922,7 +922,7 @@
     },
     "supportLinks": {
       "segwit_or_native_segwit": "Segwit or Native Segwit?"
-    }
+    },
     "cta": {
       "addMore": "Add more",
       "add": "Add account",


### PR DESCRIPTION
Add a missing comma in the `static/i18n/en/app.json` file.

### Type

Bug Fix

### Context

A comma was missing in the english i18n json file, resulting in an error when starting the app.

PS: I couldn't find contributor guidelines so apologies in advance if I am not following recommended procedure.