### PR TITLE
[LL-6363] Fix typo in uncountable "information" wording

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -19,7 +19,7 @@
     },
     "app": {
       "informations": {
-        "title": "Informations",
+        "title": "Information",
         "website": "Website"
       }
     },


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

_Information_ is uncountable in english, i.e can't be plural

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

Bug Fix

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

cf. [this comment](https://ledgerhq.atlassian.net/browse/LL-6363?focusedCommentId=120716) on Jira

cf. [Cambridge dictionary](https://dictionary.cambridge.org/grammar/british-grammar/information) 

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
