### PR TITLE
LL-5450 upgrading to node 14

### DIFF
--- a/.github/workflows/build-linux-prod.yml
+++ b/.github/workflows/build-linux-prod.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Tag?'
+        description: "Tag?"
         required: true
 
 jobs:
@@ -19,7 +19,7 @@ jobs:
           ref: ${{github.event.inputs.tag}}
       - uses: actions/setup-node@main
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: install linux dependencies
         run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
       - name: get yarn cache

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -17,7 +17,7 @@ jobs:
           repository: ${{github.event.pull_request.head.repo.full_name}}
       - uses: actions/setup-node@main
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: install dependencies
         run: yarn --ignore-scripts --frozen-lockfile
       - name: set beta name
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@main
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: install linux dependencies
         run: sudo apt-get update && sudo apt-get install libudev-dev libusb-1.0-0-dev
       - name: get yarn cache
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@main
         with:
-          node-version: 12.x
+          node-version: 14.x
       - uses: actions/setup-python@v1
         with:
           python-version: "2.7.x"

--- a/.github/workflows/build-windows-prod.yml
+++ b/.github/workflows/build-windows-prod.yml
@@ -19,7 +19,7 @@ jobs:
           ref: ${{github.event.inputs.tag}}
       - uses: actions/setup-node@main
         with:
-          node-version: 12.x
+          node-version: 14.x
       - uses: actions/setup-python@v1
         with:
           python-version: "2.7.x"
@@ -43,4 +43,3 @@ jobs:
         with:
           name: win-unpacked
           path: dist/win-unpacked
-

--- a/.github/workflows/bundle-app.yml
+++ b/.github/workflows/bundle-app.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@main
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: set git user
         run: |
           git config user.email "team-live@ledger.fr"
@@ -87,7 +87,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@main
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: set git user
         run: |
           git config user.email "team-live@ledger.fr"
@@ -145,7 +145,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@main
         with:
-          node-version: 12.x
+          node-version: 14.x
       - uses: actions/setup-python@v1
         with:
           python-version: "2.7.x"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@ledgerhq/hw-transport": "^5.51.1",
     "@ledgerhq/hw-transport-http": "^5.51.1",
     "@ledgerhq/hw-transport-node-hid-singleton": "^5.51.1",
-    "@ledgerhq/ledger-core": "6.11.3",
+    "@ledgerhq/ledger-core": "6.12.3",
     "@ledgerhq/live-common": "19.11.3",
     "@ledgerhq/logs": "^5.50.0",
     "@polkadot/react-identicon": "0.70.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1865,10 +1865,10 @@
     "@ledgerhq/errors" "^5.50.0"
     events "^3.3.0"
 
-"@ledgerhq/ledger-core@6.11.3":
-  version "6.11.3"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-6.11.3.tgz#9f5ddb98ed2e3a9ba5d40276326a5baf7b33d2b8"
-  integrity sha512-baD2uUMVtOn4XvYZNBjnFM5g2+QmUulnRerk3JHCbKBwteIlLkJ0KHcuo5Td1qz3EPKS+M1Z3S1YmBuKZgSOqw==
+"@ledgerhq/ledger-core@6.12.3":
+  version "6.12.3"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-6.12.3.tgz#f9f0de61a5146988d47ce4765e308e7e6483ae1e"
+  integrity sha512-A8LDEPe4HFS+Z7iWyemKaP89DWgh/RHbHw7JarZ/pRgQU4kYX2vyWvmeARawyMPUg2Ez5B0y4yqBuDHctDU0mg==
   dependencies:
     bindings "1.5.0"
     nan "^2.14.2"


### PR DESCRIPTION
This PR bumps libcore to use the new node 14 bindings.
Linked to https://github.com/LedgerHQ/ledger-live-common/pull/1261

### Type

Chore

### Context

LL-5450

### Parts of the app affected / Test plan

The whole app. We need to see if upgrading to node 14 doesn't break anything. 
As of now I have tested to add accounts and sync and I did not see any issues, but extensive QA is required.

To all devs, whenever this PR is merge, bump to node 14
