### PR TITLE
[LL-6107] Fix send flow modal close

### DIFF
--- a/src/renderer/modals/Send/index.js
+++ b/src/renderer/modals/Send/index.js
@@ -24,7 +24,9 @@ const SendModal = ({ stepId, onClose }: Props) => {
 
   const handleStepChange = (stepId: StepId) => setState({ ...state, stepId });
 
-  const isModalLocked = ["recipient", "confirmation"].includes(state.stepId);
+  const isModalLocked = ["recipient", "amount", "summary", "device", "confirmation"].includes(
+    state.stepId,
+  );
 
   const rest = {};
   if (onClose) {


### PR DESCRIPTION
Prevent closing modal when clicking on backdrop while on any of the send flow step.

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-6107

### Parts of the app affected / Test plan

Send flow modal. Clicking on the backdrop should not close the modal on any step.