### PR TITLE
Add AccountSubHeader per family section

### DIFF
--- a/scripts/sync-families-dispatch.sh
+++ b/scripts/sync-families-dispatch.sh
@@ -9,6 +9,7 @@ accountActions.js \
 TransactionConfirmFields.js \
 AccountHeaderActions.js \
 AccountBodyHeader.js \
+AccountSubHeader.js \
 SendAmountFields.js \
 SendRecipientFields.js \
 SendWarning.js \

--- a/src/renderer/screens/account/EmptyStateAccount.js
+++ b/src/renderer/screens/account/EmptyStateAccount.js
@@ -55,7 +55,7 @@ class EmptyStateAccount extends PureComponent<Props, *> {
       mainAccount.subAccounts[0].type === "TokenAccount";
 
     return (
-      <Box mt={7} alignItems="center" selectable>
+      <Box mt={10} alignItems="center" selectable>
         <Image
           alt="emptyState Account logo"
           resource={{

--- a/src/renderer/screens/account/index.js
+++ b/src/renderer/screens/account/index.js
@@ -22,6 +22,7 @@ import { countervalueFirstSelector } from "~/renderer/reducers/settings";
 
 import TrackPage from "~/renderer/analytics/TrackPage";
 import perFamilyAccountBodyHeader from "~/renderer/generated/AccountBodyHeader";
+import perFamilyAccountSubHeader from "~/renderer/generated/AccountSubHeader";
 import Box from "~/renderer/components/Box";
 import OperationsList from "~/renderer/components/OperationsList";
 import useTheme from "~/renderer/hooks/useTheme";
@@ -79,6 +80,9 @@ const AccountPage = ({
   const AccountBodyHeader = mainAccount
     ? perFamilyAccountBodyHeader[mainAccount.currency.family]
     : null;
+  const AccountSubHeader = mainAccount
+    ? perFamilyAccountSubHeader[mainAccount.currency.family]
+    : null;
   const bgColor = useTheme("colors.palette.background.paper");
 
   const isCompoundEnabled = useCompoundAccountEnabled(account, parentAccount);
@@ -101,14 +105,18 @@ const AccountPage = ({
       />
       <SyncOneAccountOnMount priority={10} accountId={mainAccount.id} />
 
-      <Box horizontal mb={5} flow={4} style={{ justifyContent: "space-between" }}>
+      <Box horizontal mb={2} flow={4} style={{ justifyContent: "space-between" }}>
         <AccountHeader account={account} parentAccount={parentAccount} />
         <AccountHeaderActions account={account} parentAccount={parentAccount} />
       </Box>
 
+      {AccountSubHeader ? (
+        <AccountSubHeader account={account} parentAccount={parentAccount} />
+      ) : null}
+
       {!isAccountEmpty(account) ? (
         <>
-          <Box mb={7}>
+          <Box mt={3} mb={7}>
             <BalanceSummary
               mainAccount={mainAccount}
               account={account}


### PR DESCRIPTION
This allows a coin integration family to add a section between the header and the graph in the Account screen.

For instance, by adding this file

**src/renderer/families/ethereum/AccountSubHeader.js**

```
function AccountSubHeader() {
  return "IT WORKS.";
}
export default AccountSubHeader;

```

it will renders this:

![Screenshot 2021-08-20 at 09 40 00](https://user-images.githubusercontent.com/211411/130198182-674da601-4653-4fd2-a658-300a6215e500.png)


### Type

feature

### Context

coin integration
https://ledgerhq.atlassian.net/browse/LL-6925

### Parts of the app affected / Test plan

**if CI pass, it can gets in, there are no impact on existing app as no currencies uses this yet**