### PR TITLE
LL-5866 (Swap) Drop the concept of payoutNetworkFees from UI

### DIFF
--- a/src/renderer/components/DeviceAction/rendering.js
+++ b/src/renderer/components/DeviceAction/rendering.js
@@ -551,21 +551,10 @@ export const renderSwapDeviceConfirmation = ({
           ),
         },
         (value, key) => {
-          const maybeModifiedKey =
-            key === "amountReceived" && exchangeRate.tradeMethod === "float"
-              ? "amountReceivedFloat"
-              : key;
           return (
-            <Box
-              horizontal
-              justifyContent="space-between"
-              key={maybeModifiedKey}
-              mb={2}
-              ml="12px"
-              mr="12px"
-            >
+            <Box horizontal justifyContent="space-between" key={key} mb={2} ml="12px" mr="12px">
               <Text fontWeight="500" color="palette.text.shade40" fontSize={3}>
-                <Trans i18nKey={`DeviceAction.swap.${maybeModifiedKey}`} />
+                <Trans i18nKey={`DeviceAction.swap.${key}`} />
               </Text>
               <Text color="palette.text.shade80" fontWeight="500" fontSize={3}>
                 {value}
@@ -574,36 +563,6 @@ export const renderSwapDeviceConfirmation = ({
           );
         },
       )}
-      {exchangeRate.payoutNetworkFees ? (
-        <Box
-          horizontal
-          justifyContent="space-between"
-          key={"payoutNetworkFees"}
-          mb={2}
-          ml="12px"
-          mr="12px"
-        >
-          <LabelInfoTooltip
-            text={<Trans i18nKey={"DeviceAction.swap.payoutNetworkFeesTooltip"} />}
-            style={{ marginLeft: 4 }}
-          >
-            <Text fontWeight="500" color="palette.text.shade40" fontSize={3}>
-              <Trans i18nKey={"DeviceAction.swap.payoutNetworkFees"} />
-            </Text>
-          </LabelInfoTooltip>
-          <Text color="palette.text.shade80" fontWeight="500" fontSize={3}>
-            {exchangeRate.payoutNetworkFees && (
-              <CurrencyUnitValue
-                unit={getAccountUnit(exchange.toAccount)}
-                // $FlowFixMe
-                value={exchangeRate.payoutNetworkFees}
-                disableRounding
-                showCode
-              />
-            )}
-          </Text>
-        </Box>
-      ) : null}
       {renderVerifyUnwrapped({ modelId, type })}
     </>
   );

--- a/src/renderer/modals/Swap/steps/StepSummary.js
+++ b/src/renderer/modals/Swap/steps/StepSummary.js
@@ -70,7 +70,7 @@ const StepSummary = ({
 }) => {
   const swapAcceptedproviderIds = useSelector(swapAcceptedProviderIdsSelector);
   const { exchange, exchangeRate } = swap;
-  const { provider } = exchangeRate;
+  const { provider, toAmount } = exchangeRate;
   const alreadyAcceptedTerms = swapAcceptedproviderIds.includes(swap.exchangeRate.provider);
   const { fromAccount, toAccount } = exchange;
   const fromAmount = transaction.amount;
@@ -81,7 +81,6 @@ const StepSummary = ({
   const toCurrency = getAccountCurrency(toAccount);
   const fromUnit = getAccountUnit(fromAccount);
   const toUnit = getAccountUnit(toAccount);
-  const toAmount = exchangeRate.toAmount.minus(exchangeRate.payoutNetworkFees || 0);
   const { main, tos } = urls.swap.providers[provider];
 
   return (

--- a/src/renderer/screens/exchange/swap/Form/index.js
+++ b/src/renderer/screens/exchange/swap/Form/index.js
@@ -254,17 +254,8 @@ const Form = ({
     }
   }, [enabledTradeMethods, setTradeMethod, tradeMethod]);
 
-  const { provider, magnitudeAwareRate } = exchangeRate || {};
+  const { provider, magnitudeAwareRate, toAmount } = exchangeRate || {};
   const { amount = BigNumber(0) } = transaction || {};
-
-  const toAmount = useMemo(() => {
-    if (!exchangeRate) return;
-    let base = exchangeRate.toAmount;
-    if (exchangeRate && exchangeRate.payoutNetworkFees && toCurrency) {
-      base = base.minus(exchangeRate.payoutNetworkFees);
-    }
-    return base;
-  }, [exchangeRate, toCurrency]);
 
   return (
     <>


### PR DESCRIPTION
> This pr is tightly linked to https://github.com/LedgerHQ/ledger-live-common/pull/1244 and they should land on production together. Delivering one of them independently from the other will make the amounts not match for the users doing swaps.

### Context
Originally when we delivered the floating rate trading method for swap there was a new concept of `payoutNetworkFees`, which represents an amount that is charged as a fee on top of the rate provided. We needed to display this because the amount on the device included that amount, but the amount to be received had it deducted. 

With the latest code on staging, this is no longer the case and the binary payload amount (which we use on the device verification) deducts this amount, allowing us to drop the UI that referred to this concept altogether.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-5866

### Parts of the app affected / Test plan
- Build the application using a yalc'ed live-common from https://github.com/LedgerHQ/ledger-live-common/pull/1244
  - Point your application to the staging swap API URL by using the env `SWAP_API_BASE=https://swap-stg.ledger.com/v2`
  - Access the swap feature and request rates, make sure the rates and amounts make sense and are coherent
  - Reach the summary step and make sure the data is correct
  - Reach the device confirmation step and make sure the amount on the device matches the amount on the app
- Build the application **without the live-common pr yalc'ed**
  - Perform the previous steps, confirm amounts don't match for floating rate but do match for fixed rate.