### PR TITLE
LL-5505 (DiscreetMode): show fee values on send flow even on discreet mode

### DIFF
--- a/src/renderer/components/FormattedVal.js
+++ b/src/renderer/components/FormattedVal.js
@@ -60,6 +60,7 @@ type OwnProps = {
   ellipsis?: boolean,
   suffix?: string,
   showAllDigits?: boolean,
+  alwaysShowValue?: boolean, // overrides discreet mode
 };
 
 const mapStateToProps = createStructuredSelector({
@@ -90,8 +91,9 @@ function FormattedVal(props: Props) {
     subMagnitude,
     prefix,
     suffix,
-    discreet,
     showAllDigits,
+    alwaysShowValue,
+    discreet,
     ...p
   } = props;
   const valProp = props.val;
@@ -123,7 +125,7 @@ function FormattedVal(props: Props) {
       showCode,
       locale,
       subMagnitude,
-      discreet,
+      discreet: alwaysShowValue ? false : discreet,
       showAllDigits,
     });
   }

--- a/src/renderer/components/SelectFeeStrategy.js
+++ b/src/renderer/components/SelectFeeStrategy.js
@@ -114,6 +114,7 @@ const SelectFeeStrategy = ({
                       })}`
                     : ""
                 }
+                alwaysShowValue
               />
             </Box>
             <Box>
@@ -125,6 +126,7 @@ const SelectFeeStrategy = ({
                   fontWeight="500"
                   fontSize={3}
                   showCode
+                  alwaysShowValue
                 />
               ) : null}
             </Box>

--- a/src/renderer/components/SpendableAmount.js
+++ b/src/renderer/components/SpendableAmount.js
@@ -59,6 +59,7 @@ const SpendableAmount = ({
       disableRounding={disableRounding}
       showAllDigits={showAllDigits}
       showCode
+      alwaysShowValue
     />
   ) : null;
 };

--- a/src/renderer/modals/Send/AccountFooter.js
+++ b/src/renderer/modals/Send/AccountFooter.js
@@ -41,6 +41,7 @@ const AccountFooter = ({ account, parentAccount, status }: Props) => {
               val={status.estimatedFees}
               unit={accountUnit}
               showCode
+              alwaysShowValue
             />
             <CounterValue
               color="palette.text.shade60"
@@ -51,6 +52,7 @@ const AccountFooter = ({ account, parentAccount, status }: Props) => {
               value={status.estimatedFees}
               alwaysShowSign={false}
               subMagnitude={1}
+              alwaysShowValue
             />
           </>
         )}


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(DiscreetMode): show fee values on send flow even on discreet mode
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
[LL-5505]
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Send flow with fees selection should now show the amount even with discreet mode on


[LL-5505]: https://ledgerhq.atlassian.net/browse/LL-5505