### PR TITLE
[LL-6363] add platform app info panel

### DIFF
--- a/src/renderer/actions/UI.js
+++ b/src/renderer/actions/UI.js
@@ -6,3 +6,8 @@ export const setTabInformationCenter = createAction("INFORMATION_CENTER_SET_TAB"
   tabId,
 }));
 export const closeInformationCenter = createAction("INFORMATION_CENTER_CLOSE");
+
+export const openPlatformAppInfo = createAction("PLATFORM_APP_INFO_OPEN", manifest => ({
+  manifest,
+}));
+export const closePlatformAppInfo = createAction("PLATFORM_APP_INFO_CLOSE");

--- a/src/renderer/components/Alert.js
+++ b/src/renderer/components/Alert.js
@@ -20,8 +20,8 @@ import Shield from "../icons/Shield";
 import ExclamationCircle from "../icons/ExclamationCircle";
 import CrossCircle from "../icons/CrossCircle";
 import LightBulb from "../icons/LightBulb";
-import ExternalLinkIcon from "../icons/ExternalLink";
 import Twitter from "../icons/Twitter";
+import ExternalLink from "./ExternalLink";
 
 const getIcon = (type: AlertType) => {
   switch (type) {
@@ -198,27 +198,6 @@ const CloseContainer = styled(Box)`
   }
 `;
 
-const ExternalLink = styled(Box).attrs(p => ({
-  cursor: "pointer",
-  horizontal: true,
-}))`
-  align-items: center;
-  display: inline-flex;
-  text-decoration: underline;
-  &:hover {
-    opacity: 0.8;
-  }
-
-  &:active {
-    opacity: 1;
-  }
-`;
-
-const ExternalLinkIconContainer = styled.span`
-  display: inline-flex;
-  margin-left: 4px;
-`;
-
 type AlertType =
   | "primary"
   | "secondary"
@@ -283,14 +262,7 @@ export default function Alert({
 
   const learnMore = hasLearnMore && (
     <Text ff="Inter|SemiBold">
-      <ExternalLink onClick={handleLearnMore}>
-        {label}
-        {!learnMoreIsInternal && (
-          <ExternalLinkIconContainer>
-            <ExternalLinkIcon size={13} />
-          </ExternalLinkIconContainer>
-        )}
-      </ExternalLink>
+      <ExternalLink label={label} isInternal={learnMoreIsInternal} onClick={handleLearnMore} />
     </Text>
   );
 

--- a/src/renderer/components/ExternalLink/index.js
+++ b/src/renderer/components/ExternalLink/index.js
@@ -1,0 +1,51 @@
+// @flow
+import React from "react";
+
+import styled from "styled-components";
+
+import Box from "../Box";
+import ExternalLinkIcon from "../../icons/ExternalLink";
+
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+const Container: ThemedComponent<{}> = styled(Box).attrs(p => ({
+  cursor: "pointer",
+  horizontal: true,
+}))`
+  align-items: center;
+  display: inline-flex;
+  text-decoration: underline;
+  &:hover {
+    opacity: 0.8;
+  }
+
+  &:active {
+    opacity: 1;
+  }
+`;
+
+const ExternalLinkIconContainer = styled.span`
+  display: inline-flex;
+  margin-left: 4px;
+`;
+
+type Props = {
+  label: any,
+  isInternal: boolean,
+  onClick: () => void,
+};
+
+const ExternalLink = ({ label, isInternal, onClick }: Props) => {
+  return (
+    <Container onClick={() => onClick()}>
+      {label}
+      {!isInternal && (
+        <ExternalLinkIconContainer>
+          <ExternalLinkIcon size={13} />
+        </ExternalLinkIconContainer>
+      )}
+    </Container>
+  );
+};
+
+export default ExternalLink;

--- a/src/renderer/components/Platform/AppCard.js
+++ b/src/renderer/components/Platform/AppCard.js
@@ -2,31 +2,14 @@
 
 import React, { useCallback } from "react";
 import styled, { css } from "styled-components";
-import { useSelector } from "react-redux";
-import { useTranslation } from "react-i18next";
 
 import type { AppManifest } from "@ledgerhq/live-common/lib/platform/types";
-import { translateContent } from "@ledgerhq/live-common/lib/platform/logic";
 
 import { rgba } from "~/renderer/styles/helpers";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
-import { languageSelector } from "~/renderer/reducers/settings";
 
-import Box, { Tabbable } from "~/renderer/components/Box";
-import LiveAppIcon from "~/renderer/components/WebPlatformPlayer/LiveAppIcon";
-
-function getBranchColor(branch, colors) {
-  switch (branch) {
-    case "soon":
-      return colors.palette.text.shade100;
-    case "experimental":
-      return colors.warning;
-    case "debug":
-      return colors.palette.text.shade40;
-    default:
-      return "currentColor";
-  }
-}
+import { Tabbable } from "~/renderer/components/Box";
+import AppDetails, { IconContainer } from "./AppDetails";
 
 const Container: ThemedComponent<{ isActive?: boolean, disabled?: boolean }> = styled(
   Tabbable,
@@ -68,69 +51,12 @@ const Container: ThemedComponent<{ isActive?: boolean, disabled?: boolean }> = s
         `}
 `;
 
-const HeaderContainer: ThemedComponent<{}> = styled(Box)`
-  width: 100%;
-  flex-direction: row;
-  align-items: center;
-`;
-
-const IconContainer: ThemedComponent<{}> = styled(Box).attrs(p => ({ mr: 2 }))`
-  user-select: none;
-  pointer-events: none;
-`;
-
-const TitleContainer: ThemedComponent<{}> = styled.div`
-  flex-shrink: 1;
-`;
-
-const AppName: ThemedComponent<{}> = styled(Box).attrs(p => ({
-  ff: "Inter|SemiBold",
-  fontSize: 5,
-  textAlign: "left",
-  color: p.theme.colors.palette.secondary.main,
-}))`
-  line-height: 18px;
-`;
-
-const Content: ThemedComponent<{}> = styled(Box)`
-  margin-top: 16px;
-  width: 100%;
-
-  :empty {
-    display: none;
-  }
-`;
-
-const BranchBadge: ThemedComponent<{}> = styled(Box).attrs(p => ({
-  ff: "Inter|SemiBold",
-  fontSize: 1,
-  color: getBranchColor(p.branch, p.theme.colors),
-}))`
-  display: inline-block;
-  padding: 1px 4px;
-  border: 1px solid currentColor;
-  border-radius: 3px;
-  text-transform: uppercase;
-  margin-bottom: 4px;
-  flex-grow: 0;
-  flex-shrink: 1;
-
-  ${p =>
-    p.branch === "soon" &&
-    `
-    background: ${p.theme.colors.palette.text.shade20};
-    border-width: 0;
-  `}
-`;
-
 type Props = {
   manifest: AppManifest,
   onClick: Function,
 };
 
 const AppCard = ({ manifest, onClick, ...rest }: Props) => {
-  const { t } = useTranslation();
-  const language = useSelector(languageSelector);
   const isDisabled = manifest.branch === "soon";
 
   const handleClick = useCallback(() => {
@@ -141,20 +67,7 @@ const AppCard = ({ manifest, onClick, ...rest }: Props) => {
 
   return (
     <Container {...rest} isInteractive={!!onClick} onClick={handleClick} disabled={isDisabled}>
-      <HeaderContainer>
-        <IconContainer>
-          <LiveAppIcon icon={manifest.icon || undefined} name={manifest.name} size={48} />
-        </IconContainer>
-        <TitleContainer>
-          {manifest.branch !== "stable" && (
-            <BranchBadge branch={manifest.branch}>
-              {t(`platform.catalog.branch.${manifest.branch}`)}
-            </BranchBadge>
-          )}
-          <AppName>{manifest.name}</AppName>
-        </TitleContainer>
-      </HeaderContainer>
-      <Content>{translateContent(manifest.content.shortDescription, language)}</Content>
+      <AppDetails manifest={manifest} />
     </Container>
   );
 };

--- a/src/renderer/components/Platform/AppDetails.js
+++ b/src/renderer/components/Platform/AppDetails.js
@@ -1,0 +1,112 @@
+// @flow
+
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+import styled from "styled-components";
+
+import { translateContent } from "@ledgerhq/live-common/lib/platform/logic";
+import type { AppManifest } from "@ledgerhq/live-common/lib/platform/types";
+
+import Box from "~/renderer/components/Box";
+import LiveAppIcon from "~/renderer/components/WebPlatformPlayer/LiveAppIcon";
+import { languageSelector } from "~/renderer/reducers/settings";
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+const getBranchColor = (branch, colors) => {
+  switch (branch) {
+    case "soon":
+      return colors.palette.text.shade100;
+    case "experimental":
+      return colors.warning;
+    case "debug":
+      return colors.palette.text.shade40;
+    default:
+      return "currentColor";
+  }
+};
+
+const HeaderContainer: ThemedComponent<{}> = styled(Box)`
+  width: 100%;
+  flex-direction: row;
+  align-items: center;
+`;
+
+export const IconContainer: ThemedComponent<{}> = styled(Box).attrs(p => ({ mr: 2 }))`
+  user-select: none;
+  pointer-events: none;
+`;
+
+const TitleContainer: ThemedComponent<{}> = styled.div`
+  flex-shrink: 1;
+`;
+
+const AppName: ThemedComponent<{}> = styled(Box).attrs(p => ({
+  ff: "Inter|SemiBold",
+  fontSize: 5,
+  textAlign: "left",
+  color: p.theme.colors.palette.secondary.main,
+}))`
+  line-height: 18px;
+`;
+
+const Content: ThemedComponent<{}> = styled(Box)`
+  margin-top: 16px;
+  width: 100%;
+
+  :empty {
+    display: none;
+  }
+`;
+
+const BranchBadge: ThemedComponent<{}> = styled(Box).attrs(p => ({
+  ff: "Inter|SemiBold",
+  fontSize: 1,
+  color: getBranchColor(p.branch, p.theme.colors),
+}))`
+  display: inline-block;
+  padding: 1px 4px;
+  border: 1px solid currentColor;
+  border-radius: 3px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+  flex-grow: 0;
+  flex-shrink: 1;
+
+  ${p =>
+    p.branch === "soon" &&
+    `
+    background: ${p.theme.colors.palette.text.shade20};
+    border-width: 0;
+  `}
+`;
+
+type Props = {
+  manifest: AppManifest,
+};
+
+const AppDetails = ({ manifest }: Props) => {
+  const { t } = useTranslation();
+  const language = useSelector(languageSelector);
+
+  return (
+    <>
+      <HeaderContainer>
+        <IconContainer>
+          <LiveAppIcon icon={manifest.icon || undefined} name={manifest.name} size={48} />
+        </IconContainer>
+        <TitleContainer>
+          {manifest.branch !== "stable" && (
+            <BranchBadge branch={manifest.branch}>
+              {t(`platform.catalog.branch.${manifest.branch}`)}
+            </BranchBadge>
+          )}
+          <AppName>{manifest.name}</AppName>
+        </TitleContainer>
+      </HeaderContainer>
+      <Content>{translateContent(manifest.content.shortDescription, language)}</Content>
+    </>
+  );
+};
+
+export default AppDetails;

--- a/src/renderer/components/SideDrawer.js
+++ b/src/renderer/components/SideDrawer.js
@@ -203,7 +203,7 @@ export function SideDrawer({
       {state => (
         <DrawerContainer className="sidedrawer" state={state} ref={focusTrapElem} tabIndex="-1">
           <DrawerContent {...props} isOpened={isOpen} state={state} direction={direction}>
-            {onRequestClose || onRequestBack ? (
+            {onRequestClose || onRequestBack || title ? (
               <Box
                 horizontal
                 justifyContent="space-between"
@@ -230,10 +230,12 @@ export function SideDrawer({
                   </Text>
                 )}
 
-                {onRequestClose && (
+                {onRequestClose ? (
                   <TouchButton onClick={onRequestClose} className="sidedrawer-close">
                     <IconCross size={16} />
                   </TouchButton>
+                ) : (
+                  <Box />
                 )}
               </Box>
             ) : null}

--- a/src/renderer/components/SideDrawer.js
+++ b/src/renderer/components/SideDrawer.js
@@ -116,6 +116,7 @@ type DrawerProps = {
   onRequestBack?: (*) => void,
   direction?: "right" | "left",
   paper?: boolean,
+  title?: string,
 };
 
 export function SideDrawer({
@@ -124,6 +125,7 @@ export function SideDrawer({
   onRequestClose,
   onRequestBack,
   direction = "right",
+  title,
   ...props
 }: DrawerProps) {
   const [isMounted, setMounted] = useState(false);
@@ -211,15 +213,23 @@ export function SideDrawer({
                 p="24px"
                 style={{ zIndex: 200 }}
               >
-                {onRequestBack && (
+                {onRequestBack ? (
                   <Button onClick={onRequestBack} className="sidedrawer-close">
                     <IconAngleLeft size={12} />
                     <Text ff="Inter|Medium" fontSize={4} color="palette.text.shade40">
                       <Trans i18nKey="common.back" />
                     </Text>
                   </Button>
+                ) : (
+                  <Box />
                 )}
-                <Box flex="1" />
+
+                {title && (
+                  <Text ff="Inter|SemiBold" fontWeight="600" fontSize="18px">
+                    {title}
+                  </Text>
+                )}
+
                 {onRequestClose && (
                   <TouchButton onClick={onRequestClose} className="sidedrawer-close">
                     <IconCross size={16} />

--- a/src/renderer/components/TopBar/index.js
+++ b/src/renderer/components/TopBar/index.js
@@ -31,6 +31,7 @@ import { setDiscreetMode } from "~/renderer/actions/settings";
 import { hasPasswordSelector } from "~/renderer/reducers/application";
 import { NotificationIndicator } from "~/renderer/components/TopBar/NotificationIndicator";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import { LiveAppInformationDrawer } from "~/renderer/components/WebPlatformPlayer/LiveAppInformationDrawer";
 
 const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({}))`
   height: ${p => p.theme.sizes.topBarHeight}px;
@@ -103,6 +104,7 @@ const TopBar = () => {
                 </Box>
               </>
             )}
+            <LiveAppInformationDrawer />
             <ServiceStatusIndicator />
             <NotificationIndicator />
             <Box justifyContent="center">

--- a/src/renderer/components/WebPlatformPlayer/InfosDrawer.js
+++ b/src/renderer/components/WebPlatformPlayer/InfosDrawer.js
@@ -1,0 +1,60 @@
+// @flow
+
+import React from "react";
+import { SideDrawer } from "~/renderer/components/SideDrawer";
+import Box from "~/renderer/components/Box";
+import styled from "styled-components";
+import { openURL } from "~/renderer/linking";
+
+import { useTranslation } from "react-i18next";
+
+import type { AppManifest } from "@ledgerhq/live-common/lib/platform/types";
+
+import Text from "../Text";
+import ExternalLink from "../ExternalLink/index";
+import AppDetails from "../Platform/AppDetails";
+
+const Divider = styled(Box)`
+  width: 420px;
+  top: 168px;
+  border: 1px solid rgba(20, 37, 51, 0.1);
+  margin: 32px 0px;
+`;
+
+export const InformationDrawer = ({
+  isOpen,
+  onRequestClose,
+  manifest,
+}: {
+  isOpen: boolean,
+  onRequestClose: () => void,
+  manifest: AppManifest,
+}) => {
+  const { homepageUrl } = manifest;
+
+  const { t } = useTranslation();
+
+  return (
+    <SideDrawer
+      title={t(`platform.app.informations.title`)}
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      direction="left"
+    >
+      <Box pt="60px" height="100%" px="40px">
+        <AppDetails manifest={manifest} />
+
+        <Divider />
+
+        <Text ff="Inter|SemiBold">{t(`platform.app.informations.website`)}</Text>
+        <Text ff="Inter" color="#6490F1">
+          <ExternalLink
+            label={homepageUrl}
+            isInternal={false}
+            onClick={() => openURL(homepageUrl)}
+          />
+        </Text>
+      </Box>
+    </SideDrawer>
+  );
+};

--- a/src/renderer/components/WebPlatformPlayer/LiveAppInformationDrawer.js
+++ b/src/renderer/components/WebPlatformPlayer/LiveAppInformationDrawer.js
@@ -1,14 +1,16 @@
 // @flow
 
 import React from "react";
-import { SideDrawer } from "~/renderer/components/SideDrawer";
-import Box from "~/renderer/components/Box";
 import styled from "styled-components";
-import { openURL } from "~/renderer/linking";
-
+import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 
-import type { AppManifest } from "@ledgerhq/live-common/lib/platform/types";
+import { SideDrawer } from "~/renderer/components/SideDrawer";
+import Box from "~/renderer/components/Box";
+import { openURL } from "~/renderer/linking";
+
+import { closePlatformAppInfo } from "~/renderer/actions/UI";
+import { platformAppInfoStateSelector } from "~/renderer/reducers/UI";
 
 import Text from "../Text";
 import ExternalLink from "../ExternalLink/index";
@@ -21,24 +23,22 @@ const Divider = styled(Box)`
   margin: 32px 0px;
 `;
 
-export const InformationDrawer = ({
-  isOpen,
-  onRequestClose,
-  manifest,
-}: {
-  isOpen: boolean,
-  onRequestClose: () => void,
-  manifest: AppManifest,
-}) => {
-  const { homepageUrl } = manifest;
+export const LiveAppInformationDrawer = () => {
+  const { isOpen, manifest } = useSelector(platformAppInfoStateSelector);
+
+  const { homepageUrl } = manifest || {};
 
   const { t } = useTranslation();
+
+  const dispatch = useDispatch();
 
   return (
     <SideDrawer
       title={t(`platform.app.informations.title`)}
       isOpen={isOpen}
-      onRequestClose={onRequestClose}
+      onRequestClose={() => {
+        dispatch(closePlatformAppInfo());
+      }}
       direction="left"
     >
       <Box pt="60px" height="100%" px="40px">

--- a/src/renderer/components/WebPlatformPlayer/LiveAppInformationDrawer.js
+++ b/src/renderer/components/WebPlatformPlayer/LiveAppInformationDrawer.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import React, { useCallback } from "react";
 import styled from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
@@ -31,6 +31,10 @@ export const LiveAppInformationDrawer = () => {
 
   const dispatch = useDispatch();
 
+  const onClick = useCallback(() => {
+    openURL(homepageUrl);
+  }, [homepageUrl]);
+
   return (
     <SideDrawer
       title={t(`platform.app.informations.title`)}
@@ -47,11 +51,7 @@ export const LiveAppInformationDrawer = () => {
 
         <Text ff="Inter|SemiBold">{t(`platform.app.informations.website`)}</Text>
         <Text ff="Inter" color="#6490F1">
-          <ExternalLink
-            label={homepageUrl}
-            isInternal={false}
-            onClick={() => openURL(homepageUrl)}
-          />
+          <ExternalLink label={homepageUrl} isInternal={false} onClick={onClick} />
         </Text>
       </Box>
     </SideDrawer>

--- a/src/renderer/components/WebPlatformPlayer/LiveAppInformationDrawer.js
+++ b/src/renderer/components/WebPlatformPlayer/LiveAppInformationDrawer.js
@@ -16,11 +16,10 @@ import Text from "../Text";
 import ExternalLink from "../ExternalLink/index";
 import AppDetails from "../Platform/AppDetails";
 
-const Divider = styled(Box)`
-  width: 420px;
-  top: 168px;
+const Divider = styled(Box).attrs(() => ({
+  my: 5,
+}))`
   border: 1px solid rgba(20, 37, 51, 0.1);
-  margin: 32px 0px;
 `;
 
 export const LiveAppInformationDrawer = () => {
@@ -41,7 +40,7 @@ export const LiveAppInformationDrawer = () => {
       }}
       direction="left"
     >
-      <Box pt="60px" height="100%" px="40px">
+      <Box pt={7} px={6}>
         <AppDetails manifest={manifest} />
 
         <Divider />

--- a/src/renderer/components/WebPlatformPlayer/TopBar.js
+++ b/src/renderer/components/WebPlatformPlayer/TopBar.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import { useDispatch } from "react-redux";
@@ -114,6 +114,10 @@ const WebPlatformTopBar = ({ manifest, onReload, onHelp, onClose }: Props) => {
 
   const dispatch = useDispatch();
 
+  const onClick = useCallback(() => {
+    dispatch(openPlatformAppInfo(manifest));
+  }, [manifest, dispatch]);
+
   return (
     <Container>
       <TitleContainer>
@@ -128,12 +132,7 @@ const WebPlatformTopBar = ({ manifest, onReload, onHelp, onClose }: Props) => {
         </ItemContent>
       </ItemContainer>
       <RightContainer>
-        <ItemContainer
-          isInteractive
-          onClick={() => {
-            dispatch(openPlatformAppInfo(manifest));
-          }}
-        >
+        <ItemContainer isInteractive onClick={onClick}>
           <IconInfoCircle size={16} />
         </ItemContainer>
         <ItemContainer isInteractive onClick={onClose}>

--- a/src/renderer/components/WebPlatformPlayer/TopBar.js
+++ b/src/renderer/components/WebPlatformPlayer/TopBar.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import React, { useState } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 
@@ -11,11 +11,12 @@ import { rgba } from "~/renderer/styles/helpers";
 
 import Box, { Tabbable } from "~/renderer/components/Box";
 
-// import IconInfoCircle from "~/renderer/icons/InfoCircle";
+import IconInfoCircle from "~/renderer/icons/InfoCircle";
 import IconReload from "~/renderer/icons/UpdateCircle";
 import IconClose from "~/renderer/icons/Cross";
 
 import LiveAppIcon from "./LiveAppIcon";
+import { InformationDrawer } from "./InfosDrawer";
 
 const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({
   horizontal: true,
@@ -109,8 +110,15 @@ export type Props = {
 const WebPlatformTopBar = ({ manifest, onReload, onHelp, onClose }: Props) => {
   const { name, icon } = manifest;
 
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
     <Container>
+      <InformationDrawer
+        isOpen={isOpen}
+        onRequestClose={() => setIsOpen(false)}
+        manifest={manifest}
+      />
       <TitleContainer>
         <LiveAppIcon name={name} icon={icon || undefined} size={24} />
         <ItemContent>{name}</ItemContent>
@@ -123,9 +131,14 @@ const WebPlatformTopBar = ({ manifest, onReload, onHelp, onClose }: Props) => {
         </ItemContent>
       </ItemContainer>
       <RightContainer>
-        {/* <ItemContainer isInteractive onClick={onHelp}>
+        <ItemContainer
+          isInteractive
+          onClick={() => {
+            setIsOpen(true);
+          }}
+        >
           <IconInfoCircle size={16} />
-        </ItemContainer> */}
+        </ItemContainer>
         <ItemContainer isInteractive onClick={onClose}>
           <IconClose size={16} />
         </ItemContainer>

--- a/src/renderer/components/WebPlatformPlayer/TopBar.js
+++ b/src/renderer/components/WebPlatformPlayer/TopBar.js
@@ -1,8 +1,9 @@
 // @flow
 
-import React, { useState } from "react";
+import React from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
+import { useDispatch } from "react-redux";
 
 import type { AppManifest } from "@ledgerhq/live-common/lib/platform/types";
 
@@ -16,7 +17,8 @@ import IconReload from "~/renderer/icons/UpdateCircle";
 import IconClose from "~/renderer/icons/Cross";
 
 import LiveAppIcon from "./LiveAppIcon";
-import { InformationDrawer } from "./InfosDrawer";
+
+import { openPlatformAppInfo } from "~/renderer/actions/UI";
 
 const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({
   horizontal: true,
@@ -110,15 +112,10 @@ export type Props = {
 const WebPlatformTopBar = ({ manifest, onReload, onHelp, onClose }: Props) => {
   const { name, icon } = manifest;
 
-  const [isOpen, setIsOpen] = useState(false);
+  const dispatch = useDispatch();
 
   return (
     <Container>
-      <InformationDrawer
-        isOpen={isOpen}
-        onRequestClose={() => setIsOpen(false)}
-        manifest={manifest}
-      />
       <TitleContainer>
         <LiveAppIcon name={name} icon={icon || undefined} size={24} />
         <ItemContent>{name}</ItemContent>
@@ -134,7 +131,7 @@ const WebPlatformTopBar = ({ manifest, onReload, onHelp, onClose }: Props) => {
         <ItemContainer
           isInteractive
           onClick={() => {
-            setIsOpen(true);
+            dispatch(openPlatformAppInfo(manifest));
           }}
         >
           <IconInfoCircle size={16} />

--- a/src/renderer/reducers/UI.js
+++ b/src/renderer/reducers/UI.js
@@ -1,12 +1,19 @@
 // @flow
 
 import { handleActions } from "redux-actions";
+
+import type { AppManifest } from "@ledgerhq/live-common/lib/platform/types";
+
 import type { State } from "~/renderer/reducers";
 
 export type UIState = {
   informationCenter: {
     isOpen: boolean,
     tabId: string,
+  },
+  platformAppInfo: {
+    isOpen: boolean,
+    manifest: ?AppManifest,
   },
 };
 
@@ -15,10 +22,18 @@ const initialState: UIState = {
     isOpen: false,
     tabId: "announcement",
   },
+  platformAppInfo: {
+    isOpen: false,
+    manifest: undefined,
+  },
 };
 
 type OpenPayload = {
   tabId?: string,
+};
+
+type OpenPlatformAppInfoPayload = {
+  manifest: AppManifest,
 };
 
 const handlers = {
@@ -54,6 +69,28 @@ const handlers = {
       },
     };
   },
+
+  PLATFORM_APP_INFO_OPEN: (state, { payload }: { payload: OpenPlatformAppInfoPayload }) => {
+    const { manifest } = payload;
+
+    return {
+      ...state,
+      platformAppInfo: {
+        isOpen: true,
+        manifest,
+      },
+    };
+  },
+
+  PLATFORM_APP_INFO_CLOSE: state => {
+    return {
+      ...state,
+      platformAppInfo: {
+        ...state.platformAppInfo,
+        isOpen: false,
+      },
+    };
+  },
 };
 
 // Selectors
@@ -61,6 +98,8 @@ const handlers = {
 export const UIStateSelector = (state: State): UIState => state.UI;
 
 export const informationCenterStateSelector = (state: Object) => state.UI.informationCenter;
+
+export const platformAppInfoStateSelector = (state: Object) => state.UI.platformAppInfo;
 // Exporting reducer
 
 export default handleActions(handlers, initialState);

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -17,6 +17,12 @@
         }
       }
     },
+    "app": {
+      "informations": {
+        "title": "Informations",
+        "website": "Website"
+      }
+    },
     "catalog": {
       "title": "Discover",
       "branch": {


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

Add a button that open a side drawer featuring generic platform app information
cf. https://ledgerhq.atlassian.net/browse/LL-6363

<details>
  <summary>Desktop 📸 </summary>

![Screenshot](https://user-images.githubusercontent.com/87011321/125460268-315d1205-8f57-4d57-9f2f-251006a22d76.png)

</details>

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

Feature

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->

_Platform catalog_

Once in a "service" or "app" in the "discover" page, open an app and click the information button on the top right corner. A side drawer with informations relative to the selected app are displayed, including title, description and a link to the service website. Clicking on this link should open the service webpage.
