### PR TITLE
LL-5671 (AccountPage Lend): fix ui regression in open loans empty placeholder

### DIFF
--- a/src/renderer/screens/lend/Account/AccountBodyHeader.js
+++ b/src/renderer/screens/lend/Account/AccountBodyHeader.js
@@ -65,7 +65,7 @@ const Loans = ({ account, parentAccount }: Props) => {
               : null}
           </>
         ) : (
-          <>
+          <Box horizontal p={2}>
             <Box style={{ maxWidth: "65%" }}>
               <Text ff="Inter|Medium|SemiBold" color="palette.text.shade60" fontSize={4}>
                 <Trans i18nKey={"lend.account.info"} values={{ currency: currency.name }} />
@@ -77,12 +77,12 @@ const Loans = ({ account, parentAccount }: Props) => {
                 />
               </Box>
             </Box>
-            <Box>
+            <Box flex="1" alignItems="flex-end" ml={2}>
               <Button primary small disabled={lendingDisabled} onClick={onLending}>
                 <Trans i18nKey={"lend.account.lend"} values={{ currency: currency.name }} />
               </Button>
             </Box>
-          </>
+          </Box>
         )}
       </TableContainer>
       {summary && summary.closed.length > 0 ? (


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(AccountPage Lend): fix ui regression in open loans empty placeholder
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug Fix
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
[LL-5671]
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Open loans section in account page when no loans opened yet


[LL-5671]: https://ledgerhq.atlassian.net/browse/LL-5671