### PR TITLE
[Mac] Fix signature verification on build

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -8,6 +8,7 @@ protocols:
 afterSign: scripts/notarize.js
 
 mac:
+  strictVerify: false
   artifactName: ${name}-${version}-${os}.${ext}
   category: public.app-category.wallet
   hardenedRuntime: true


### PR DESCRIPTION
Building the Mac app currently fails because the signature check can't find `Ledger Live.app`.

Dropping the `--strict` flag passed to [electron-osx-sign](https://github.com/electron/electron-osx-sign#opts---options) fixes that, and is here done as one liner in config thanks to an undocumented option in electron-builder.

### Type

Bug Fix

### Context

electron/electron-osx-sign#161

### Parts of the app affected

App building on Mac.

### Test plan

`yarn dist` and `yarn release` should now be working.

NB: building without a valid certificate (like on the CI) was never affected, as signing and verifying were just skipped in this case.
