### PR TITLE
Ellipsis for extra fields in operation details

### DIFF
--- a/src/renderer/modals/OperationDetails/index.js
+++ b/src/renderer/modals/OperationDetails/index.js
@@ -570,7 +570,9 @@ const OperationDetailsExtra = ({ extra }: OperationDetailsExtraProps) => {
       <OpDetailsTitle>
         <Trans i18nKey={`operationDetails.extra.${key}`} defaults={key} />
       </OpDetailsTitle>
-      <OpDetailsData>{value}</OpDetailsData>
+      <OpDetailsData>
+        <Ellipsis>{value}</Ellipsis>
+      </OpDetailsData>
     </Box>
   ));
 };


### PR DESCRIPTION
In operation details, extra fields may overflow when too long.
This PR just sets an Ellipsis on them.

Example with Stellar memo:
![image](https://user-images.githubusercontent.com/59644786/113173285-836a9400-9249-11eb-9b2f-fa9914422cb9.png)
