### PR TITLE
fix(errors): add en translation for InvalidServerError - LL-4886

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -3005,6 +3005,10 @@
       "title": "Sorry, {{currencyName}} services unavailable",
       "description": "Please retry or contact Ledger Support"
     },
+    "InvalidServerResponse": {
+      "title": "Sorry, something went wrong",
+      "description": "Could not handle server response. Please retry or contact Ledger Support"
+    },
     "ManagerAppAlreadyInstalled": {
       "title": "Sorry, that's already installed",
       "description": "Please check which apps are already installed on your device."


### PR DESCRIPTION
fixes https://ledgerhq.atlassian.net/browse/LL-4853
address issue https://github.com/LedgerHQ/ledger-live-desktop/issues/3651

### Type

Translation Key

### Context

Wording for error "InvalidServerResponse" in https://github.com/LedgerHQ/ledger-live-common/pull/1128

### Parts of the app affected / Test plan

Only ethereum sync error atm.

Set the EXPLORER env variable to something not responding with correct JSON using https://run.mocky.io/
```
EXPLORER=https://run.mocky.io/v3/89a32b62-c7a6-42ff-b766-add526c9cf04 yarn start
```
Ethereum should have a more generic error instead of "Unexpected '<'".

![image](https://user-images.githubusercontent.com/70533374/113122954-6a93bb80-9214-11eb-87a6-f7a08f00e03e.png)

