### PR TITLE
[LL-6340] Remove apps wording in catalog

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -25,8 +25,8 @@
         "debug": "debug"
       },
       "banner": {
-        "title": "Discover our Live Apps Catalog",
-        "description": "We're working hard to bring you access to the world of DeFi, NFTs and more, securely, right inside Ledger Live!"
+        "title": "Discover our Live Catalog",
+        "description": "Unlock a new world of crypto possibilities. One secure access to all services – DeFi, NFTs and more to come."
       },
       "twitterBanner": {
         "description": "Tell us what’s the next service you want to see on Ledger Live with the hashtag",


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

https://ledgerhq.atlassian.net/browse/LL-6340
In the Discover page of the app remove all the "Apps" mentions

<details>
  <summary>Desktop 📸 </summary>

<img width="1028" alt="Screenshot" src="https://user-images.githubusercontent.com/87011321/125296817-f5617780-e326-11eb-9f97-c9fff2bf52bf.png">
</details>

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

UI Polish

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

N/A

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->

Live Catalog
