### PR TITLE
LL-6886 - SWAP - Remove provider edit button

### DIFF
--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionProvider.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionProvider.js
@@ -25,8 +25,7 @@ const SectionProvider = () => {
         label={t("swap2.form.details.label.provider")}
         details={t("swap2.form.details.tooltip.provider")}
       />
-      {/* TODO: Remove me as soon as the data is connected */}
-      <SummaryValue handleChange={() => {}}>{getProviderIcon("changelly")}</SummaryValue>
+      <SummaryValue value="changelly">{getProviderIcon("changelly")}</SummaryValue>
     </SummarySection>
   );
 };

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionProvider.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionProvider.js
@@ -4,16 +4,19 @@ import SummaryLabel from "./SummaryLabel";
 import SummaryValue from "./SummaryValue";
 import SummarySection from "./SummarySection";
 import { useTranslation } from "react-i18next";
-import IconChangelly from "~/renderer/icons/providers/Changelly";
+import ChangellyIcon from "~/renderer/icons/providers/Changelly";
+import WyreIcon from "~/renderer/icons/providers/Wyre";
 
-// TODO: Think about a fallback provider icon
+const providerIcons = { changelly: ChangellyIcon, wyre: WyreIcon };
+
 export const getProviderIcon = (providerName?: string) => {
   if (!providerName) return null;
 
-  const providerIcons = { changelly: IconChangelly };
   const Icon = providerIcons[providerName.toLowerCase()];
+
   /* eslint-disable react/display-name */
-  return <Icon size={20} />;
+  if (Icon) return <Icon size={20} />;
+  return null;
 };
 
 const SectionProvider = () => {

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SummaryValue.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SummaryValue.js
@@ -18,8 +18,8 @@ const Text: ThemedComponent<{}> = styled(TextBase).attrs(() => ({
   fontWeight: 600,
   lineHeight: "1.4",
 }))`
-  display: inline-flex;
-  column-gap: 0.7rem;
+  display: inline-block;
+
   &:first-letter {
     text-transform: uppercase;
   }

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SummaryValue.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SummaryValue.js
@@ -31,21 +31,13 @@ const Button: ThemedComponent<{}> = styled(ButtonBase).attrs(() => ({
   height: unset;
 `;
 
-const ButtonEdit = ({ onClick }: { onClick: Function }) => {
-  if (!onClick) return null;
-
-  return <Button onClick={onClick}>Edit</Button>;
-};
-
-// This component fetch the current value, the optional icon and the handleChange function
-// from the section's context and render them if possible
 const SummaryValue = ({
   value,
   handleChange,
   children,
 }: {
   value?: string,
-  handleChange: Function,
+  handleChange?: Function,
   children?: React$Node,
 }) => {
   if (!value) return <Text>-</Text>;
@@ -54,7 +46,7 @@ const SummaryValue = ({
     <Container>
       {children}
       <Text>{value}</Text>
-      <ButtonEdit onClick={handleChange} />
+      {handleChange ? <Button onClick={handleChange}>Edit</Button> : null}
     </Container>
   );
 };


### PR DESCRIPTION
## 🦒 Context (issues, jira)

~~This PR includes all commits from #4034. They will be removed before the review step.~~
In this PR I removed the edit button from the provider row and added the wyre icon to the provider row.

## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
