### PR TITLE
LL-6596 Swap - Make floating rate default again

### DIFF
--- a/src/renderer/screens/exchange/swap/Form/index.js
+++ b/src/renderer/screens/exchange/swap/Form/index.js
@@ -63,7 +63,7 @@ const Form = ({
   const providerKYC = swapKYC[provider];
   const selectableCurrencies = getSupportedCurrencies({ providers, provider });
   const [shouldFocusOnAmountNonce, setShouldFocusOnAmountNonce] = useState(0);
-  const [tradeMethod, setTradeMethod] = useState<Method>("fixed");
+  const [tradeMethod, setTradeMethod] = useState<Method>("float");
 
   const [state, dispatch] = useReducer(reducer, {
     useAllAmount: false,


### PR DESCRIPTION
With the merger of the Wyre pr I introduced a regression that set the default trade method back to fixed, I assume this was done during development for some reason and I completely missed it.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-6596

### Parts of the app affected / Test plan

- Check that when selecting a currency pair the default trade method selected is float when available
