### PR TITLE
LL-6379 - SWAP - Add fees drawer

### DIFF
--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -61,8 +61,7 @@ export const urls = {
   contactSupport:
     "https://support.ledger.com/hc/en-us/requests/new?ticket_form_id=248165?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=support_contact",
   whatIsARecoveryPhrase: "https://www.ledger.com/academy/crypto/what-is-a-recovery-phrase",
-  feesMoreInfo:
-    "https://support.ledger.com/hc/en-us/articles/360006535873?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=fees",
+  feesMoreInfo: "https://support.ledger.com/hc/en-us/articles/360021039173-Choose-network-fees",
   recipientAddressInfo:
     "https://support.ledger.com/hc/en-us/articles/360006444193?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=sendflow",
   privacyPolicy: {

--- a/src/renderer/actions/swap.js
+++ b/src/renderer/actions/swap.js
@@ -4,13 +4,16 @@ import { createSelector } from "reselect";
 import type { OutputSelector } from "reselect";
 import type { State } from "~/renderer/reducers";
 import type { SwapStateType, UPDATE_PROVIDERS_TYPE } from "~/renderer/reducers/swap";
+import type { Transaction } from "@ledgerhq/live-common/lib/exchange/swap/types";
 import memoize from "lodash/memoize";
 
 /* ACTIONS */
 export const updateProvidersAction = createAction<$PropertyType<UPDATE_PROVIDERS_TYPE, "payload">>(
   "SWAP/UPDATE_PROVIDERS",
 );
-
+export const updateTransactionAction = createAction<$PropertyType<?Transaction, "payload">>(
+  "SWAP/UPDATE_TRANSACTION",
+);
 export const resetSwapAction = createAction("SWAP/RESET_STATE");
 
 /* SELECTORS */
@@ -40,4 +43,13 @@ export const toSelector: OutputSelector<State, void, *> = createSelector(
       const uniqueAssetList = [...new Set(filteredAssets)];
       return uniqueAssetList;
     }),
+);
+
+export const transactionSelector: OutputSelector<
+  State,
+  void,
+  $PropertyType<SwapStateType, "transaction">,
+> = createSelector(
+  state => state.swap,
+  swap => swap.transaction,
 );

--- a/src/renderer/components/FormattedVal.js
+++ b/src/renderer/components/FormattedVal.js
@@ -32,7 +32,7 @@ const T: ThemedComponent<{ color?: string, inline?: boolean, ff?: string }> = st
   white-space: pre;
   text-overflow: ellipsis;
   display: ${p => (p.inline ? "inline-block" : "block")};
-  flex-shrink: 1;
+  flex-shrink: ${p => (p.noShrink ? "0" : "1")};
   width: ${p => (p.inline ? "" : "100%")};
   overflow: hidden;
 `;

--- a/src/renderer/components/LabelWithExternalIcon.js
+++ b/src/renderer/components/LabelWithExternalIcon.js
@@ -14,7 +14,7 @@ const LabelWrapper: ThemedComponent<{ ff?: string, hoverColor: string }> = style
   }),
 )`
   display: inline-flex;
