### PR TITLE
LL-6086 add tracking to view in explorer

### DIFF
--- a/src/renderer/drawers/OperationDetails/index.js
+++ b/src/renderer/drawers/OperationDetails/index.js
@@ -215,6 +215,12 @@ const OperationD: React$ComponentType<Props> = (props: Props) => {
     onClose();
   }, [mainAccount, account, history, onClose, location]);
 
+  const currencyName = currency
+    ? currency.type === "TokenCurrency"
+      ? currency.parentCurrency.name
+      : currency.name
+    : undefined;
+
   return (
     <Box flow={3} px={20} mt={20}>
       <TrackPage
@@ -295,7 +301,7 @@ const OperationD: React$ComponentType<Props> = (props: Props) => {
         <Box m={0} ff="Inter|SemiBold" horizontal justifyContent="center" fontSize={4} my={1}>
           <LinkWithExternalIcon
             fontSize={4}
-            onClick={() => openURL(url)}
+            onClick={() => openURL(url, "viewOperationInExplorer", { currencyId: currencyName })}
             label={t("operationDetails.viewOperation")}
           />
         </Box>

--- a/src/renderer/drawers/SwapOperationDetails/index.js
+++ b/src/renderer/drawers/SwapOperationDetails/index.js
@@ -160,6 +160,12 @@ const SwapOperationDetails = ({
   const senders = uniq(operation.senders);
   const recipients = uniq(operation.recipients);
 
+  const currencyName = fromCurrency
+    ? fromCurrency.type === "TokenCurrency"
+      ? fromCurrency.parentCurrency.name
+      : fromCurrency.name
+    : undefined;
+
   return (
     <Box flow={3} px={20} mt={20}>
       <Status status={status}>
@@ -205,7 +211,9 @@ const SwapOperationDetails = ({
         <Box m={0} ff="Inter|SemiBold" horizontal justifyContent="center" fontSize={4} mb={1}>
           <LinkWithExternalIcon
             fontSize={4}
-            onClick={() => openURL(url)}
+            onClick={() =>
+              openURL(url, "viewSwapOperationInExplorer", { currencyId: currencyName })
+            }
             label={t("operationDetails.viewOperation")}
           />
         </Box>

--- a/src/renderer/linking.js
+++ b/src/renderer/linking.js
@@ -1,6 +1,6 @@
 // @flow
 
-// import { track } from '~/analytics/segment'
+import { track } from "~/renderer/analytics/segment";
 import electron from "electron";
 
 let shell;
@@ -13,6 +13,8 @@ export const openURL = (
   customEventName: string = "OpenURL",
   extraParams: Object = {},
 ) => {
-  // track(customEventName, { ...extraParams, url })
+  if (customEventName) {
+    track(customEventName, { ...extraParams, url });
+  }
   shell && shell.openExternal(url);
 };

--- a/src/renderer/modals/Swap/steps/StepFinished.js
+++ b/src/renderer/modals/Swap/steps/StepFinished.js
@@ -5,8 +5,8 @@ import type { Exchange, ExchangeRate } from "@ledgerhq/live-common/lib/exchange/
 import Box from "~/renderer/components/Box";
 import CopyWithFeedback from "~/renderer/components/CopyWithFeedback";
 import { Trans } from "react-i18next";
-import Text from "~/renderer/components/Text";
 import styled from "styled-components";
+import Text from "~/renderer/components/Text";
 import { colors } from "~/renderer/styles/theme";
 import Alert from "~/renderer/components/Alert";
 import Button from "~/renderer/components/Button";


### PR DESCRIPTION
I readded the ability to track events using `openURL` (the API was there in v1 but it seems like we forgot to resume it on v2)
Then I added the tracking event to the View in Explorer

### Type

tracking improvement

### Context

LL-6086

### Parts of the app affected / Test plan

View Operation / View Swap Operation
