### PR TITLE
LL-6890 - SWAP - Fees strategy & value logic

### DIFF
--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
@@ -1,37 +1,82 @@
 // @flow
-import React, { useMemo } from "react";
+import React, { useMemo, useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+import { getAccountUnit } from "@ledgerhq/live-common/lib/account";
 import { context } from "~/renderer/drawers/Provider";
 import SummaryLabel from "./SummaryLabel";
 import SummaryValue from "./SummaryValue";
 import SummarySection from "./SummarySection";
 import FeesDrawer from "../FeesDrawer";
 import sendAmountByFamily from "~/renderer/generated/SendAmountFields";
+import type { SwapTransactionType } from "~/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction";
+import { rateSelector } from "~/renderer/actions/swap";
+import FormattedVal from "~/renderer/components/FormattedVal";
+import Text from "~/renderer/components/Text";
 
-const SectionFees = ({ swapTransaction }: { swapTransaction: * }) => {
+const SectionFees = ({ swapTransaction }: { swapTransaction: SwapTransactionType }) => {
   const { t } = useTranslation();
   const { setDrawer } = React.useContext(context);
   const { account, transaction } = swapTransaction;
-  const canEdit = transaction?.networkInfo && sendAmountByFamily[account?.currency?.family];
+  const exchangeRate = useSelector(rateSelector);
+  const fromAccount = swapTransaction.swap.from.account;
+  const fromAccountUnit = fromAccount && getAccountUnit(fromAccount);
+  const estimatedFees = swapTransaction.status?.estimatedFees;
+  const showSummaryValue = fromAccountUnit && estimatedFees && estimatedFees.gt(0);
+  const canEdit =
+    showSummaryValue && transaction?.networkInfo && sendAmountByFamily[account?.currency?.family];
+
+  // Deselect slow strategy if the exchange rate is changed to fixed.
+  useEffect(
+    () => {
+      if (
+        exchangeRate?.tradeMethod === "fixed" &&
+        swapTransaction.transaction?.feesStrategy === "slow"
+      ) {
+        swapTransaction.updateTransaction(t => ({
+          ...t,
+          feesStrategy: "medium",
+        }));
+      }
+    },
+    // eslint-disable-next-line
+    [swapTransaction.transaction?.feesStrategy, exchangeRate?.tradeMethod],
+  );
+
   const handleChange = useMemo(
     () =>
       canEdit &&
       (() =>
         setDrawer(FeesDrawer, {
           swapTransaction,
+          disableSlowStrategy: exchangeRate?.tradeMethod === "fixed",
         })),
-    [canEdit, setDrawer, swapTransaction],
+    [canEdit, setDrawer, swapTransaction, exchangeRate?.tradeMethod],
   );
 
-  // TODO: disable the "slow" strategy based on the fees/provider in use.
-  // Waiting for the logic to be completed.
+  const summaryValue = canEdit ? (
+    <FormattedVal
+      color="palette.text.shade100"
+      val={estimatedFees}
+      unit={fromAccountUnit}
+      fontSize={3}
+      ff="Inter|SemiBold"
+      showCode
+      alwaysShowValue
+    />
+  ) : (
+    <Text color="palette.text.shade100" fontSize={4}>
+      {"-"}
+    </Text>
+  );
+
   return (
     <SummarySection>
       <SummaryLabel
         label={t("swap2.form.details.label.fees")}
         details={t("swap2.form.details.tooltip.fees")}
       />
-      <SummaryValue value="0.000034 ETH" handleChange={handleChange} />
+      <SummaryValue handleChange={handleChange}>{summaryValue}</SummaryValue>
     </SummarySection>
   );
 };


### PR DESCRIPTION
## 🦒 Context (issues, jira)

- Conditionally enable/disable slow strategy based on the rate trade method.
- Link the displayed fee value to the transaction.

[LL-6890](https://ledgerhq.atlassian.net/browse/LL-6890)

## 💻  Description / Demo (image or video)

https://user-images.githubusercontent.com/86958797/131538145-eb70d58d-ae02-4ef5-9b86-4f05699bb67e.mp4

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
