### PR TITLE
LL-4825 - fix(Buy): update without my device button UI + wording

### DIFF
--- a/src/renderer/modals/ExchangeDeviceConfirm/index.js
+++ b/src/renderer/modals/ExchangeDeviceConfirm/index.js
@@ -228,6 +228,8 @@ const StepConnectDeviceFooter = ({ data, onClose, onSkipDevice }: PropsFooter) =
     <Box horizontal flow={2}>
       <TrackPage category="Buy Flow" name="Step 1" />
       <Button
+        primary
+        inverted
         event="Buy Flow Without Device Clicked"
         id={"buy-connect-device-skip-device-button"}
         onClick={() => {

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -1315,9 +1315,9 @@
     "title": "Buy",
     "titleCrypto": "Buy {{currency}}",
     "buyCTA": "Buy {{currencyTicker}}",
-    "withoutDevice": "Don't have your device?",
+    "withoutDevice": "Continue without my device",
     "connectWithoutDevice": "It's better to use your device for optimal security.",
-    "skipConnect": "Continue without device"
+    "skipConnect": "Continue without my device"
   },
   "sell": {
     "title": "Sell",


### PR DESCRIPTION

### Type

UI Polish

### Context

Re-align "Buy without my device" button with figma.

*NOTE: The button uses a "primary inverted" variant, that looks strange in dark modes.*
Button component should be redesign to have some "transparent" variant instead of "inverted" for better integration.

ticket: https://ledgerhq.atlassian.net/browse/LL-4825
figma: https://www.figma.com/file/b0h2ODfRlIp8yNnoCQUG7c/Buy-%26-Sell---LLD?node-id=26%3A11463

### Parts of the app affected / Test plan
Light mode:
![image](https://user-images.githubusercontent.com/70533374/113418678-3e1fa100-93c6-11eb-8776-4e710a9a18a2.png)


Dark mode:
![image](https://user-images.githubusercontent.com/70533374/113418535-f8fb6f00-93c5-11eb-89d6-16190ec0bdd5.png)