### PR TITLE
[Windows] Drop signing unpacked builds and sign on build

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -33,6 +33,7 @@ linux:
 win:
   artifactName: ${name}-${version}-${os}-${arch}.${ext}
   icon: build/windows/app.ico
+  sign: scripts/sign-windows.js
   signingHashAlgorithms:
     - sha256
   target:

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "spectron": "jest \"tests/specs/.*\\.spec\\.js\" --maxWorkers=4",
     "spectron-inband": "jest \"tests/specs/.*\\.spec\\.js\" --runInBand",
     "spectron-coverage": "nyc report --reporter=text-lcov --temp-dir=tests/coverage | codecov --pipe --disable=gcov",
-    "generate-screenshots": "PWD=$(pwd); cd docker; docker run -v \"$PWD:/github/workspace\" -w \"/github/workspace\" --rm -it $(docker build -q .)",
-    "sign-and-pack-windows": "electron-builder build --pd dist/win-unpacked -c.win.sign='scripts/sign-windows.js'"
+    "generate-screenshots": "PWD=$(pwd); cd docker; docker run -v \"$PWD:/github/workspace\" -w \"/github/workspace\" --rm -it $(docker build -q .)"
   },
   "engines": {
     "node": ">=12"

--- a/scripts/sign-windows.js
+++ b/scripts/sign-windows.js
@@ -1,10 +1,7 @@
-const path = require("path");
 const execa = require("execa");
 const chalk = require("chalk");
 
 require("dotenv").config();
-
-let firstCall = true;
 
 const info = str => {
   console.log(chalk.blue(str));
@@ -44,15 +41,6 @@ async function azureSign(filePath) {
 
 async function signWindows(context) {
   const filePath = context.path;
-
-  // electron-builder normally signs Ledger Live.exe during the _building_ part, but we don't on the CI
-  // this is a quick hack to have it signed during the _packing_ part
-  if (firstCall) {
-    firstCall = false;
-    const livePath = path.resolve(__dirname, "..", "dist/win-unpacked/Ledger Live.exe");
-
-    await azureSign(livePath);
-  }
 
   await azureSign(filePath);
 }


### PR DESCRIPTION
### The issue

Signing locally Windows builds from the CI brakes the auto-update because of `electron-builder` unexpected behavior (not sure it's intended or not): in such a case the `resources\app-update.yml` file doesn't get bundled in the app, preventing the auto-updater to know where to look for potential updates.
Like Frankie Vincent's _le Restaurant_ it was a good idea, though.

### The fix

Don't rely on CI builds.
This PR removes the code related to signing unpacked builds, and makes signing part of the build process itself. This is the only way to get a release with a working update mechanism. Sorry.

### The sad part

LLD `2.29` has been build _wrong_, it won't be able to auto-update to a newer version.
Note that unlike pre`2.29` apps showing the update banner and then failing to update, this time the update banner won't even show. Speaking of which...

### The same, but different

So for a second time in a row, a Windows release has its update mechanism broken. As much as this time it's `electron-builder` acting wrong, the previous time it was `electron-updater` acting _right_: it checks that the _same_ signing certificate has been used to sign the current build and the new one. The thing is that GlobalSign didn't renew our certificate, they gave us a _new_ one. We're still `Ledger SAS` (although the case changed to all upper) but the serial number changed.

### Type

Bug Fix

### Context

#3886

### Parts of the app affected

App building
Auto-update

### Test plan

I did test the following way:
- Change the app version to something below the latest version (I used `2.28.42` to avoid using a real release number)
- Build the app
- Install and run
- See nothing happening without any warning because of [remote config disabling update to `2.29` on Windows
](https://raw.githubusercontent.com/LedgerHQ/ledger-live-desktop/config/config.json) and lose 2 hours (also how come it shows up on `raw.githubusercontent.com` and not on the repo? 🤯)
- Add `return true` on line 36 in `src/helpers/user.js` to bypass the remote config
- Back to step 2
- The auto-update to version `2.29` should work just fine