### PR TITLE
[Windows] Sign and pack unpacked builds

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -33,10 +33,8 @@ linux:
 win:
   artifactName: ${name}-${version}-${os}-${arch}.${ext}
   icon: build/windows/app.ico
-  # certificateSubjectName: Ledger SAS
-  # certificateSha1: 7DD9ACB2EF0402883C65901EBBAFD06E5293D391
-  # signingHashAlgorithms:
-  #   - sha256
+  signingHashAlgorithms:
+    - sha256
   target:
     - target: nsis
       arch:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "spectron": "jest \"tests/specs/.*\\.spec\\.js\" --maxWorkers=4",
     "spectron-inband": "jest \"tests/specs/.*\\.spec\\.js\" --runInBand",
     "spectron-coverage": "nyc report --reporter=text-lcov --temp-dir=tests/coverage | codecov --pipe --disable=gcov",
-    "generate-screenshots": "PWD=$(pwd); cd docker; docker run -v \"$PWD:/github/workspace\" -w \"/github/workspace\" --rm -it $(docker build -q .)"
+    "generate-screenshots": "PWD=$(pwd); cd docker; docker run -v \"$PWD:/github/workspace\" -w \"/github/workspace\" --rm -it $(docker build -q .)",
+    "sign-and-pack-windows": "electron-builder build --pd dist/win-unpacked -c.win.sign='scripts/sign-windows.js'"
   },
   "engines": {
     "node": ">=12"

--- a/scripts/sign-windows.js
+++ b/scripts/sign-windows.js
@@ -1,0 +1,60 @@
+const path = require("path");
+const execa = require("execa");
+const chalk = require("chalk");
+
+require("dotenv").config();
+
+let firstCall = true;
+
+const info = str => {
+  console.log(chalk.blue(str));
+};
+
+async function azureSign(filePath) {
+  const { AZURE_APP_ID, AZURE_SECRET } = process.env;
+
+  if (!AZURE_APP_ID || !AZURE_SECRET) {
+    throw new Error(
+      "AZURE_APP_ID and AZURE_SECRET env variables are required for signing Windows builds.",
+    );
+  }
+
+  info(`Signing ${filePath}`);
+
+  const args = [
+    "sign",
+    "-du",
+    "Ledger SAS",
+    "-kvu",
+    "https://ledgerlivevault.vault.azure.net",
+    "-kvi",
+    AZURE_APP_ID,
+    "-kvs",
+    AZURE_SECRET,
+    "-kvc",
+    "LL20210603-01",
+    "-v",
+    "-tr",
+    "http://timestamp.digicert.com",
+    filePath,
+  ];
+
+  await execa("azuresigntool", args, { stdio: "inherit" });
+}
+
+async function signWindows(context) {
+  const filePath = context.path;
+
+  // electron-builder normally signs Ledger Live.exe during the _building_ part, but we don't on the CI
+  // this is a quick hack to have it signed during the _packing_ part
+  if (firstCall) {
+    firstCall = false;
+    const livePath = path.resolve(__dirname, "..", "dist/win-unpacked/Ledger Live.exe");
+
+    await azureSign(livePath);
+  }
+
+  await azureSign(filePath);
+}
+
+exports.default = signWindows;


### PR DESCRIPTION
Adds `yarn sign-and-pack-windows` to sign and pack Windows release artifacts from the CI.

### How-to

- Checkout to the new tag on your local machine
- `rm -rf` anything present in you `dist` folder
- grab the `win-unpacked.zip` file from the CI
- unzip it in `dist`
- make sure you have `azuresigntool` installed and `AZURE_APP_ID` and `AZURE_SECRET` set in your `.env` file (or as plain env variables)
- run `yarn sign-and-pack-windows`
- ???
- profit

### Type

Feature

### Context

Windows prod build signing.
