### PR TITLE
[LL-6803] generalize sign transaction workflow for all crypto

### DIFF
--- a/src/renderer/components/WebPlatformPlayer/index.js
+++ b/src/renderer/components/WebPlatformPlayer/index.js
@@ -81,6 +81,43 @@ type Props = {
   inputs?: Object,
 };
 
+const getTransactionInfos = platformTx => {
+  const { family } = platformTx;
+  const tx = platformTx;
+
+  switch (family) {
+    case "ethereum": {
+      const hasFeesProvided = tx.gasLimit || tx.gasPrice;
+
+      if (hasFeesProvided) {
+        tx.feesStrategy = "custom";
+        tx.userGasLimit = tx.gasLimit;
+      }
+
+      return { canEditFees: true, tx, hasFeesProvided };
+    }
+
+    case "bitcoin": {
+      const hasFeesProvided = !!tx.feePerByte;
+
+      if (hasFeesProvided) {
+        tx.feesStrategy = null;
+      }
+
+      return { canEditFees: true, tx, hasFeesProvided };
+    }
+
+    case "ripple": {
+      const hasFeesProvided = !!tx.fee;
+
+      return { canEditFees: true, tx, hasFeesProvided };
+    }
+
+    default:
+      return { canEditFees: false, tx, hasFeesProvided: false };
+  }
+};
+
 const WebPlatformPlayer = ({ manifest, onClose, inputs }: Props) => {
   const theme = useTheme("colors.palette");
 
@@ -247,10 +284,14 @@ const WebPlatformPlayer = ({ manifest, onClose, inputs }: Props) => {
 
       tracking.platformSignTransactionRequested(manifest);
 
+      const { canEditFees, tx, hasFeesProvided } = getTransactionInfos(platformTransaction);
+
       return new Promise((resolve, reject) =>
         dispatch(
           openModal("MODAL_SIGN_TRANSACTION", {
-            transactionData: platformTransaction,
+            canEditFees,
+            stepId: canEditFees && !hasFeesProvided ? "amount" : "summary",
+            transactionData: tx,
             useApp: params.useApp,
             account,
             parentAccount: null,

--- a/src/renderer/modals/SignTransaction/Body.js
+++ b/src/renderer/modals/SignTransaction/Body.js
@@ -21,6 +21,7 @@ import Track from "~/renderer/analytics/Track";
 import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import StepAmount, { StepAmountFooter } from "./steps/StepAmount";
 import StepConnectDevice from "./steps/StepConnectDevice";
+import StepSummary, { StepSummaryFooter } from "./steps/StepSummary";
 import StepConfirmation, { StepConfirmationFooter } from "./steps/StepConfirmation";
 import type { St, StepId } from "./types";
 import { getMainAccount } from "@ledgerhq/live-common/lib/account";
@@ -32,6 +33,7 @@ type OwnProps = {|
   onChangeStepId: StepId => void,
   onClose: () => void,
   params: {
+    canEditFees: boolean,
     useApp?: string,
     account: ?AccountLike,
     transactionData: PlatformTransaction,
@@ -59,30 +61,46 @@ type Props = {|
   ...StateProps,
 |};
 
-const createSteps = (): St[] => [
-  {
-    id: "amount",
-    label: <Trans i18nKey="send.steps.amount.title" />,
-    component: StepAmount,
-    footer: StepAmountFooter,
-  },
-  {
-    id: "device",
-    label: <Trans i18nKey="send.steps.device.title" />,
-    component: StepConnectDevice,
-  },
-  {
-    id: "confirmation",
-    label: <Trans i18nKey="send.steps.confirmation.title" />,
-    excludeFromBreadcrumb: true,
-    component: StepConfirmation,
-    footer: StepConfirmationFooter,
-    onBack: ({ transitionTo, onRetry }) => {
-      onRetry();
-      transitionTo("amount");
+const createSteps = (canEditFees = false): St[] => {
+  const steps = [
+    {
+      id: "summary",
+      label: <Trans i18nKey="send.steps.summary.title" />,
+      component: StepSummary,
+      footer: StepSummaryFooter,
+      onBack: canEditFees ? ({ transitionTo }) => transitionTo("amount") : null,
     },
-  },
-];
+    {
+      id: "device",
+      label: <Trans i18nKey="send.steps.device.title" />,
+      component: StepConnectDevice,
+      onBack: ({ transitionTo }) => transitionTo("summary"),
+    },
+    {
+      id: "confirmation",
+      label: <Trans i18nKey="send.steps.confirmation.title" />,
+      excludeFromBreadcrumb: true,
+      component: StepConfirmation,
+      footer: StepConfirmationFooter,
+      onBack: ({ transitionTo, onRetry }) => {
+        onRetry();
+        transitionTo("summary");
+      },
+    },
+  ];
+
+  return canEditFees
+    ? [
+        {
+          id: "amount",
+          label: <Trans i18nKey="send.steps.amount.title" />,
+          component: StepAmount,
+          footer: StepAmountFooter,
+        },
+        ...steps,
+      ]
+    : steps;
+};
 
 const STATUS_KEYS_IGNORE = ["recipient", "gasLimit"];
 
@@ -118,8 +136,10 @@ const Body = ({
   params,
   accounts,
 }: Props) => {
+  const { canEditFees, transactionData } = params;
+
   const openedFromAccount = !!params.account;
-  const [steps] = useState(createSteps);
+  const [steps] = useState(() => createSteps(canEditFees));
 
   const {
     transaction,
@@ -136,15 +156,14 @@ const Body = ({
     const account = getMainAccount((params && params.account) || accounts[0], parentAccount);
 
     const bridge = getAccountBridge(account, parentAccount);
-    const t = bridge.createTransaction(account);
-    const { recipient, ...txData } = params.transactionData;
-    const t2 = bridge.updateTransaction(t, {
+    const tx = bridge.createTransaction(account);
+
+    const { recipient, ...txData } = transactionData;
+    const tx2 = bridge.updateTransaction(tx, {
       recipient,
-      feesStrategy: "custom",
     });
-    const transaction = bridge.updateTransaction(t2, {
+    const transaction = bridge.updateTransaction(tx2, {
       ...txData,
-      userGasLimit: txData.gasLimit,
     });
 
     return { account, parentAccount, transaction };
@@ -230,12 +249,12 @@ const Body = ({
     updateTransaction,
   };
 
-  if (!status || !transaction?.networkInfo) return null;
+  if (!status) return null;
 
   return (
     <Stepper {...stepperProps}>
       <SyncSkipUnderPriority priority={100} />
-      <Track onUnmount event="CloseModalSend" />
+      <Track onUnmount event="CloseModalSignTransaction" />
     </Stepper>
   );
 };

--- a/src/renderer/modals/SignTransaction/Body.js
+++ b/src/renderer/modals/SignTransaction/Body.js
@@ -213,7 +213,7 @@ const Body = ({
   const errorSteps = [];
 
   if (transactionError) {
-    errorSteps.push(1);
+    errorSteps.push(steps.length - 2);
   } else if (bridgeError) {
     errorSteps.push(0);
   }
@@ -232,7 +232,7 @@ const Body = ({
     account,
     parentAccount,
     transaction,
-    hideBreadcrumb: (!!error && ["recipient", "amount"].includes(stepId)) || stepId === "warning",
+    hideBreadcrumb: (!!error && ["amount"].includes(stepId)) || stepId === "warning",
     error,
     warning,
     status,

--- a/src/renderer/modals/SignTransaction/index.js
+++ b/src/renderer/modals/SignTransaction/index.js
@@ -1,53 +1,57 @@
 // @flow
 
-import React, { PureComponent } from "react";
+import React, { useState } from "react";
 import Modal from "~/renderer/components/Modal";
 import Body from "./Body";
 import type { StepId } from "./types";
 
-class SignTransactionModal extends PureComponent<{}, { stepId: StepId, error?: Error }> {
-  state = {
-    stepId: "amount",
-    error: undefined,
-  };
+type Props = {
+  stepId: StepId,
+  canEditFees: boolean,
+  error?: Error,
+};
 
-  handleReset = () =>
-    this.setState({
-      stepId: "amount",
+const SignTransactionModal = ({ stepId, canEditFees, error }: Props) => {
+  const [state, setState] = useState({
+    stepId: stepId || "summary",
+    error: undefined,
+  });
+
+  const handleReset = () => {
+    setState({
+      ...state,
+      stepId: "summary",
       error: undefined,
     });
+  };
 
-  handleStepChange = (stepId: StepId) => this.setState({ stepId });
+  const handleStepChange = (stepId: StepId) => setState({ ...state, stepId });
 
-  setError = (error?: Error) => this.setState({ error });
+  const setError = (error?: Error) => setState({ ...state, error });
 
-  render() {
-    const { stepId } = this.state;
-
-    return (
-      <Modal
-        name="MODAL_SIGN_TRANSACTION"
-        centered
-        refocusWhenChange={stepId}
-        onHide={this.handleReset}
-        preventBackdropClick
-        render={({ onClose, data }) => (
-          <Body
-            stepId={stepId}
-            onClose={() => {
-              if (data.onCancel) {
-                data.onCancel(this.state.error || new Error("Signature interrupted by user"));
-              }
-              onClose();
-            }}
-            setError={this.setError}
-            onChangeStepId={this.handleStepChange}
-            params={data || {}}
-          />
-        )}
-      />
-    );
-  }
-}
+  return (
+    <Modal
+      name="MODAL_SIGN_TRANSACTION"
+      centered
+      refocusWhenChange={state.stepId}
+      onHide={handleReset}
+      preventBackdropClick
+      render={({ onClose, data }) => (
+        <Body
+          stepId={state.stepId}
+          onClose={() => {
+            if (data.onCancel) {
+              data.onCancel(state.error || new Error("Signature interrupted by user"));
+            }
+            onClose();
+          }}
+          setError={setError}
+          onChangeStepId={handleStepChange}
+          params={data || {}}
+        />
+      )}
+    />
+  );
+};
 
 export default SignTransactionModal;

--- a/src/renderer/modals/SignTransaction/steps/GenericStepConnectDevice.js
+++ b/src/renderer/modals/SignTransaction/steps/GenericStepConnectDevice.js
@@ -1,8 +1,11 @@
 // @flow
 
 import React from "react";
+import { Trans } from "react-i18next";
 import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import DeviceAction from "~/renderer/components/DeviceAction";
+import StepProgress from "~/renderer/components/StepProgress";
+import { DeviceBlocker } from "~/renderer/components/DeviceAction/DeviceBlocker";
 import { createAction } from "@ledgerhq/live-common/lib/hw/actions/transaction";
 import type {
   Account,
@@ -26,7 +29,13 @@ const Result = ({
   signedOperation: ?SignedOperation,
   device: Device,
 }) => {
-  return null;
+  if (!signedOperation) return null;
+  return (
+    <StepProgress modelId={device.modelId}>
+      <DeviceBlocker />
+      <Trans i18nKey="send.steps.confirmation.pending.title" />
+    </StepProgress>
+  );
 };
 
 export default function StepConnectDevice({

--- a/src/renderer/modals/SignTransaction/steps/StepAmount.js
+++ b/src/renderer/modals/SignTransaction/steps/StepAmount.js
@@ -59,7 +59,7 @@ const StepAmount = ({
 export class StepAmountFooter extends PureComponent<StepProps> {
   onNext = async () => {
     const { transitionTo } = this.props;
-    transitionTo("device");
+    transitionTo("summary");
   };
 
   render() {

--- a/src/renderer/modals/SignTransaction/steps/StepConfirmation.js
+++ b/src/renderer/modals/SignTransaction/steps/StepConfirmation.js
@@ -58,7 +58,7 @@ export function StepConfirmationFooter({
           primary
           onClick={() => {
             onRetry();
-            transitionTo("amount");
+            transitionTo("summary");
           }}
         />
       ) : null}

--- a/src/renderer/modals/SignTransaction/steps/StepSummary.js
+++ b/src/renderer/modals/SignTransaction/steps/StepSummary.js
@@ -1,0 +1,268 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import {
+  getAccountCurrency,
+  getAccountName,
+  getAccountUnit,
+  getMainAccount,
+} from "@ledgerhq/live-common/lib/account";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import Box from "~/renderer/components/Box";
+import Button from "~/renderer/components/Button";
+import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
+import Ellipsis from "~/renderer/components/Ellipsis";
+import FormattedVal from "~/renderer/components/FormattedVal";
+import Text from "~/renderer/components/Text";
+import TranslatedError from "~/renderer/components/TranslatedError";
+import IconExclamationCircle from "~/renderer/icons/ExclamationCircle";
+import IconQrCode from "~/renderer/icons/QrCode";
+import IconWallet from "~/renderer/icons/Wallet";
+import { rgba } from "~/renderer/styles/helpers";
+import CounterValue from "~/renderer/components/CounterValue";
+import Alert from "~/renderer/components/Alert";
+
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+import type { StepProps } from "../types";
+import AccountTagDerivationMode from "~/renderer/components/AccountTagDerivationMode";
+
+const FromToWrapper: ThemedComponent<{}> = styled.div``;
+const Circle: ThemedComponent<{}> = styled.div`
+  height: 32px;
+  width: 32px;
+  border-radius: 32px;
+  background-color: ${p => rgba(p.theme.colors.palette.primary.main, 0.1)};
+  color: ${p => p.theme.colors.palette.primary.main};
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  margin-right: 12px;
+`;
+const VerticalSeparator: ThemedComponent<{}> = styled.div`
+  height: 18px;
+  background: ${p => p.theme.colors.palette.text.shade20};
+  width: 1px;
+  margin: 1px 0px 0px 15px;
+`;
+const Separator: ThemedComponent<{}> = styled.div`
+  height: 1px;
+  background: ${p => p.theme.colors.palette.text.shade20};
+  width: 100%;
+  margin: 15px 0;
+`;
+
+const WARN_FROM_UTXO_COUNT = 50;
+
+export default class StepSummary extends PureComponent<StepProps> {
+  render() {
+    const { account, parentAccount, transaction, status } = this.props;
+    if (!account) return null;
+    const mainAccount = getMainAccount(account, parentAccount);
+    if (!mainAccount || !transaction) return null;
+    const { estimatedFees, amount, totalSpent, warnings, txInputs } = status;
+    const feeTooHigh = warnings.feeTooHigh;
+    const currency = getAccountCurrency(account);
+    const feesUnit = getAccountUnit(mainAccount);
+    const feesCurrency = getAccountCurrency(mainAccount);
+    const unit = getAccountUnit(account);
+    const utxoLag = txInputs ? txInputs.length >= WARN_FROM_UTXO_COUNT : null;
+    const hasNonEmptySubAccounts =
+      account.type === "Account" &&
+      (account.subAccounts || []).some(subAccount => subAccount.balance.gt(0));
+
+    // $FlowFixMe
+    const memo = transaction.memo;
+
+    return (
+      <Box flow={4} mx={40}>
+        <TrackPage category="Sign Flow" name="Step Summary" />
+        {utxoLag ? (
+          <Alert type="warning">
+            <Trans i18nKey="send.steps.details.utxoLag" />
+          </Alert>
+        ) : null}
+        {transaction.useAllAmount && hasNonEmptySubAccounts ? (
+          <Alert type="primary">
+            <Trans
+              i18nKey="send.steps.details.subaccountsWarning"
+              values={{
+                currency: currency.name,
+              }}
+            />
+          </Alert>
+        ) : null}
+        <FromToWrapper>
+          <Box>
+            <Box horizontal alignItems="center">
+              <Circle>
+                <IconWallet size={14} />
+              </Circle>
+              <Box flex="1">
+                <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+                  <Trans i18nKey="send.steps.details.from" />
+                </Text>
+                <Box horizontal alignItems="center">
+                  <div style={{ marginRight: 7 }}>
+                    <CryptoCurrencyIcon size={16} currency={currency} />
+                  </div>
+                  <Text ff="Inter" color="palette.text.shade100" fontSize={4} style={{ flex: 1 }}>
+                    {getAccountName(account)}
+                  </Text>
+                  <AccountTagDerivationMode account={account} />
+                </Box>
+              </Box>
+            </Box>
+            <VerticalSeparator />
+            <Box horizontal alignItems="center">
+              <Circle>
+                <IconQrCode size={14} />
+              </Circle>
+              <Box flex={1}>
+                <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+                  <Trans i18nKey="send.steps.details.to" />
+                </Text>
+                <Ellipsis>
+                  <Text ff="Inter" color="palette.text.shade100" fontSize={4}>
+                    {transaction.recipient}
+                  </Text>
+                </Ellipsis>
+              </Box>
+            </Box>
+          </Box>
+          <Separator />
+          {memo && (
+            <Box horizontal justifyContent="space-between" mb={2}>
+              <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+                <Trans i18nKey="operationDetails.extra.memo" />
+              </Text>
+              <Text ff="Inter|Medium" fontSize={4}>
+                {memo}
+              </Text>
+            </Box>
+          )}
+          <Box horizontal justifyContent="space-between" mb={2}>
+            <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+              <Trans i18nKey="send.steps.details.amount" />
+            </Text>
+            <Box>
+              <FormattedVal
+                color={"palette.text.shade80"}
+                disableRounding
+                unit={unit}
+                val={amount}
+                fontSize={4}
+                inline
+                showCode
+              />
+              <Box textAlign="right">
+                <CounterValue
+                  color="palette.text.shade60"
+                  fontSize={3}
+                  currency={currency}
+                  value={amount}
+                  alwaysShowSign={false}
+                  subMagnitude={1}
+                />
+              </Box>
+            </Box>
+          </Box>
+          <Box horizontal justifyContent="space-between">
+            <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+              <Trans i18nKey="send.steps.details.fees" />
+            </Text>
+            <Box>
+              <FormattedVal
+                color={feeTooHigh ? "warning" : "palette.text.shade80"}
+                disableRounding
+                unit={feesUnit}
+                val={estimatedFees}
+                fontSize={4}
+                inline
+                showCode
+              />
+              <Box textAlign="right">
+                <CounterValue
+                  color={feeTooHigh ? "warning" : "palette.text.shade60"}
+                  fontSize={3}
+                  currency={feesCurrency}
+                  value={estimatedFees}
+                  alwaysShowSign={false}
+                  subMagnitude={1}
+                />
+              </Box>
+            </Box>
+          </Box>
+          {feeTooHigh ? (
+            <Box horizontal justifyContent="flex-end" alignItems="center" color="warning">
+              <IconExclamationCircle size={10} />
+              <Text ff="Inter|Medium" fontSize={2} style={{ marginLeft: "5px" }}>
+                <TranslatedError error={feeTooHigh} />
+              </Text>
+            </Box>
+          ) : null}
+
+          {!totalSpent.eq(amount) ? (
+            <>
+              <Separator />
+              <Box horizontal justifyContent="space-between">
+                <Text ff="Inter|Medium" color="palette.text.shade40" fontSize={4}>
+                  <Trans i18nKey="send.totalSpent" />
+                </Text>
+
+                <Box>
+                  <FormattedVal
+                    color={"palette.text.shade80"}
+                    disableRounding
+                    unit={unit}
+                    val={totalSpent}
+                    fontSize={4}
+                    inline
+                    showCode
+                  />
+                  <Box textAlign="right">
+                    <CounterValue
+                      color="palette.text.shade60"
+                      fontSize={3}
+                      currency={currency}
+                      value={totalSpent}
+                      alwaysShowSign={false}
+                      subMagnitude={1}
+                    />
+                  </Box>
+                </Box>
+              </Box>
+            </>
+          ) : null}
+        </FromToWrapper>
+      </Box>
+    );
+  }
+}
+
+export class StepSummaryFooter extends PureComponent<StepProps> {
+  onNext = async () => {
+    const { transitionTo } = this.props;
+    transitionTo("device");
+  };
+
+  render() {
+    const { account, status, bridgePending } = this.props;
+    if (!account) return null;
+    const { errors } = status;
+    const canNext = !bridgePending && !Object.keys(errors).length;
+    return (
+      <>
+        <Button
+          id={"sign-summary-continue-button"}
+          primary
+          disabled={!canNext}
+          onClick={this.onNext}
+        >
+          <Trans i18nKey="common.continue" />
+        </Button>
+      </>
+    );
+  }
+}

--- a/src/renderer/modals/SignTransaction/steps/StepSummary.js
+++ b/src/renderer/modals/SignTransaction/steps/StepSummary.js
@@ -57,7 +57,7 @@ const WARN_FROM_UTXO_COUNT = 50;
 
 export default class StepSummary extends PureComponent<StepProps> {
   render() {
-    const { account, parentAccount, transaction, status } = this.props;
+    const { account, parentAccount, transaction, status, error, warning } = this.props;
     if (!account) return null;
     const mainAccount = getMainAccount(account, parentAccount);
     if (!mainAccount || !transaction) return null;
@@ -91,6 +91,11 @@ export default class StepSummary extends PureComponent<StepProps> {
                 currency: currency.name,
               }}
             />
+          </Alert>
+        ) : null}
+        {error || warning ? (
+          <Alert type={error ? "error" : "warning"}>
+            <TranslatedError error={error || warning} />
           </Alert>
         ) : null}
         <FromToWrapper>

--- a/src/renderer/modals/SignTransaction/types.js
+++ b/src/renderer/modals/SignTransaction/types.js
@@ -11,7 +11,8 @@ import type {
 } from "@ledgerhq/live-common/lib/types";
 import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import type { Step } from "~/renderer/components/Stepper";
-export type StepId = "amount" | "device" | "confirmation";
+
+export type StepId = "amount" | "summary" | "device" | "confirmation";
 
 export type StepProps = {
   t: TFunction,


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

Leverage and update the current sign transaction workflow in order to make it more generalized and work with all cryptos

This also allows to skip fees step if already provided by the dapp in the related platform transaction.

The overall goal of this PR is to be a first step toward generic coin integration with platform apps, i.e: being able to "make it work" functionally with the least amount of changes in the codebase.

**⚠️  Linked / associated PRs ⚠️ :**
~🔗 https://github.com/LedgerHQ/ledger-live-platform-sdk/pull/18~
🔗  https://github.com/LedgerHQ/ledger-live-common/pull/1351


<details>
<summary>Demo 🎥 </summary>

**PS: If you have trouble playing the video on Github, you might need to download it locally**

https://user-images.githubusercontent.com/87011321/129882949-438fb79f-ec16-4e7f-a671-87611fa5a101.mp4

</details>

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

Feature

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

https://ledgerhq.atlassian.net/browse/LL-6803

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->

Sign transaction flow in app platform context.

To test:

- in LLC:
    - checkout to the [related branch](https://github.com/LedgerHQ/ledger-live-common/pull/1351): `git checkout feature/LL-6803-generalized-sign-transaction-flow `
    - use yalc to publish locally the ledger-live-common dep: `yalc publish`
- in LLD:
    - add the local version of LLC using yalc: `yalc add @ledgerhq/live-common`
    - install deps: `yarn`
