### PR TITLE
Disable auto select of language on onboarding for new users

### DIFF
--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -120,7 +120,7 @@ const defaultsForCurrency: Currency => CurrencySettings = crypto => {
 const INITIAL_STATE: SettingsState = {
   hasCompletedOnboarding: false,
   counterValue: "USD",
-  language: null,
+  language: "en",
   theme: null,
   region: null,
   orderAccounts: "balance|desc",


### PR DESCRIPTION
Expectation:

- if you already have live, it will use system settings (or one chosen)
- if you come for first time, you would just get "en" by default (even if your computer is FR)