-  color: ${p => p.theme.colors[p.color] || "palette.text.shade60"};
+  color: ${p => p.theme.colors[p.color] || p.theme.colors.palette.text.shade60};
   &:hover {
     color: ${p => p.theme.colors[p.hoverColor]};
     cursor: pointer;

--- a/src/renderer/components/SendFeeMode.js
+++ b/src/renderer/components/SendFeeMode.js
@@ -1,86 +1,63 @@
 // @flow
 
 import React, { useCallback } from "react";
-import { Trans, withTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
-import Switch from "~/renderer/components/Switch";
-import Label from "~/renderer/components/Label";
+import Tabbable from "~/renderer/components/Box/Tabbable";
+import { urls } from "~/config/urls";
+import { openURL } from "~/renderer/linking";
+import { track } from "~/renderer/analytics/segment";
+import LabelWithExternalIcon from "~/renderer/components/LabelWithExternalIcon";
 
 type Props = {
   isAdvanceMode: boolean,
   setAdvanceMode: *,
 };
 
-const StandardText = styled(Text)`
+const SelectorContainer = styled.div`
+  display: inline-flex;
+  cursor: pointer;
+  overflow: hidden;
+  border-radius: 9999px;
+`;
+const Selector = styled(Tabbable)`
   color: ${p =>
-    p.selected ? p.theme.colors.palette.primary.main : p.theme.colors.palette.text.shade50};
-  &:hover {
-    cursor: pointer;
-  }
-`;
-
-const AdvancedText = styled(Text)`
-  color: ${p =>
-    p.selected ? p.theme.colors.palette.primary.main : p.theme.colors.palette.text.shade50};
-  &:hover {
-    cursor: pointer;
-  }
-`;
-
-const Divider = styled(Box)`
-  color: ${p => p.theme.colors.palette.text.shade70};
-  width: 26px;
-  font-size: 12px;
-  line-height: 17px;
-`;
-
-const ModeBox = styled(Box)`
-  width: 135px;
+    p.active ? p.theme.colors.palette.primary.contrastText : p.theme.colors.palette.text.shade20};
+  background: ${p =>
+    p.active ? p.theme.colors.palette.primary.main : p.theme.colors.palette.action.disabled};
+  padding: 4px 12px 4px 12px;
 `;
 
 const SendFeeMode = ({ isAdvanceMode, setAdvanceMode }: Props) => {
-  const toggleAdvanceMode = useCallback(() => {
-    setAdvanceMode(!isAdvanceMode);
-  }, [setAdvanceMode, isAdvanceMode]);
+  const { t } = useTranslation();
+  const setAdvanced = useCallback(() => setAdvanceMode(true), [setAdvanceMode]);
+  const setStandard = useCallback(() => setAdvanceMode(false), [setAdvanceMode]);
 
   return (
-    <Box horizontal alignItems="center" justifyContent="flex-start" style={{ width: 200 }}>
-      <Label>
-        <span>
-          <Trans i18nKey="send.steps.amount.fees" />
-        </span>
-      </Label>
-      <Divider alignItems="center">|</Divider>
-      <ModeBox horizontal alignItems="center" justifyContent="space-between">
-        <StandardText
-          ff="Inter"
-          fontSize={10}
-          fontWeight="600"
-          selected={!isAdvanceMode}
-          onClick={toggleAdvanceMode}
-        >
-          <Trans i18nKey="send.steps.amount.standard" />
-        </StandardText>
-        <Switch
-          forceBgColor={isAdvanceMode ? "wallet" : undefined}
-          small
-          isChecked={isAdvanceMode}
-          onChange={toggleAdvanceMode}
-        />
-        <AdvancedText
-          ff="Inter"
-          fontSize={10}
-          fontWeight="600"
-          selected={isAdvanceMode}
-          onClick={toggleAdvanceMode}
-        >
-          <Trans i18nKey="send.steps.amount.advanced" />
-        </AdvancedText>
-      </ModeBox>
+    <Box horizontal alignItems="center" justifyContent="space-between">
+      <LabelWithExternalIcon
+        onClick={() => {
+          openURL(urls.feesMoreInfo);
+          track("Send Flow Fees Help Requested");
+        }}
+        label={t("send.steps.amount.fees")}
+      />
+      <SelectorContainer>
+        <Selector active={!isAdvanceMode} onClick={setStandard}>
+          <Text ff="Inter" fontSize={10} fontWeight="600">
+            <Trans i18nKey="send.steps.amount.standard" />
+          </Text>
+        </Selector>
+        <Selector active={isAdvanceMode} onClick={setAdvanced}>
+          <Text ff="Inter" fontSize={10} fontWeight="600">
+            <Trans i18nKey="send.steps.amount.advanced" />
+          </Text>
+        </Selector>
+      </SelectorContainer>
     </Box>
   );
 };
 
-export default withTranslation()(SendFeeMode);
+export default SendFeeMode;

--- a/src/renderer/components/Text.js
+++ b/src/renderer/components/Text.js
@@ -22,6 +22,10 @@ const uppercase = system({
   },
 });
 
+const textTransform = system({
+  textTransform: true,
+});
+
 const Text: ThemedComponent<{
   fontFamily?: string,
   fontSize?: number | string,
@@ -43,6 +47,7 @@ const Text: ThemedComponent<{
   ${fontWeight};
   ${space};
   ${letterSpacing};
+  ${textTransform};
 `;
 
 export default Text;

--- a/src/renderer/families/bitcoin/SendAmountFields.js
+++ b/src/renderer/families/bitcoin/SendAmountFields.js
@@ -4,7 +4,12 @@ import invariant from "invariant";
 import React, { useState, useCallback, useEffect } from "react";
 import { Trans, withTranslation } from "react-i18next";
 import styled from "styled-components";
-import type { Account, Transaction, TransactionStatus } from "@ledgerhq/live-common/lib/types";
+import type {
+  Account,
+  Transaction,
+  TransactionStatus,
+  FeeStrategy,
+} from "@ledgerhq/live-common/lib/types";
 import { getAccountBridge } from "@ledgerhq/live-common/lib/bridge";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
@@ -27,6 +32,7 @@ type Props = {
   status: TransactionStatus,
   bridgePending: boolean,
   updateTransaction: (updater: any) => void,
+  mapStrategies?: FeeStrategy => FeeStrategy & { [string]: * },
 };
 
 const Separator = styled.div`
@@ -50,6 +56,7 @@ const Fields = ({
   onChange,
   status,
   updateTransaction,
+  mapStrategies,
 }: Props) => {
   invariant(transaction.family === "bitcoin", "FeeField: bitcoin family expected");
 
@@ -150,6 +157,7 @@ const Fields = ({
           account={account}
           parentAccount={parentAccount}
           suffixPerByte={true}
+          mapStrategies={mapStrategies}
         />
       )}
     </>

--- a/src/renderer/modals/Send/SendAmountFields.js
+++ b/src/renderer/modals/Send/SendAmountFields.js
@@ -1,6 +1,11 @@
 // @flow
 import React from "react";
-import type { Account, Transaction, TransactionStatus } from "@ledgerhq/live-common/lib/types";
+import type {
+  Account,
+  Transaction,
+  TransactionStatus,
+  FeeStrategy,
+} from "@ledgerhq/live-common/lib/types";
 
 import byFamily from "~/renderer/generated/SendAmountFields";
 
@@ -10,6 +15,7 @@ type Props = {
   status: TransactionStatus,
   onChange: Transaction => void,
   updateTransaction: (updater: any) => void,
+  mapStrategies?: FeeStrategy => FeeStrategy & { [string]: * },
 };
 
 const AmountRelatedField = (props: Props) => {

--- a/src/renderer/reducers/swap.js
+++ b/src/renderer/reducers/swap.js
@@ -1,13 +1,16 @@
 // @flow
 import { handleActions } from "redux-actions";
-import type { AvailableProviderV3 } from "@ledgerhq/live-common/lib/exchange/swap/types";
-
+import type {
+  AvailableProviderV3,
+  Transaction,
+} from "@ledgerhq/live-common/lib/exchange/swap/types";
 export type SwapStateType = {
   providers: ?Array<AvailableProviderV3>,
   pairs: ?$PropertyType<AvailableProviderV3, "pairs">,
+  transaction: ?Transaction,
 };
 
-const initialState: SwapStateType = { providers: null, pairs: null };
+const initialState: SwapStateType = { providers: null, pairs: null, transaction: null };
 
 export const flattenPairs = (
   acc: Array<{ from: string, to: string }>,
@@ -25,6 +28,10 @@ const updateProviders = (state: SwapStateType, { payload: providers }: UPDATE_PR
 
 const handlers = {
   UPDATE_PROVIDERS: updateProviders,
+  UPDATE_TRANSACTION: (state: SwapStateType, { payload }: { payload: ?Transaction }) => ({
+    ...state,
+    transaction: payload,
+  }),
   RESET_STATE: () => ({ ...initialState }),
 };
 

--- a/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.js
@@ -1,11 +1,12 @@
 // @flow
+import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
-import React, { useCallback } from "react";
+import { useSelector } from "react-redux";
 import Box from "~/renderer/components/Box";
 import Text from "~/renderer/components/Text";
 import SendAmountFields from "~/renderer/modals/Send/SendAmountFields";
-import useBridgeTransaction from "@ledgerhq/live-common/lib/bridge/useBridgeTransaction";
+import { transactionSelector } from "~/renderer/actions/swap";
 
 const Separator = styled.div`
   border-top: 1px solid ${p => p.theme.colors.palette.divider};
@@ -14,39 +15,8 @@ const Separator = styled.div`
 `;
 
 export default function FeesDrawer({ swapTransaction, disableSlowStrategy = false }: *) {
-  // Drawers are getting initial props but not the updates since the state lives in a separate Component in the hierarchy tree.
-  // Hence, this hack - keeping a copy of the transaction and updating both - seems to be needed.
-  // TO DIG: Might be a good thing to store swapTransaction in redux.
-  const {
-    transaction,
-    setTransaction: _setTransaction,
-    updateTransaction: _updateTransaction,
-    account,
-    parentAccount,
-    status,
-  } = useBridgeTransaction(() => ({
-    account: swapTransaction.account,
-    parentAccount: swapTransaction.parentAccount,
-    transaction: swapTransaction.transaction,
-  }));
-
-  const updateTransaction = useCallback(
-    (...args) => {
-      _updateTransaction(...args);
-      swapTransaction.updateTransaction(...args);
-    },
-    // eslint-disable-next-line
-    [_updateTransaction, swapTransaction.updateTransaction],
-  );
-
-  const setTransaction = useCallback(
-    (...args) => {
-      _setTransaction(...args);
-      swapTransaction.setTransaction(...args);
-    },
-    // eslint-disable-next-line
-    [_setTransaction, swapTransaction.setTransaction],
-  );
+  const { setTransaction, updateTransaction, account, parentAccount, status } = swapTransaction;
+  const transaction = useSelector(transactionSelector);
 
   const mapStrategies = useCallback(
     strategy =>

--- a/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.js
@@ -1,0 +1,86 @@
+// @flow
+import { Trans } from "react-i18next";
+import styled from "styled-components";
+import React, { useCallback } from "react";
+import Box from "~/renderer/components/Box";
+import Text from "~/renderer/components/Text";
+import SendAmountFields from "~/renderer/modals/Send/SendAmountFields";
+import useBridgeTransaction from "@ledgerhq/live-common/lib/bridge/useBridgeTransaction";
+
+const Separator = styled.div`
+  border-top: 1px solid ${p => p.theme.colors.palette.divider};
+  margin-top: 24px;
+  margin-bottom: 24px;
+`;
+
+export default function FeesDrawer({ swapTransaction, disableSlowStrategy = false }: *) {
+  // Drawers are getting initial props but not the updates since the state lives in a separate Component in the hierarchy tree.
+  // Hence, this hack - keeping a copy of the transaction and updating both - seems to be needed.
+  // TO DIG: Might be a good thing to store swapTransaction in redux.
+  const {
+    transaction,
+    setTransaction: _setTransaction,
+    updateTransaction: _updateTransaction,
+    account,
+    parentAccount,
+    status,
+  } = useBridgeTransaction(() => ({
+    account: swapTransaction.account,
+    parentAccount: swapTransaction.parentAccount,
+    transaction: swapTransaction.transaction,
+  }));
+
+  const updateTransaction = useCallback(
+    (...args) => {
+      _updateTransaction(...args);
+      swapTransaction.updateTransaction(...args);
+    },
+    // eslint-disable-next-line
+    [_updateTransaction, swapTransaction.updateTransaction],
+  );
+
+  const setTransaction = useCallback(
+    (...args) => {
+      _setTransaction(...args);
+      swapTransaction.setTransaction(...args);
+    },
+    // eslint-disable-next-line
+    [_setTransaction, swapTransaction.setTransaction],
+  );
+
+  const mapStrategies = useCallback(
+    strategy =>
+      strategy.label === "slow" && disableSlowStrategy ? { ...strategy, disabled: true } : strategy,
+    [disableSlowStrategy],
+  );
+
+  const titleSection = (
+    <>
+      <Box horizontal justifyContent="center">
+        <Text fontSize={6} fontWeight="600" textTransform="capitalize">
+          <Trans i18nKey="swap2.form.details.label.fees" />
+        </Text>
+      </Box>
+      <Separator />
+    </>
+  );
+
+  return (
+    <Box height="100%">
+      {titleSection}
+      <Box mt={6} flow={4}>
+        {transaction.networkInfo && (
+          <SendAmountFields
+            account={account}
+            parentAccount={parentAccount}
+            status={status}
+            transaction={transaction}
+            onChange={setTransaction}
+            updateTransaction={updateTransaction}
+            mapStrategies={mapStrategies}
+          />
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
@@ -1,20 +1,37 @@
 // @flow
-import React from "react";
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { context } from "~/renderer/drawers/Provider";
 import SummaryLabel from "./SummaryLabel";
 import SummaryValue from "./SummaryValue";
 import SummarySection from "./SummarySection";
-import { useTranslation } from "react-i18next";
+import FeesDrawer from "../FeesDrawer";
+import sendAmountByFamily from "~/renderer/generated/SendAmountFields";
 
-const SectionFees = ({ value }: { value?: string }) => {
+const SectionFees = ({ swapTransaction }: { swapTransaction: * }) => {
   const { t } = useTranslation();
+  const { setDrawer } = React.useContext(context);
+  const { account, transaction } = swapTransaction;
+  const canEdit = transaction?.networkInfo && sendAmountByFamily[account?.currency?.family];
+  const handleChange = useMemo(
+    () =>
+      canEdit &&
+      (() =>
+        setDrawer(FeesDrawer, {
+          swapTransaction,
+        })),
+    [canEdit, setDrawer, swapTransaction],
+  );
 
+  // TODO: disable the "slow" strategy based on the fees/provider in use.
+  // Waiting for the logic to be completed.
   return (
     <SummarySection>
       <SummaryLabel
         label={t("swap2.form.details.label.fees")}
         details={t("swap2.form.details.tooltip.fees")}
       />
-      <SummaryValue value={value} handleChange={() => {}} />
+      <SummaryValue value="0.000034 ETH" handleChange={handleChange} />
     </SummarySection>
   );
 };

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/index.js
@@ -6,7 +6,7 @@ import SectionFees from "./SectionFees";
 import SectionTarget from "./SectionTarget";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import styled from "styled-components";
-import type { SwapSelectorStateType } from "~/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction";
+import type { SwapTransactionType } from "~/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction";
 
 const Form: ThemedComponent<{}> = styled.section`
   display: grid;
@@ -15,15 +15,17 @@ const Form: ThemedComponent<{}> = styled.section`
 `;
 
 type SwapFormSummaryProps = {
-  targetAccount: $PropertyType<SwapSelectorStateType, "account">,
-  targetCurrency: $PropertyType<SwapSelectorStateType, "currency">,
+  swapTransaction: SwapTransactionType,
 };
-const SwapFormSummary = ({ targetAccount, targetCurrency }: SwapFormSummaryProps) => (
+const SwapFormSummary = ({ swapTransaction }: SwapFormSummaryProps) => (
   <Form>
     <SectionProvider />
     <SectionRate />
-    <SectionFees />
-    <SectionTarget account={targetAccount} currency={targetCurrency} />
+    <SectionFees swapTransaction={swapTransaction} />
+    <SectionTarget
+      account={swapTransaction.swap.to.parentAccount ?? swapTransaction.swap.to.account}
+      currency={swapTransaction.swap.to.currency}
+    />
   </Form>
 );
 

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/types.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/types.js
@@ -1,0 +1,12 @@
+// @flow
+
+export type FormSummarySections = "provider" | "fees" | "rate" | "target";
+export type FormSummaryProps = {
+  provider?: string,
+  rate?: string,
+  fees?: string,
+  onProviderChange: Function,
+  onFeesChange: Function,
+  onTargetChange: Function,
+  swapTransaction: *,
+};

--- a/src/renderer/screens/exchange/Swap2/Form/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/index.js
@@ -61,10 +61,7 @@ const SwapForm = () => {
           isMaxEnabled={swapTransaction.swap.isMaxEnabled}
           toggleMax={swapTransaction.toggleMax}
         />
-        <SwapFormSummary
-          targetAccount={swapTransaction.swap.to.parentAccount ?? swapTransaction.swap.to.account}
-          targetCurrency={swapTransaction.swap.to.currency}
-        />
+        <SwapFormSummary swapTransaction={swapTransaction} />
         <Button primary disabled={!isSwapReady} onClick={onSubmit}>
           {t("common.exchange")}
         </Button>

--- a/src/renderer/screens/exchange/Swap2/Form/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/index.js
@@ -11,7 +11,12 @@ import { useSwapProviders } from "~/renderer/screens/exchange/Swap2/utils/shared
 import useSwapTransaction from "~/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction";
 
 import { useDispatch, useSelector } from "react-redux";
-import { updateProvidersAction, resetSwapAction, providersSelector } from "~/renderer/actions/swap";
+import {
+  updateProvidersAction,
+  resetSwapAction,
+  providersSelector,
+  updateTransactionAction,
+} from "~/renderer/actions/swap";
 import FormLoading from "./FormLoading";
 import FormNotAvailable from "./FormNotAvailable";
 
@@ -46,6 +51,11 @@ const SwapForm = () => {
   useEffect(() => {
     if (error) dispatch(resetSwapAction());
   }, [error]);
+
+  useEffect(() => {
+    dispatch(updateTransactionAction(swapTransaction.transaction));
+    // eslint-disable-next-line
+  }, [swapTransaction.transaction]);
 
   if (providers?.length)
     return (

--- a/src/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction.js
+++ b/src/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction.js
@@ -98,7 +98,7 @@ const useSwapTransaction = (): SwapTransactionType => {
   const setToAmount: $PropertyType<SwapTransactionType, "setToAmount"> = amount =>
     setToState(previousState => ({ ...previousState, amount: amount }));
 
-  /* UPDATE from amount to the estimate max spendable on account 
+  /* UPDATE from amount to the estimate max spendable on account
   change when the amount feature is enabled */
   useEffect(() => {
     const updateAmountUsingMax = async () => {


### PR DESCRIPTION
## 🦒 Context (issues, jira)

**Done**

- Redesigned the select fees component (both for swap and for the send flow).
- Added this component to a drawer trigger by the edit label in the swap form.
- Disabled this trigger if the crypto family is not supported (!= bitcoin, eth, ripple)

**Todo in a separate PR when the provider/rate logic is done**

- Conditionally disable the "slow" fees strategy 

[LL-6379]

## 💻  Description / Demo (image or video)

https://user-images.githubusercontent.com/86958797/130819194-5dc97891-541a-4122-82f0-93c805791c00.mp4

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
