### PR TITLE
[FIX] Add execution condition to tests step

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -59,6 +59,7 @@ jobs:
           INSTRUMENT_BUILD: true
         run: yarn build
       - name: Tests
+        if: always() && job.status != 'cancelled'
         run: yarn test 2> >(tee jest.txt)
       - name: Read jest output
         id: jest


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

It looks like there is an inconsistency in the CI workflow on LLD:
- The lint step fails -> no subsequent steps are run
- i.e: Tests step is not run
- But Read jest output runs because of it’s condition, but fails since it has no test result file to read (because tests were skipped)

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

Bug Fix

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

N/A

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->

N/A