### PR TITLE
[Mac] LL-6309 Fix GateKeeper

### DIFF
--- a/electron-builder-nightly.yml
+++ b/electron-builder-nightly.yml
@@ -42,4 +42,6 @@ files:
   # Include files
   - .webpack/**/*
   # Exclude files
+  - "!node_modules/sodium-native/prebuilds"
+  - "!node_modules/sodium-native/tmp"
   # Exclude modules

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -8,7 +8,6 @@ protocols:
 afterSign: scripts/notarize.js
 
 mac:
-  strictVerify: false
   artifactName: ${name}-${version}-${os}.${ext}
   category: public.app-category.wallet
   hardenedRuntime: true

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -54,4 +54,6 @@ files:
   # Include files
   - .webpack/**/*
   # Exclude files
+  - "!node_modules/sodium-native/prebuilds"
+  - "!node_modules/sodium-native/tmp"
   # Exclude modules


### PR DESCRIPTION
#3963 fixed the building of the app, but the resulting bundle ended being still denied by GateKeeper ("developer cannot be verified" error on launch).
It turns out when the app is built, a list of binaries to be signed is embedded, and in this list was a _symlink_. At runtime, GateKeeper checks all the files in the list, but the symlink is now broken and the check fails.

The fix here is to exclude the unnecessary tmp folder containing the symlink.

Since I was at it, I also excluded the 40M of useless `sodium-native` prebuilds.

### Type

Bug Fix

### Context

#3963
https://ledgerhq.atlassian.net/browse/LL-6309

### Parts of the app affected

Building and running on Mac.


### Test plan

- Building the app on Mac should finish successfully
- Running the resulting binary shouldn't show an error on launch, even when downloaded from GitHub (my previous fix worked on local builds, but failed when downloaded from the net. My guess is that a more in depth check is done for downloaded apps)
