### PR TITLE
[Linux] Add deep linking

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -30,8 +30,8 @@ if (!gotLock) {
       }
       w.focus();
 
-      // Deep linking for when the app is already running (Windows)
-      if (process.platform === "win32") {
+      // Deep linking for when the app is already running (Windows, Linux)
+      if (process.platform === "win32" || process.platform === "linux") {
         const uri = commandLine.filter(arg => arg.startsWith("ledgerlive://"));
 
         if (uri.length) {
@@ -156,8 +156,8 @@ ipcMain.on("ready-to-show", () => {
   if (w) {
     show(w);
 
-    // Deep linking for when the app is not running already (Windows)
-    if (process.platform === "win32") {
+    // Deep linking for when the app is not running already (Windows, Linux)
+    if (process.platform === "win32" || process.platform === "linux") {
       const { argv } = process;
       const uri = argv.filter(arg => arg.startsWith("ledgerlive://"));
 


### PR DESCRIPTION
Fix deep linking for Linux.

These internal changes by themselves won't make deeplinking work without third party _desktop integration_.

Tested and working AppImage desktop integration framework are:
- [appimaged](https://github.com/probonopd/go-appimage/releases/tag/continuous): official framework from AppImage project. Newly rewritten in Go and considered unstable for now. Packaged as a distro agnostic installable AppImage.
- [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher/releases/tag/continuous): third party project, stable. Offer packages for Debian/Ubuntu based distro and for RedHat based ones.

### Type

Bug Fix (Feature ?)

### Context

https://ledgerhq.atlassian.net/browse/LL-4813

### Parts of the app affected

Deep linking.

### Test plan

- Build the app (it can't work in dev mode)
- Integrate the app with desktop environment: install either `appimaged` or `AppImageLauncher` then double click the `.appimage` from a file manager (if that doesn't work, try moving the file to `~/Download` and run it as usual from a shell)
- Go to https://ledger-live-tools.vercel.app/bridgetest
- Clicking the link should
  - open the app if closed
  - bring it to the front if running
  - open the bridge modal

(just so you know, I _did_ test with both frameworks on both Ubuntu 20.04 and Debian 10)