### PR TITLE
LL-4934 Send flow step 1 - memo type Hash: input content shouldn't be underlined

### DIFF
--- a/src/renderer/families/stellar/MemoValueField.js
+++ b/src/renderer/families/stellar/MemoValueField.js
@@ -37,6 +37,7 @@ const MemoValueField = ({
       error={status.errors.transaction}
       value={transaction.memoValue}
       onChange={onMemoValueChange}
+      spellCheck="false"
     />
   );
 };


### PR DESCRIPTION
Remove the spellchecker for the stellar memo field.

*Before the fix*

<img width="485" alt="Capture d’écran 2021-07-09 à 12 09 19" src="https://user-images.githubusercontent.com/86958797/125062366-985b8c80-e0ae-11eb-842a-777715b01974.png">

*After the fix*

<img width="483" alt="Capture d’écran 2021-07-09 à 12 09 27" src="https://user-images.githubusercontent.com/86958797/125062398-a01b3100-e0ae-11eb-94f1-d8435c488023.png">


### Type

Bug Fix

### Context

[LL-4934]

### Parts of the app affected / Test plan

- Send Stellar crypto
- Select any Memo type in the combo box
- Type anything as the Memo value
- It should not be spellchecked (underlined in red)


[LL-4934]: https://ledgerhq.atlassian.net/browse/LL-4934