### PR TITLE
Make CI build config even with release one (minus signing)

### DIFF
--- a/electron-builder-nightly.yml
+++ b/electron-builder-nightly.yml
@@ -21,7 +21,7 @@ linux:
 
 win:
   artifactName: ${name}-${version}-${os}-${arch}.${ext}
-  # icon: build/windows/app.ico
+  icon: build/windows/app.ico
   verifyUpdateCodeSignature: false
   signAndEditExecutable: false
   target:
@@ -33,11 +33,13 @@ nsis:
   oneClick: false
   perMachine: true
   allowToChangeInstallationDirectory: true
+  installerIcon: build/windows/installer.ico
+  installerSidebar: build/windows/installerSidebar.bmp
+  uninstallerIcon: build/windows/uninstaller.ico
+  uninstallerSidebar: build/windows/uninstallerSidebar.bmp
 
 files:
   # Include files
   - .webpack/**/*
-  - node_modules/**/*
-  - package.json
   # Exclude files
   # Exclude modules


### PR DESCRIPTION
Fix Windows CI build missing graphical assets.

### Type

Bug fix

### Context

Switching to CI for Windows release builds (minus the signing part)

### Parts of the app affected

CI build

### Test plan

- Make sure the CI doesn't break
- Verify that the installer now show Ledger images rather than generic ones
