### PR TITLE
LL-5305 - add currencyName in Send and Receive flow

### DIFF
--- a/src/renderer/modals/Receive/Body.js
+++ b/src/renderer/modals/Receive/Body.js
@@ -9,6 +9,7 @@ import { SyncSkipUnderPriority } from "@ledgerhq/live-common/lib/bridge/react";
 import Track from "~/renderer/analytics/Track";
 import type { Account, TokenCurrency, AccountLike } from "@ledgerhq/live-common/lib/types";
 import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
+import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { accountsSelector } from "~/renderer/reducers/accounts";
 import { closeModal } from "~/renderer/actions/modals";
@@ -69,6 +70,7 @@ export type StepProps = {
   onChangeAccount: (account: ?AccountLike, tokenAccount: ?Account) => void,
   onChangeAddressVerified: (?boolean, ?Error) => void,
   onClose: () => void,
+  currencyName: ?string,
 };
 
 export type St = Step<StepId, StepProps>;
@@ -127,6 +129,7 @@ const Body = ({
   const [parentAccount, setParentAccount] = useState(() => params && params.parentAccount);
   const [disabledSteps, setDisabledSteps] = useState([]);
   const [token, setToken] = useState(null);
+  const [currencyName, setCurrencyName] = useState("");
 
   const handleChangeAccount = useCallback(
     (account, parentAccount) => {
@@ -175,6 +178,20 @@ const Body = ({
     }
   }, [accounts, account, params, handleChangeAccount]);
 
+  useEffect(() => {
+    if (account) {
+      const currency = getAccountCurrency(account);
+
+      const currencyName = currency
+        ? currency.type === "TokenCurrency"
+          ? currency.parentCurrency.name
+          : currency.name
+        : undefined;
+
+      setCurrencyName(currencyName);
+    }
+  }, [account]);
+
   const errorSteps = verifyAddressError ? [2] : [];
 
   const stepperProps = {
@@ -201,6 +218,7 @@ const Body = ({
     onChangeAddressVerified,
     onStepChange: handleStepChange,
     onClose: handleCloseModal,
+    currencyName,
   };
 
   return (

--- a/src/renderer/modals/Receive/Body.js
+++ b/src/renderer/modals/Receive/Body.js
@@ -129,7 +129,13 @@ const Body = ({
   const [parentAccount, setParentAccount] = useState(() => params && params.parentAccount);
   const [disabledSteps, setDisabledSteps] = useState([]);
   const [token, setToken] = useState(null);
-  const [currencyName, setCurrencyName] = useState("");
+
+  const currency = getAccountCurrency(account);
+  const currencyName = currency
+    ? currency.type === "TokenCurrency"
+      ? currency.parentCurrency.name
+      : currency.name
+    : undefined;
 
   const handleChangeAccount = useCallback(
     (account, parentAccount) => {
@@ -177,20 +183,6 @@ const Body = ({
       }
     }
   }, [accounts, account, params, handleChangeAccount]);
-
-  useEffect(() => {
-    if (account) {
-      const currency = getAccountCurrency(account);
-
-      const currencyName = currency
-        ? currency.type === "TokenCurrency"
-          ? currency.parentCurrency.name
-          : currency.name
-        : undefined;
-
-      setCurrencyName(currencyName);
-    }
-  }, [account]);
 
   const errorSteps = verifyAddressError ? [2] : [];
 

--- a/src/renderer/modals/Receive/Body.js
+++ b/src/renderer/modals/Receive/Body.js
@@ -131,11 +131,7 @@ const Body = ({
   const [token, setToken] = useState(null);
 
   const currency = getAccountCurrency(account);
-  const currencyName = currency
-    ? currency.type === "TokenCurrency"
-      ? currency.parentCurrency.name
-      : currency.name
-    : undefined;
+  const currencyName = currency ? currency.name : undefined;
 
   const handleChangeAccount = useCallback(
     (account, parentAccount) => {

--- a/src/renderer/modals/Receive/steps/StepConnectDevice.js
+++ b/src/renderer/modals/Receive/steps/StepConnectDevice.js
@@ -1,7 +1,7 @@
 // @flow
 
-import React from "react";
-import { getMainAccount } from "@ledgerhq/live-common/lib/account/helpers";
+import React, { useEffect, useState } from "react";
+import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import DeviceAction from "~/renderer/components/DeviceAction";
@@ -44,10 +44,31 @@ export function StepConnectDeviceFooter({
   onSkipConfirm,
   device,
   eventType,
+  account,
 }: StepProps) {
+  const [currencyName, setCurrencyName] = useState("");
+
+  useEffect(() => {
+    if (account) {
+      const currency = getAccountCurrency(account);
+
+      const currencyName = currency
+        ? currency.type === "TokenCurrency"
+          ? currency.parentCurrency.name
+          : currency.name
+        : undefined;
+
+      setCurrencyName(currencyName);
+    }
+  }, [account]);
+
   return (
     <Box horizontal flow={2}>
-      <TrackPage category={`Receive Flow${eventType ? ` (${eventType})` : ""}`} name="Step 2" />
+      <TrackPage
+        category={`Receive Flow${eventType ? ` (${eventType})` : ""}`}
+        name="Step 2"
+        currencyName={currencyName}
+      />
       <Button
         event="Receive Flow Without Device Clicked"
         id={"receive-connect-device-skip-device-button"}

--- a/src/renderer/modals/Receive/steps/StepConnectDevice.js
+++ b/src/renderer/modals/Receive/steps/StepConnectDevice.js
@@ -1,7 +1,7 @@
 // @flow
 
-import React, { useEffect, useState } from "react";
-import { getMainAccount, getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
+import React from "react";
+import { getMainAccount } from "@ledgerhq/live-common/lib/account/helpers";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import DeviceAction from "~/renderer/components/DeviceAction";
@@ -44,24 +44,8 @@ export function StepConnectDeviceFooter({
   onSkipConfirm,
   device,
   eventType,
-  account,
+  currencyName,
 }: StepProps) {
-  const [currencyName, setCurrencyName] = useState("");
-
-  useEffect(() => {
-    if (account) {
-      const currency = getAccountCurrency(account);
-
-      const currencyName = currency
-        ? currency.type === "TokenCurrency"
-          ? currency.parentCurrency.name
-          : currency.name
-        : undefined;
-
-      setCurrencyName(currencyName);
-    }
-  }, [account]);
-
   return (
     <Box horizontal flow={2}>
       <TrackPage

--- a/src/renderer/modals/Receive/steps/StepReceiveFunds.js
+++ b/src/renderer/modals/Receive/steps/StepReceiveFunds.js
@@ -3,6 +3,7 @@
 import invariant from "invariant";
 import React, { useEffect, useRef, useCallback, useState } from "react";
 import { getAccountBridge } from "@ledgerhq/live-common/lib/bridge";
+import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 import { getMainAccount, getAccountName } from "@ledgerhq/live-common/lib/account";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
@@ -138,6 +139,7 @@ const StepReceiveFunds = ({
   const initialDevice = useRef(device);
   const address = mainAccount.freshAddress;
   const [modalVisible, setModalVisible] = useState(false);
+  const [currencyName, setCurrencyName] = useState("");
 
   const hideQRCodeModal = useCallback(() => setModalVisible(false), [setModalVisible]);
   const showQRCodeModal = useCallback(() => setModalVisible(true), [setModalVisible]);
@@ -185,10 +187,28 @@ const StepReceiveFunds = ({
     }
   }, [isAddressVerified, confirmAddress]);
 
+  useEffect(() => {
+    if (account) {
+      const currency = getAccountCurrency(account);
+
+      const currencyName = currency
+        ? currency.type === "TokenCurrency"
+          ? currency.parentCurrency.name
+          : currency.name
+        : undefined;
+
+      setCurrencyName(currencyName);
+    }
+  }, [account]);
+
   return (
     <>
       <Box px={2}>
-        <TrackPage category={`Receive Flow${eventType ? ` (${eventType})` : ""}`} name="Step 3" />
+        <TrackPage
+          category={`Receive Flow${eventType ? ` (${eventType})` : ""}`}
+          name="Step 3"
+          currencyName={currencyName}
+        />
         {verifyAddressError ? (
           <ErrorDisplay error={verifyAddressError} onRetry={onVerify} />
         ) : isAddressVerified === true ? (

--- a/src/renderer/modals/Receive/steps/StepReceiveFunds.js
+++ b/src/renderer/modals/Receive/steps/StepReceiveFunds.js
@@ -3,7 +3,6 @@
 import invariant from "invariant";
 import React, { useEffect, useRef, useCallback, useState } from "react";
 import { getAccountBridge } from "@ledgerhq/live-common/lib/bridge";
-import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 import { getMainAccount, getAccountName } from "@ledgerhq/live-common/lib/account";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
@@ -132,6 +131,7 @@ const StepReceiveFunds = ({
   token,
   onClose,
   eventType,
+  currencyName,
 }: StepProps) => {
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
   invariant(account && mainAccount, "No account given");
@@ -139,7 +139,6 @@ const StepReceiveFunds = ({
   const initialDevice = useRef(device);
   const address = mainAccount.freshAddress;
   const [modalVisible, setModalVisible] = useState(false);
-  const [currencyName, setCurrencyName] = useState("");
 
   const hideQRCodeModal = useCallback(() => setModalVisible(false), [setModalVisible]);
   const showQRCodeModal = useCallback(() => setModalVisible(true), [setModalVisible]);
@@ -186,20 +185,6 @@ const StepReceiveFunds = ({
       confirmAddress();
     }
   }, [isAddressVerified, confirmAddress]);
-
-  useEffect(() => {
-    if (account) {
-      const currency = getAccountCurrency(account);
-
-      const currencyName = currency
-        ? currency.type === "TokenCurrency"
-          ? currency.parentCurrency.name
-          : currency.name
-        : undefined;
-
-      setCurrencyName(currencyName);
-    }
-  }, [account]);
 
   return (
     <>

--- a/src/renderer/modals/Send/Body.js
+++ b/src/renderer/modals/Send/Body.js
@@ -9,6 +9,7 @@ import { createStructuredSelector } from "reselect";
 import { Trans, withTranslation } from "react-i18next";
 import { UserRefusedOnDevice } from "@ledgerhq/errors";
 import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/lib/account";
+import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 import useBridgeTransaction from "@ledgerhq/live-common/lib/bridge/useBridgeTransaction";
 import type { Account, AccountLike, Operation } from "@ledgerhq/live-common/lib/types";
 import logger from "~/logger";
@@ -161,6 +162,22 @@ const Body = ({
     if (stepId) onChangeStepId(stepId);
   }, [onChangeStepId, params]);
 
+  const [currencyName, setCurrencyName] = useState("");
+
+  useEffect(() => {
+    if (account) {
+      const currency = getAccountCurrency(account);
+
+      const currencyName = currency
+        ? currency.type === "TokenCurrency"
+          ? currency.parentCurrency.name
+          : currency.name
+        : undefined;
+
+      setCurrencyName(currencyName);
+    }
+  }, [account]);
+
   const [optimisticOperation, setOptimisticOperation] = useState(null);
   const [transactionError, setTransactionError] = useState(null);
   const [signed, setSigned] = useState(false);
@@ -227,6 +244,7 @@ const Body = ({
     parentAccount,
     transaction,
     signed,
+    currencyName,
     hideBreadcrumb: (!!error && ["recipient", "amount"].includes(stepId)) || stepId === "warning",
     error,
     status,

--- a/src/renderer/modals/Send/Body.js
+++ b/src/renderer/modals/Send/Body.js
@@ -162,25 +162,17 @@ const Body = ({
     if (stepId) onChangeStepId(stepId);
   }, [onChangeStepId, params]);
 
-  const [currencyName, setCurrencyName] = useState("");
-
-  useEffect(() => {
-    if (account) {
-      const currency = getAccountCurrency(account);
-
-      const currencyName = currency
-        ? currency.type === "TokenCurrency"
-          ? currency.parentCurrency.name
-          : currency.name
-        : undefined;
-
-      setCurrencyName(currencyName);
-    }
-  }, [account]);
-
   const [optimisticOperation, setOptimisticOperation] = useState(null);
   const [transactionError, setTransactionError] = useState(null);
   const [signed, setSigned] = useState(false);
+
+  const currency = account ? getAccountCurrency(account) : undefined;
+
+  const currencyName = currency
+    ? currency.type === "TokenCurrency"
+      ? currency.parentCurrency.name
+      : currency.name
+    : undefined;
 
   const handleCloseModal = useCallback(() => {
     closeModal("MODAL_SEND");

--- a/src/renderer/modals/Send/Body.js
+++ b/src/renderer/modals/Send/Body.js
@@ -168,11 +168,7 @@ const Body = ({
 
   const currency = account ? getAccountCurrency(account) : undefined;
 
-  const currencyName = currency
-    ? currency.type === "TokenCurrency"
-      ? currency.parentCurrency.name
-      : currency.name
-    : undefined;
+  const currencyName = currency ? currency.name : undefined;
 
   const handleCloseModal = useCallback(() => {
     closeModal("MODAL_SEND");

--- a/src/renderer/modals/Send/steps/StepAmount.js
+++ b/src/renderer/modals/Send/steps/StepAmount.js
@@ -1,8 +1,9 @@
 // @flow
 
-import React, { Fragment, PureComponent } from "react";
+import React, { Fragment, PureComponent, useEffect, useState } from "react";
 import { Trans } from "react-i18next";
 import { getMainAccount } from "@ledgerhq/live-common/lib/account";
+import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -30,12 +31,28 @@ const StepAmount = ({
   onResetMaybeAmount,
   updateTransaction,
 }: StepProps) => {
-  if (!status) return null;
+  const [currencyName, setCurrencyName] = useState("");
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
+
+  useEffect(() => {
+    if (account) {
+      const currency = getAccountCurrency(account);
+
+      const currencyName = currency
+        ? currency.type === "TokenCurrency"
+          ? currency.parentCurrency.name
+          : currency.name
+        : undefined;
+
+      setCurrencyName(currencyName);
+    }
+  }, [account]);
+
+  if (!status) return null;
 
   return (
     <Box flow={4}>
-      <TrackPage category="Send Flow" name="Step Amount" />
+      <TrackPage category="Send Flow" name="Step Amount" currencyName={currencyName} />
       {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
       {error ? <ErrorBanner error={error} /> : null}
       {account && transaction && mainAccount && (

--- a/src/renderer/modals/Send/steps/StepAmount.js
+++ b/src/renderer/modals/Send/steps/StepAmount.js
@@ -1,9 +1,8 @@
 // @flow
 
-import React, { Fragment, PureComponent, useEffect, useState } from "react";
+import React, { Fragment, PureComponent } from "react";
 import { Trans } from "react-i18next";
 import { getMainAccount } from "@ledgerhq/live-common/lib/account";
-import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
@@ -30,25 +29,10 @@ const StepAmount = ({
   maybeAmount,
   onResetMaybeAmount,
   updateTransaction,
+  currencyName,
 }: StepProps) => {
-  const [currencyName, setCurrencyName] = useState("");
-  const mainAccount = account ? getMainAccount(account, parentAccount) : null;
-
-  useEffect(() => {
-    if (account) {
-      const currency = getAccountCurrency(account);
-
-      const currencyName = currency
-        ? currency.type === "TokenCurrency"
-          ? currency.parentCurrency.name
-          : currency.name
-        : undefined;
-
-      setCurrencyName(currencyName);
-    }
-  }, [account]);
-
   if (!status) return null;
+  const mainAccount = account ? getMainAccount(account, parentAccount) : null;
 
   return (
     <Box flow={4}>

--- a/src/renderer/modals/Send/steps/StepConfirmation.js
+++ b/src/renderer/modals/Send/steps/StepConfirmation.js
@@ -1,9 +1,8 @@
 // @flow
 
-import React, { useLayoutEffect, useState } from "react";
+import React from "react";
 import { Trans } from "react-i18next";
 import styled, { withTheme } from "styled-components";
-import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 import { SyncOneAccountOnMount } from "@ledgerhq/live-common/lib/bridge/react";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
@@ -34,23 +33,8 @@ function StepConfirmation({
   theme,
   device,
   signed,
+  currencyName,
 }: StepProps & { theme: * }) {
-  const [currencyName, setCurrencyName] = useState("");
-
-  useLayoutEffect(() => {
-    if (account) {
-      const currency = getAccountCurrency(account);
-
-      const currencyName = currency
-        ? currency.type === "TokenCurrency"
-          ? currency.parentCurrency.name
-          : currency.name
-        : undefined;
-
-      setCurrencyName(currencyName);
-    }
-  }, [account]);
-
   if (optimisticOperation) {
     return (
       <Container>

--- a/src/renderer/modals/Send/steps/StepConnectDevice.js
+++ b/src/renderer/modals/Send/steps/StepConnectDevice.js
@@ -1,6 +1,5 @@
 // @flow
-import React, { useEffect, useState } from "react";
-import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
+import React from "react";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import GenericStepConnectDevice from "./GenericStepConnectDevice";
 import type { StepProps } from "../types";
@@ -14,22 +13,8 @@ export default function StepConnectDevice({
   onOperationBroadcasted,
   onTransactionError,
   setSigned,
+  currencyName,
 }: StepProps) {
-  const [currencyName, setCurrencyName] = useState("");
-
-  useEffect(() => {
-    if (account) {
-      const currency = getAccountCurrency(account);
-
-      const currencyName = currency
-        ? currency.type === "TokenCurrency"
-          ? currency.parentCurrency.name
-          : currency.name
-        : undefined;
-
-      setCurrencyName(currencyName);
-    }
-  }, [account]);
   return (
     <>
       <TrackPage category="Send Flow" name="Step ConnectDevice" currencyName={currencyName} />

--- a/src/renderer/modals/Send/steps/StepConnectDevice.js
+++ b/src/renderer/modals/Send/steps/StepConnectDevice.js
@@ -1,5 +1,6 @@
 // @flow
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import GenericStepConnectDevice from "./GenericStepConnectDevice";
 import type { StepProps } from "../types";
@@ -14,9 +15,24 @@ export default function StepConnectDevice({
   onTransactionError,
   setSigned,
 }: StepProps) {
+  const [currencyName, setCurrencyName] = useState("");
+
+  useEffect(() => {
+    if (account) {
+      const currency = getAccountCurrency(account);
+
+      const currencyName = currency
+        ? currency.type === "TokenCurrency"
+          ? currency.parentCurrency.name
+          : currency.name
+        : undefined;
+
+      setCurrencyName(currencyName);
+    }
+  }, [account]);
   return (
     <>
-      <TrackPage category="Send Flow" name="Step ConnectDevice" />
+      <TrackPage category="Send Flow" name="Step ConnectDevice" currencyName={currencyName} />
       <GenericStepConnectDevice
         account={account}
         parentAccount={parentAccount}

--- a/src/renderer/modals/Send/steps/StepRecipient.js
+++ b/src/renderer/modals/Send/steps/StepRecipient.js
@@ -1,7 +1,8 @@
 // @flow
 
-import React, { PureComponent } from "react";
+import React, { PureComponent, useEffect, useState } from "react";
 import { getMainAccount } from "@ledgerhq/live-common/lib/account";
+import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
@@ -32,12 +33,27 @@ const StepRecipient = ({
   maybeRecipient,
   onResetMaybeRecipient,
 }: StepProps) => {
-  if (!status) return null;
+  const [currencyName, setCurrencyName] = useState("");
+
+  useEffect(() => {
+    if (account) {
+      const currency = getAccountCurrency(account);
+
+      const currencyName = currency
+        ? currency.type === "TokenCurrency"
+          ? currency.parentCurrency.name
+          : currency.name
+        : undefined;
+
+      setCurrencyName(currencyName);
+    }
+  }, [account]);
   const mainAccount = account ? getMainAccount(account, parentAccount) : null;
+  if (!status) return null;
 
   return (
     <Box flow={4}>
-      <TrackPage category="Send Flow" name="Step Recipient" />
+      <TrackPage category="Send Flow" name="Step Recipient" currencyName={currencyName} />
       {mainAccount ? <CurrencyDownStatusAlert currencies={[mainAccount.currency]} /> : null}
       {error ? <ErrorBanner error={error} /> : null}
       <Box flow={1}>

--- a/src/renderer/modals/Send/steps/StepRecipient.js
+++ b/src/renderer/modals/Send/steps/StepRecipient.js
@@ -1,8 +1,7 @@
 // @flow
 
-import React, { PureComponent, useEffect, useState } from "react";
+import React, { PureComponent } from "react";
 import { getMainAccount } from "@ledgerhq/live-common/lib/account";
-import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Box from "~/renderer/components/Box";
@@ -32,24 +31,10 @@ const StepRecipient = ({
   bridgePending,
   maybeRecipient,
   onResetMaybeRecipient,
+  currencyName,
 }: StepProps) => {
-  const [currencyName, setCurrencyName] = useState("");
-
-  useEffect(() => {
-    if (account) {
-      const currency = getAccountCurrency(account);
-
-      const currencyName = currency
-        ? currency.type === "TokenCurrency"
-          ? currency.parentCurrency.name
-          : currency.name
-        : undefined;
-
-      setCurrencyName(currencyName);
-    }
-  }, [account]);
-  const mainAccount = account ? getMainAccount(account, parentAccount) : null;
   if (!status) return null;
+  const mainAccount = account ? getMainAccount(account, parentAccount) : null;
 
   return (
     <Box flow={4}>

--- a/src/renderer/modals/Send/steps/StepSummary.js
+++ b/src/renderer/modals/Send/steps/StepSummary.js
@@ -72,12 +72,18 @@ export default class StepSummary extends PureComponent<StepProps> {
       account.type === "Account" &&
       (account.subAccounts || []).some(subAccount => subAccount.balance.gt(0));
 
+    const currencyName = currency
+      ? currency.type === "TokenCurrency"
+        ? currency.parentCurrency.name
+        : currency.name
+      : undefined;
+
     // $FlowFixMe
     const memo = transaction.memo;
 
     return (
       <Box flow={4} mx={40}>
-        <TrackPage category="Send Flow" name="Step Summary" />
+        <TrackPage category="Send Flow" name="Step Summary" currencyName={currencyName} />
         {utxoLag ? (
           <Alert type="warning">
             <Trans i18nKey="send.steps.details.utxoLag" />

--- a/src/renderer/modals/Send/steps/StepSummary.js
+++ b/src/renderer/modals/Send/steps/StepSummary.js
@@ -57,7 +57,7 @@ const WARN_FROM_UTXO_COUNT = 50;
 
 export default class StepSummary extends PureComponent<StepProps> {
   render() {
-    const { account, parentAccount, transaction, status } = this.props;
+    const { account, parentAccount, transaction, status, currencyName } = this.props;
     if (!account) return null;
     const mainAccount = getMainAccount(account, parentAccount);
     if (!mainAccount || !transaction) return null;
@@ -71,12 +71,6 @@ export default class StepSummary extends PureComponent<StepProps> {
     const hasNonEmptySubAccounts =
       account.type === "Account" &&
       (account.subAccounts || []).some(subAccount => subAccount.balance.gt(0));
-
-    const currencyName = currency
-      ? currency.type === "TokenCurrency"
-        ? currency.parentCurrency.name
-        : currency.name
-      : undefined;
 
     // $FlowFixMe
     const memo = transaction.memo;

--- a/src/renderer/modals/Send/types.js
+++ b/src/renderer/modals/Send/types.js
@@ -40,6 +40,7 @@ export type StepProps = {
   maybeAmount?: BigNumber,
   onResetMaybeAmount: () => void,
   updateTransaction: (updater: any) => void,
+  currencyName: ?string,
 };
 
 export type St = Step<StepId, StepProps>;


### PR DESCRIPTION
As for addAccounts, adds currencyName into tracking event in Send and Receive flow

### Type

Improvement

### Context

LL-5305


### Parts of the app affected / Test plan

Analytics
