### PR TITLE
LL-5533 update sentry url?

### DIFF
--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -86,16 +86,14 @@ const captureBreadcrumb = (breadcrumb: any) => {
 };
 
 const captureException = (error: Error) => {
-  if (!process.env.STORYBOOK_ENV) {
-    try {
-      if (typeof window !== "undefined") {
-        require("~/sentry/browser").captureException(error);
-      } else {
-        require("~/sentry/node").captureException(error);
-      }
-    } catch (e) {
-      logger.log("warn", "Can't send to sentry", error, e);
+  try {
+    if (typeof window !== "undefined") {
+      require("~/sentry/browser").captureException(error);
+    } else {
+      require("~/sentry/node").captureException(error);
     }
+  } catch (e) {
+    logger.log("warn", "Can't send to sentry", error, e);
   }
 };
 

--- a/src/renderer/init.js
+++ b/src/renderer/init.js
@@ -86,6 +86,8 @@ async function init() {
 
   const store = createStore({ dbMiddleware });
 
+  sentry(() => sentryLogsSelector(store.getState()));
+
   ipcRenderer.once("deep-linking", (event, url) => {
     store.dispatch(setDeepLinkUrl(url));
   });
@@ -111,9 +113,6 @@ async function init() {
 
   const hideEmptyTokenAccounts = hideEmptyTokenAccountsSelector(state);
   setEnvOnAllThreads("HIDE_EMPTY_TOKEN_ACCOUNTS", hideEmptyTokenAccounts);
-
-  // TODO: DON'T FORGET SENTRY
-  sentry(() => sentryLogsSelector(store.getState()));
 
   const isMainWindow = remote.getCurrentWindow().name === "MainWindow";
 

--- a/tools/dist/index.js
+++ b/tools/dist/index.js
@@ -84,7 +84,8 @@ const buildTasks = args => [
       await exec("yarn", commands, {
         env: args.publish
           ? {
-              SENTRY_URL: "https://db8f5b9b021048d4a401f045371701cb@sentry.io/274561",
+              SENTRY_URL:
+                "https://db8f5b9b021048d4a401f045371701cb@o118392.ingest.sentry.io/274561",
             }
           : {},
       });


### PR DESCRIPTION
### Type

FIX

### Context

LL-5533

### Parts of the app affected / Test plan

Let's be honest, I don't know how we can test this. I think I fixed the url by going into the sentry settings and copying the url but still, I couldn't find to trigger an event for Sentry

Recommendation => move to the new sdk and not use raven-js anymore. Pain point: anonymizing the data