### PR TITLE
LL-6435 Fix manager redirection from platform

### DIFF
--- a/src/renderer/components/DeviceAction/rendering.js
+++ b/src/renderer/components/DeviceAction/rendering.js
@@ -202,7 +202,7 @@ const OpenManagerBtn = ({
     const search = urlParams.toString();
     setTrackingSource("device action open manager button");
     history.push({
-      pathname: "manager",
+      pathname: "/manager",
       search: search ? `?${search}` : "",
     });
     closeAllModal();


### PR DESCRIPTION
As discovered by @FabriceDautriat there was an issue in the platform context that prevented reaching the manager when a flow (sign/send/whatever) required the user to navigate away from platform. In essence what was happening is that clicking the "Go to manager" CTA made us navigate to `/platform/manager` instead of `/manager` and therefor resulted in the a blank screen and no manager to manage the manageable. 

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-6435

### Parts of the app affected / Test plan

Following the steps provided by Fabrice:
- Fill the connected device to the brim with apps, including Ethereum and excluding Paraswap
- Enter the Paraswap dApp
- Attempt a swap
- Reach the Device Action error screen with the "Go to manager" CTA
- Click on the CTA

If all goes well, you should enter the manager and have Paraswap pre filtered in the catalog. 
If you reach a white screen, the fix doesn't work.
