### PR TITLE
new libcore fix to fix linux crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@ledgerhq/hw-transport": "6.3.0",
     "@ledgerhq/hw-transport-http": "6.3.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "6.3.0",
-    "@ledgerhq/ledger-core": "6.12.3-beta1",
+    "@ledgerhq/ledger-core": "6.12.5",
     "@ledgerhq/live-common": "20.11.0",
     "@ledgerhq/logs": "6.2.0",
     "@polkadot/react-identicon": "0.84.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@ledgerhq/hw-transport": "6.3.0",
     "@ledgerhq/hw-transport-http": "6.3.0",
     "@ledgerhq/hw-transport-node-hid-singleton": "6.3.0",
-    "@ledgerhq/ledger-core": "6.12.3",
+    "@ledgerhq/ledger-core": "6.12.3-beta1",
     "@ledgerhq/live-common": "20.11.0",
     "@ledgerhq/logs": "6.2.0",
     "@polkadot/react-identicon": "0.84.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,10 +2042,10 @@
     "@ledgerhq/errors" "^6.2.0"
     events "^3.3.0"
 
-"@ledgerhq/ledger-core@6.12.3":
-  version "6.12.3"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-6.12.3.tgz#f9f0de61a5146988d47ce4765e308e7e6483ae1e"
-  integrity sha512-A8LDEPe4HFS+Z7iWyemKaP89DWgh/RHbHw7JarZ/pRgQU4kYX2vyWvmeARawyMPUg2Ez5B0y4yqBuDHctDU0mg==
+"@ledgerhq/ledger-core@6.12.3-beta1":
+  version "6.12.3-beta1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-6.12.3-beta1.tgz#8b3c7df6575a8d2a0f72ec76bea678d636515bd9"
+  integrity sha512-tt1hXVV5ehKnd9wj7Ra8WbqJwCClsA19qQfNMRKqxPy5Vlu44lZcbIJFJsz8SW92G2d1dYqe6ZaLVTwUz4Krxg==
   dependencies:
     bindings "1.5.0"
     nan "^2.14.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,10 +2042,10 @@
     "@ledgerhq/errors" "^6.2.0"
     events "^3.3.0"
 
-"@ledgerhq/ledger-core@6.12.3-beta1":
-  version "6.12.3-beta1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-6.12.3-beta1.tgz#8b3c7df6575a8d2a0f72ec76bea678d636515bd9"
-  integrity sha512-tt1hXVV5ehKnd9wj7Ra8WbqJwCClsA19qQfNMRKqxPy5Vlu44lZcbIJFJsz8SW92G2d1dYqe6ZaLVTwUz4Krxg==
+"@ledgerhq/ledger-core@6.12.5":
+  version "6.12.5"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-6.12.5.tgz#f99ee19c175dd43d2404dbd7df290063deb82373"
+  integrity sha512-9joHhYj4gOxVZ4nk2/tMYiA6jsfoN1MeAEpDyGy+EU1dXtV0/E+Wtg3cG6R14hm81sRnXfrx28OTcPfHjWNElA==
   dependencies:
     bindings "1.5.0"
     nan "^2.14.2"


### PR DESCRIPTION
Fix linux crash:
https://github.com/LedgerHQ/ledger-live-desktop/issues/4016

For the libcore part, 
when we build the nodejs binding for libcore, I use the 
our own docker image ghcr.io/ledgerhq/lib-ledger-core-build-env/lib-ledger-core-build-env:latest
instead of the ubuntu16.04 github action image because our docker image has a lower stable GLIBCXX version. So that we don't have the GLIBCXX version problem now.

More detail can be found here for the nodejs binding build:  
https://github.com/LedgerHQ/lib-ledger-core-node-bindings/compare/v6.12.3_fix#diff-4e8bf7a54f3e0839dd1725cf4053a605ac30839b8c5b3202c17872960596fd60

