### PR TITLE
LL-6402 - Add deep link for settings page, including settings tabs

### DIFF
--- a/src/renderer/hooks/useDeeplinking.js
+++ b/src/renderer/hooks/useDeeplinking.js
@@ -166,9 +166,24 @@ export function useDeepLinkHandler() {
           break;
         }
 
-        case "settings":
-          navigate(`/settings/${splitedPath[1]}`);
+        case "settings": {
+          switch (splitedPath[1]) {
+            case "general":
+              navigate("/settings/display");
+              break;
+            case "accounts":
+            case "about":
+            case "help":
+            case "experimental":
+              navigate(`/settings/${splitedPath[1]}`);
+              break;
+            default:
+              navigate("/settings");
+              break;
+          }
+
           break;
+        }
 
         case "portfolio":
         default:

--- a/src/renderer/hooks/useDeeplinking.js
+++ b/src/renderer/hooks/useDeeplinking.js
@@ -54,8 +54,9 @@ export function useDeepLinkHandler() {
       const { pathname, searchParams } = new URL(deeplink);
       const query = Object.fromEntries(searchParams);
       const url = pathname.replace(/(^\/+|\/+$)/g, "");
+      const splitedPath = url.split("/");
 
-      switch (url) {
+      switch (splitedPath[0]) {
         case "accounts":
           navigate("/accounts");
           break;
@@ -164,6 +165,10 @@ export function useDeepLinkHandler() {
 
           break;
         }
+
+        case "settings":
+          navigate(`/settings/${splitedPath[1]}`);
+          break;
 
         case "portfolio":
         default:

--- a/src/renderer/screens/settings/index.js
+++ b/src/renderer/screens/settings/index.js
@@ -107,6 +107,8 @@ const Settings = ({ history, location, match }: Props) => {
 
       if (idx > -1 && idx !== activeTabIndex) {
         setActiveTabIndex(idx);
+      } else {
+        setActiveTabIndex(0);
       }
     }
   }, [match, history, location, items, activeTabIndex]);

--- a/src/renderer/screens/settings/index.js
+++ b/src/renderer/screens/settings/index.js
@@ -104,12 +104,7 @@ const Settings = ({ history, location, match }: Props) => {
       const idx = items.findIndex(val => {
         return `${match.url}/${val.key}` === location.pathname;
       });
-
-      if (idx > -1 && idx !== activeTabIndex) {
-        setActiveTabIndex(idx);
-      } else {
-        setActiveTabIndex(0);
-      }
+      setActiveTabIndex(idx > -1 && idx !== activeTabIndex ? idx : 0);
     }
   }, [match, history, location, items, activeTabIndex]);
 


### PR DESCRIPTION
Adding deep link (ledgerlive://) to settings page and it's tabs

ledgerlive://settings
ledgerlive://settings/general
ledgerlive://settings/accounts
ledgerlive://settings/about
ledgerlive://settings/help
ledgerlive://settings/experimental

## 🦒 Context (issues, jira)

https://ledgerhq.atlassian.net/browse/LL-6402

## 💻  Description / Demo (image or video)

https://user-images.githubusercontent.com/89014981/131155769-180bf887-04b3-4120-addb-c837863feeb9.mp4

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [x] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
