### PR TITLE
LL-6084 - Filter ANN by Live versions

### DIFF
--- a/src/renderer/components/AnnouncementProviderWrapper.js
+++ b/src/renderer/components/AnnouncementProviderWrapper.js
@@ -67,6 +67,7 @@ export function AnnouncementProviderWrapper({ children }: Props) {
     language,
     currencies,
     getDate: () => new Date(),
+    appVersion: __APP_VERSION__,
   };
 
   const onNewAnnouncement = useCallback(

--- a/src/renderer/components/debug/DebugMock.js
+++ b/src/renderer/components/debug/DebugMock.js
@@ -261,8 +261,8 @@ const DebugMock = () => {
   const [expandedNotif, setExpandedNotif] = useState(false);
 
   const [notifPlatform, setNotifPlatform] = useState("");
-  const [notifAppVersionApps, setNotifAppVersionApps] = useState("");
-  const [notifLLComonVersionApps, setNotifLLComonVersionApps] = useState("");
+  const [notifAppVersions, setNotifAppVersions] = useState("");
+  const [notifLiveCommonVersions, setNotifLiveCommonVersions] = useState("");
   const [notifCurrencies, setNotifCurrencies] = useState("");
   const [notifDeviceVersion, setNotifDeviceVersion] = useState("");
   const [notifDeviceModelId, setNotifDeviceModelId] = useState("");
@@ -316,8 +316,8 @@ const DebugMock = () => {
     const params = {
       currencies: formatInputValue(notifCurrencies),
       platforms: formatInputValue(notifPlatform),
-      appVersions: formatInputValue(notifAppVersionApps),
-      liveCommonVersions: formatInputValue(notifLLComonVersionApps),
+      appVersions: formatInputValue(notifAppVersions),
+      liveCommonVersions: formatInputValue(notifLiveCommonVersions),
       languages: formatInputValue(notifLanguages),
     };
 
@@ -352,8 +352,8 @@ const DebugMock = () => {
     notifExtra,
     notifLanguages,
     notifPlatform,
-    notifAppVersionApps,
-    notifLLComonVersionApps,
+    notifAppVersions,
+    notifLiveCommonVersions,
     updateCache,
   ]);
 
@@ -525,14 +525,14 @@ const DebugMock = () => {
                 <input
                   type="text"
                   placeholder="app versions separated by ','"
-                  value={notifAppVersionApps}
-                  onChange={setValue(setNotifAppVersionApps)}
+                  value={notifAppVersions}
+                  onChange={setValue(setNotifAppVersions)}
                 />
                 <input
                   type="text"
-                  placeholder="ll-common versions separated by ','"
-                  value={notifLLComonVersionApps}
-                  onChange={setValue(setNotifLLComonVersionApps)}
+                  placeholder="live-common versions separated by ','"
+                  value={notifLiveCommonVersions}
+                  onChange={setValue(setNotifLiveCommonVersions)}
                 />
                 <textarea
                   type="text"

--- a/src/renderer/components/debug/DebugMock.js
+++ b/src/renderer/components/debug/DebugMock.js
@@ -261,6 +261,8 @@ const DebugMock = () => {
   const [expandedNotif, setExpandedNotif] = useState(false);
 
   const [notifPlatform, setNotifPlatform] = useState("");
+  const [notifAppVersionApps, setNotifAppVersionApps] = useState("");
+  const [notifLLComonVersionApps, setNotifLLComonVersionApps] = useState("");
   const [notifCurrencies, setNotifCurrencies] = useState("");
   const [notifDeviceVersion, setNotifDeviceVersion] = useState("");
   const [notifDeviceModelId, setNotifDeviceModelId] = useState("");
@@ -314,6 +316,8 @@ const DebugMock = () => {
     const params = {
       currencies: formatInputValue(notifCurrencies),
       platforms: formatInputValue(notifPlatform),
+      appVersions: formatInputValue(notifAppVersionApps),
+      liveCommonVersions: formatInputValue(notifLLComonVersionApps),
       languages: formatInputValue(notifLanguages),
     };
 
@@ -348,6 +352,8 @@ const DebugMock = () => {
     notifExtra,
     notifLanguages,
     notifPlatform,
+    notifAppVersionApps,
+    notifLLComonVersionApps,
     updateCache,
   ]);
 
@@ -515,6 +521,18 @@ const DebugMock = () => {
                   placeholder="device apps separated by ','"
                   value={notifDeviceApps}
                   onChange={setValue(setNotifDeviceApps)}
+                />
+                <input
+                  type="text"
+                  placeholder="app versions separated by ','"
+                  value={notifAppVersionApps}
+                  onChange={setValue(setNotifAppVersionApps)}
+                />
+                <input
+                  type="text"
+                  placeholder="ll-common versions separated by ','"
+                  value={notifLLComonVersionApps}
+                  onChange={setValue(setNotifLLComonVersionApps)}
                 />
                 <textarea
                   type="text"


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Feature

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

[LL-6084]

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->

Announces.
To test this feature, you will have to wait for the ledger-live-common bump. Current modification from ledger-live-common is [here](https://github.com/LedgerHQ/ledger-live-common/pull/1310). Once this PR is merged, the ledger-live-common package published and updated from this repository, you'll be able to test it.

No wanna wait? No problem, fetch my [ledger-live-common branch](https://github.com/LedgerHQ/ledger-live-common/pull/1310) locally, install packages if needed and run `yalc publish` command at the root of the fetched branch. Once the publish command is completed, fetch the branch of this PR and run `yarn link` command at the root of the repository. That's will allow you to test this branch with the modification from ledger-live-common without waiting for the package to be published.

Once you have the correct environment, you'll be able to generate fake announces from the mock by settings the` MOCK` env value to `true`. I added two new inputs to the mocking UI of the announcement feature to allow developers and QA to generate announcements with some app version/ledger-live-common version restriction.

Don't hesitate to ping me if needed.

[LL-6084]: https://ledgerhq.atlassian.net/browse/LL-6084