### PR TITLE
LL-2886 fix behaviour on firmware update when user cancels

### DIFF
--- a/src/renderer/Default.js
+++ b/src/renderer/Default.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { useEffect, useRef } from "react";
-import { Route, Switch, useLocation } from "react-router-dom";
+import { Redirect, Route, Switch, useLocation } from "react-router-dom";
 import TrackAppStart from "~/renderer/components/TrackAppStart";
 import { BridgeSyncProvider } from "~/renderer/bridge/BridgeSyncContext";
 import { SyncNewAccounts } from "~/renderer/bridge/SyncNewAccounts";
@@ -98,6 +98,7 @@ export default function Default() {
                     <Route path="/" exact render={props => <Dashboard {...props} />} />
                     <Route path="/settings" render={props => <Settings {...props} />} />
                     <Route path="/accounts" render={props => <Accounts {...props} />} />
+                    <Redirect from="/manager/reload" to="manager" />
                     <Route path="/manager" render={props => <Manager {...props} />} />
                     <Route path="/lend" render={props => <Lend {...props} />} />
                     <Route path="/exchange" render={props => <Exchange {...props} />} />

--- a/src/renderer/components/DeviceAction/rendering.js
+++ b/src/renderer/components/DeviceAction/rendering.js
@@ -286,15 +286,17 @@ export const renderError = ({
   withExportLogs,
   list,
   supportLink,
+  warning,
 }: {
   error: Error,
   onRetry?: () => void,
   withExportLogs?: boolean,
   list?: boolean,
   supportLink?: string,
+  warning?: boolean,
 }) => (
   <Wrapper id={`error-${error.name}`}>
-    <Logo>
+    <Logo warning={warning}>
       <ErrorIcon size={44} error={error} />
     </Logo>
     <ErrorTitle>

--- a/src/renderer/components/ErrorDisplay.js
+++ b/src/renderer/components/ErrorDisplay.js
@@ -7,9 +7,17 @@ export type ErrorDisplayProps = {
   withExportLogs?: boolean,
   list?: boolean,
   supportLink?: string,
+  warning?: boolean,
 };
 
-const ErrorDisplay = ({ error, onRetry, withExportLogs, list, supportLink }: ErrorDisplayProps) =>
-  renderError({ error, onRetry, withExportLogs, list, supportLink });
+const ErrorDisplay = ({
+  error,
+  onRetry,
+  withExportLogs,
+  list,
+  supportLink,
+  warning,
+}: ErrorDisplayProps) =>
+  renderError({ error, onRetry, withExportLogs, list, supportLink, warning });
 
 export default ErrorDisplay;

--- a/src/renderer/components/ErrorIcon.js
+++ b/src/renderer/components/ErrorIcon.js
@@ -1,6 +1,7 @@
 // @flow
 import React from "react";
 import ExclamationCircleThin from "~/renderer/icons/ExclamationCircleThin";
+import Warning from "~/renderer/icons/TriangleWarning";
 import CrossCircle from "~/renderer/icons/CrossCircle";
 import Lock from "~/renderer/icons/LockCircle";
 
@@ -23,8 +24,9 @@ const ErrorIcon = ({ error, size = 44 }: ErrorIconProps) => {
   switch (true) {
     case !error:
       return null;
-    case error instanceof UserRefusedAllowManager:
     case error instanceof UserRefusedFirmwareUpdate:
+      return <Warning size={size} />;
+    case error instanceof UserRefusedAllowManager:
     case error instanceof UserRefusedOnDevice:
     case error instanceof UserRefusedAddress:
     case error instanceof SwapGenericAPIError:

--- a/src/renderer/components/Stepper/index.js
+++ b/src/renderer/components/Stepper/index.js
@@ -38,6 +38,7 @@ type Props<T, StepProps> = {
   signed?: boolean,
   children?: React$Node,
   params?: any,
+  hideCloseButton?: boolean,
 };
 
 const Stepper = <T, StepProps>({
@@ -51,6 +52,7 @@ const Stepper = <T, StepProps>({
   disabledSteps,
   errorSteps,
   children,
+  hideCloseButton,
   ...props
 }: Props<T, StepProps>) => {
   const deviceBlocked = useDeviceBlocked();
@@ -93,7 +95,7 @@ const Stepper = <T, StepProps>({
   return (
     <ModalBody
       refocusWhenChange={stepId}
-      onClose={deviceBlocked ? undefined : onClose}
+      onClose={hideCloseButton || deviceBlocked ? undefined : onClose}
       onBack={onBack && !deviceBlocked ? () => onBack(stepProps) : undefined}
       title={title}
       noScroll={noScroll}

--- a/src/renderer/modals/UpdateFirmwareModal/index.js
+++ b/src/renderer/modals/UpdateFirmwareModal/index.js
@@ -31,6 +31,7 @@ export type StepProps = {
   deviceInfo: DeviceInfo,
   t: TFunction,
   transitionTo: string => void,
+  onRetry: () => void,
 };
 
 export type StepId = "idCheck" | "updateMCU" | "updating" | "finish" | "resetDevice";
@@ -174,6 +175,7 @@ const UpdateModal = ({
     firmware,
     error: err,
     deviceModelId,
+    onRetry: handleReset,
   };
 
   return (

--- a/src/renderer/modals/UpdateFirmwareModal/index.js
+++ b/src/renderer/modals/UpdateFirmwareModal/index.js
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { TFunction } from "react-i18next";
 import { log } from "@ledgerhq/logs";
 import type { DeviceModelId } from "@ledgerhq/devices";
+import { UserRefusedFirmwareUpdate } from "@ledgerhq/errors";
 import type { DeviceInfo, FirmwareUpdateContext } from "@ledgerhq/live-common/lib/types/manager";
 import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import { hasFinalFirmware } from "@ledgerhq/live-common/lib/hw/hasFinalFirmware";
@@ -199,6 +200,9 @@ const UpdateModal = ({
           errorSteps={errorSteps}
           deviceModelId={deviceModelId}
           onClose={() => onClose()}
+          hideCloseButton={
+            stepId === "finish" && !!error && error instanceof UserRefusedFirmwareUpdate
+          }
         >
           <HookMountUnmount onMountUnmount={setFirmwareUpdateOpened} />
         </Stepper>

--- a/src/renderer/modals/UpdateFirmwareModal/steps/03-step-confirmation.js
+++ b/src/renderer/modals/UpdateFirmwareModal/steps/03-step-confirmation.js
@@ -77,7 +77,7 @@ export const StepConfirmFooter = ({
   const onCloseReload = useCallback(() => {
     onCloseModal();
     if (error instanceof UserRefusedFirmwareUpdate) {
-      history.replace("/manager");
+      history.push("/manager/reload");
     }
   }, [error, history, onCloseModal]);
 

--- a/src/renderer/modals/UpdateFirmwareModal/steps/03-step-confirmation.js
+++ b/src/renderer/modals/UpdateFirmwareModal/steps/03-step-confirmation.js
@@ -1,10 +1,11 @@
 // @flow
 
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import { log } from "@ledgerhq/logs";
 import { UserRefusedFirmwareUpdate } from "@ledgerhq/errors";
+import { useHistory } from "react-router-dom";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Track from "~/renderer/analytics/Track";
 import Box from "~/renderer/components/Box";
@@ -71,6 +72,15 @@ export const StepConfirmFooter = ({
   onRetry,
 }: StepProps) => {
   const { t } = useTranslation();
+  const history = useHistory();
+
+  const onCloseReload = useCallback(() => {
+    onCloseModal();
+    if (error instanceof UserRefusedFirmwareUpdate) {
+      history.replace("/manager");
+    }
+  }, [error, history, onCloseModal]);
+
   if (error) {
     const isUserRefusedFirmwareUpdate = error instanceof UserRefusedFirmwareUpdate;
     return (
@@ -78,7 +88,7 @@ export const StepConfirmFooter = ({
         <Button
           id="firmware-update-completed-close-button"
           primary={!isUserRefusedFirmwareUpdate}
-          onClick={() => onCloseModal()}
+          onClick={onCloseReload}
         >
           {t("common.close")}
         </Button>

--- a/src/renderer/modals/UpdateFirmwareModal/steps/03-step-confirmation.js
+++ b/src/renderer/modals/UpdateFirmwareModal/steps/03-step-confirmation.js
@@ -4,6 +4,7 @@ import React, { useEffect } from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import { log } from "@ledgerhq/logs";
+import { UserRefusedFirmwareUpdate } from "@ledgerhq/errors";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Track from "~/renderer/analytics/Track";
 import Box from "~/renderer/components/Box";
@@ -34,7 +35,14 @@ const StepConfirmation = ({ error, appsToBeReinstalled }: StepProps) => {
   useEffect(() => () => log("firmware-record-end"), []);
 
   if (error) {
-    return <ErrorDisplay error={error} withExportLogs />;
+    const isUserRefusedFirmwareUpdate = error instanceof UserRefusedFirmwareUpdate;
+    return (
+      <ErrorDisplay
+        error={error}
+        warning={isUserRefusedFirmwareUpdate}
+        withExportLogs={!isUserRefusedFirmwareUpdate}
+      />
+    );
   }
 
   return (
@@ -56,13 +64,30 @@ const StepConfirmation = ({ error, appsToBeReinstalled }: StepProps) => {
   );
 };
 
-export const StepConfirmFooter = ({ onCloseModal, error, appsToBeReinstalled }: StepProps) => {
+export const StepConfirmFooter = ({
+  onCloseModal,
+  error,
+  appsToBeReinstalled,
+  onRetry,
+}: StepProps) => {
   const { t } = useTranslation();
   if (error) {
+    const isUserRefusedFirmwareUpdate = error instanceof UserRefusedFirmwareUpdate;
     return (
-      <Button id="firmware-update-completed-close-button" primary onClick={() => onCloseModal()}>
-        {t("common.close")}
-      </Button>
+      <>
+        <Button
+          id="firmware-update-completed-close-button"
+          primary={!isUserRefusedFirmwareUpdate}
+          onClick={() => onCloseModal()}
+        >
+          {t("common.close")}
+        </Button>
+        {isUserRefusedFirmwareUpdate ? (
+          <Button id="firmware-update-completed-restart-button" primary onClick={() => onRetry()}>
+            {t("manager.modal.cancelReinstallCTA")}
+          </Button>
+        ) : null}
+      </>
     );
   }
 

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -1187,6 +1187,7 @@
       "successTextNoApps": "You can now install apps on your device",
       "sucessCTAApps": "Re-install apps",
       "SuccessCTANoApps": "Install apps",
+      "cancelReinstallCTA": "Install update",
       "resetSteps": {
         "first": "1. Reset your device",
         "connect": "Connect the {{deviceName}} to your computer using the USB cable.",
@@ -3146,8 +3147,8 @@
       "title": "Manager denied on device"
     },
     "UserRefusedFirmwareUpdate": {
-      "title": "Update cancelled",
-      "description": "Please retry or contact Ledger Support"
+      "title": "Update cancelled on device",
+      "description": "All apps on your device have been uninstalled. Keep your device up to date to benefit from improvements in security and functionality."
     },
     "UserRefusedOnDevice": {
       "title": "Action rejected",


### PR DESCRIPTION
Slightly change the rendering behaviour on error during firmware update when user cancels

### Type

Fix

### Context

LL-2886

### Parts of the app affected / Test plan

Modal Firmware Update

![image](https://user-images.githubusercontent.com/671786/112165872-6c93c400-8bef-11eb-99bc-1182659582a5.png)

