### PR TITLE
LL-5675 (Swap) Change success screen on modal

### DIFF
--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -150,6 +150,7 @@ export const urls = {
       changelly: {
         main: "https://changelly.com/",
         tos: "https://changelly.com/terms-of-use",
+        support: "https://support.changelly.com/en/support/tickets/new",
       },
     },
   },

--- a/src/renderer/modals/Swap/SwapBody.js
+++ b/src/renderer/modals/Swap/SwapBody.js
@@ -11,7 +11,11 @@ import Breadcrumb from "~/renderer/components/Stepper/Breadcrumb";
 import ErrorDisplay from "~/renderer/components/ErrorDisplay";
 import { useDispatch } from "react-redux";
 import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
-import { addPendingOperation, getMainAccount } from "@ledgerhq/live-common/lib/account";
+import {
+  addPendingOperation,
+  getMainAccount,
+  getAccountCurrency,
+} from "@ledgerhq/live-common/lib/account";
 import addToSwapHistory from "@ledgerhq/live-common/lib/exchange/swap/addToSwapHistory";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import Track from "~/renderer/analytics/Track";
@@ -37,7 +41,8 @@ const SwapBody = ({
   ratesExpiration: Date,
 }) => {
   const { exchange } = swap;
-  const { fromAccount, fromParentAccount } = exchange;
+  const { fromAccount, fromParentAccount, toAccount } = exchange;
+  const targetCurrency = getAccountCurrency(toAccount);
   const [checkedDisclaimer, setCheckedDisclaimer] = useState(false);
   const [locked, setLocked] = useState(false);
   const [error, setError] = useState(null);
@@ -120,6 +125,7 @@ const SwapBody = ({
           ) : result && result.swapId ? (
             <StepFinished
               setLocked={setLocked}
+              targetCurrency={targetCurrency.name}
               swapId={result.swapId}
               provider={swap.exchangeRate.provider}
             />

--- a/src/renderer/modals/Swap/steps/StepFinished.js
+++ b/src/renderer/modals/Swap/steps/StepFinished.js
@@ -93,7 +93,7 @@ const StepFinished = ({
   }, [setLocked]);
 
   const openProviderSupport = useCallback(() => {
-    openURL(urls.swap.providers[provider]?.tos);
+    openURL(urls.swap.providers[provider]?.support);
   }, [provider]);
 
   const SwapPill = ({ swapId }: { swapId: string }) => (

--- a/src/renderer/modals/Swap/steps/StepFinished.js
+++ b/src/renderer/modals/Swap/steps/StepFinished.js
@@ -4,7 +4,6 @@ import type { Operation } from "@ledgerhq/live-common/lib/types/operation";
 import type { Exchange, ExchangeRate } from "@ledgerhq/live-common/lib/exchange/swap/types";
 import Box from "~/renderer/components/Box";
 import CopyWithFeedback from "~/renderer/components/CopyWithFeedback";
-import IconSwap from "~/renderer/icons/Swap";
 import { Trans } from "react-i18next";
 import Text from "~/renderer/components/Text";
 import styled from "styled-components";
@@ -15,15 +14,21 @@ import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import { OperationDetails } from "~/renderer/drawers/OperationDetails";
 import { setDrawer } from "~/renderer/drawers/Provider";
 import { GradientHover } from "~/renderer/drawers/OperationDetails/styledComponents";
+import FakeLink from "~/renderer/components/FakeLink";
+import { urls } from "~/config/urls";
+import { openURL } from "~/renderer/linking";
+import IconCheck from "~/renderer/icons/Check";
+import IconClock from "~/renderer/icons/Clock";
 
 const IconWrapper = styled(Box)`
-  background: ${colors.pillActiveBackground};
-  color: ${colors.wallet};
+  background: ${colors.lightGreen};
+  color: ${colors.positiveGreen};
   width: 50px;
   height: 50px;
   border-radius: 25px;
   align-items: center;
   justify-content: center;
+  position: relative;
 `;
 
 const CapitalizedText = styled.span`
@@ -61,46 +66,66 @@ const SwapIdWrapper: ThemedComponent<{}> = styled(Box).attrs(p => ({
 }
 `;
 
+const WrapperClock: ThemedComponent<{}> = styled(Box).attrs(() => ({
+  bg: "palette.background.paper",
+  color: "palette.text.shade60",
+}))`
+  border-radius: 50%;
+  position: absolute;
+  bottom: -2px;
+  right: -2px;
+  padding: 2px;
+`;
+
 const StepFinished = ({
   swapId,
   provider,
+  targetCurrency,
   setLocked,
 }: {
   swapId: string,
   provider: string,
+  targetCurrency: string,
   setLocked: boolean => void,
 }) => {
   useEffect(() => {
     setLocked(false);
   }, [setLocked]);
 
+  const openProviderSupport = useCallback(() => {
+    openURL(urls.swap.providers[provider]?.tos);
+  }, [provider]);
+
+  const SwapPill = ({ swapId }: { swapId: string }) => (
+    <SwapIdWrapper>
+      <Pill color="palette.text.shade100" ff="Inter|SemiBold" fontSize={14}>
+        {swapId}
+      </Pill>
+      <GradientHover>
+        <CopyWithFeedback text={swapId} />
+      </GradientHover>
+    </SwapIdWrapper>
+  );
+
   return (
     <Box alignItems="center">
       <IconWrapper>
-        <IconSwap size={18} />
+        <IconCheck size={18} />
+        <WrapperClock>
+          <IconClock size={14} />
+        </WrapperClock>
       </IconWrapper>
       <Text mt={16} color="palette.text.shade100" ff="Inter|SemiBold" fontSize={5}>
         <Trans i18nKey={`swap.modal.steps.finished.subtitle`} />
       </Text>
-      <Box mt={16} horizontal alignItems="center">
-        <Text color="palette.text.shade50" ff="Inter|Regular" fontSize={14}>
-          <Trans i18nKey={`swap.modal.steps.finished.swap`} />
-        </Text>
-        <SwapIdWrapper>
-          <Pill ml={2} color="palette.text.shade100" ff="Inter|SemiBold" fontSize={14}>
-            {swapId}
-          </Pill>
-          <GradientHover>
-            <CopyWithFeedback text={swapId} />
-          </GradientHover>
-        </SwapIdWrapper>
-      </Box>
       <Text p={20} textAlign="center" color="palette.text.shade50" ff="Inter|Regular" fontSize={4}>
-        <Trans i18nKey={`swap.modal.steps.finished.description`} />
+        <Trans i18nKey={`swap.modal.steps.finished.description`} values={{ targetCurrency }} />
       </Text>
-      <Alert type="primary" mt={3}>
+      <Alert type="help" mt={3} right={<SwapPill swapId={swapId} />}>
         <Trans i18nKey={`swap.modal.steps.finished.disclaimer`} values={{ provider }}>
-          <CapitalizedText>{provider}</CapitalizedText>
+          <FakeLink onClick={openProviderSupport}>
+            <CapitalizedText style={{ marginRight: 4 }}>{provider}</CapitalizedText>
+          </FakeLink>
         </Trans>
       </Alert>
     </Box>
@@ -138,17 +163,17 @@ export const StepFinishedFooter = ({
 
   return (
     <Box horizontal>
+      <Button onClick={onClose} secondary id="swap-modal-finished-close-button">
+        <Trans i18nKey="common.close" />
+      </Button>
       <Button
         id="swap-modal-finished-details-button"
-        secondary
+        primary
         mr={2}
         event="Swap completed - Clicked on operation details CTA"
         onClick={onViewOperationDetails}
       >
         <Trans i18nKey="swap.modal.steps.finished.seeDetails" />
-      </Button>
-      <Button onClick={onClose} primary id="swap-modal-finished-close-button">
-        <Trans i18nKey="common.close" />
       </Button>
     </Box>
   );

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -268,11 +268,11 @@
         },
         "finished": {
           "title": "Pending",
-          "subtitle": "Pending operation",
+          "subtitle": "Swap broadcast successfully ",
           "swap": "Your Swap ID:",
           "seeDetails": "See details",
-          "disclaimer": "Please take note of your Swap ID number in case you’d need assistance from <0>{{provider}}</0> later.",
-          "description": "Your Swap operation has been sent to the network for confirmation. It may take up to an hour before you receive your swapped crypto assets."
+          "disclaimer": "Take note of your Swap ID number in case you’d need assistance from <0><0>{{provider}}</0> support</0>.",
+          "description": "Your Swap operation has been sent to the network for confirmation. It may take up to an hour before you receive your {{targetCurrency}}."
         }
       }
     },


### PR DESCRIPTION

<img width="1436" alt="Screenshot 2021-06-08 at 18 02 26" src="https://user-images.githubusercontent.com/4631227/121219574-2102c500-c884-11eb-99d3-5d03f0abdb08.png">
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Ui Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-5675

### Parts of the app affected / Test plan

- Complete a swap
- Check the success modal step
- Test the operation details button 
- Test that we can still copy the swap id
- Test the support link for the provider
