### PR TITLE
LL-6467 wording change for kyc pending status

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -283,7 +283,7 @@
         "pending": {
           "cta": "Continue",
           "title": "Pending approval",
-          "subtitle": "Your information was submitted for approval by Wyre. It usually takes 1-3 days before you can start swapping.",
+          "subtitle": "Your information was submitted for approval by Wyre.",
           "link": "Learn more about KYC"
         },
         "closed": {


### PR DESCRIPTION
Wording changed again to remove time references

[LL-6467]

[LL-6467]: https://ledgerhq.atlassian.net/browse/LL-6467