### PR TITLE
LL-6359 - SWAP - Multiline selectors

### DIFF
--- a/src/renderer/components/AccountTagDerivationMode.js
+++ b/src/renderer/components/AccountTagDerivationMode.js
@@ -23,15 +23,16 @@ const CurrencyLabel: ThemedComponent<*> = styled(Text).attrs(() => ({
   flex: 0 0 auto !important;
   box-sizing: content-box;
   text-transform: uppercase;
-  margin: 0 8px;
+  margin: ${p => p.margin || "0 8px"};
   flex: unset;
 `;
 
 type Props = {
   account: AccountLike,
+  margin?: string,
 };
 
-export default function AccountTagDerivationMode({ account }: Props) {
+export default function AccountTagDerivationMode({ account, margin }: Props) {
   if (account.type !== "Account") return null;
 
   const tag =
@@ -39,5 +40,5 @@ export default function AccountTagDerivationMode({ account }: Props) {
     account.derivationMode !== null &&
     getTagDerivationMode(account.currency, account.derivationMode);
 
-  return tag ? <CurrencyLabel>{tag}</CurrencyLabel> : null;
+  return tag ? <CurrencyLabel margin={margin}>{tag}</CurrencyLabel> : null;
 }

--- a/src/renderer/components/AccountTagDerivationMode.js
+++ b/src/renderer/components/AccountTagDerivationMode.js
@@ -23,7 +23,6 @@ const CurrencyLabel: ThemedComponent<*> = styled(Text).attrs(() => ({
   flex: 0 0 auto !important;
   box-sizing: content-box;
   text-transform: uppercase;
-  margin: ${p => p.margin || "0 8px"};
   flex: unset;
 `;
 
@@ -40,5 +39,5 @@ export default function AccountTagDerivationMode({ account, margin }: Props) {
     account.derivationMode !== null &&
     getTagDerivationMode(account.currency, account.derivationMode);
 
-  return tag ? <CurrencyLabel margin={margin}>{tag}</CurrencyLabel> : null;
+  return tag ? <CurrencyLabel margin={margin ?? "0 8px"}>{tag}</CurrencyLabel> : null;
 }

--- a/src/renderer/components/Select/createRenderers.js
+++ b/src/renderer/components/Select/createRenderers.js
@@ -34,7 +34,7 @@ export default ({
   ...STYLES_OVERRIDE,
   Option: function Option(props: OptionProps) {
     const { data, isSelected, isDisabled } = props;
-    const { extraRenderers } = selectProps;
+    const { disabledTooltipText } = selectProps;
 
     return (
       <components.Option {...props}>
@@ -47,9 +47,9 @@ export default ({
               <IconCheck size={12} color={props.theme.colors.wallet} />
             </InformativeContainer>
           )}
-          {isDisabled && extraRenderers?.disableTooltipText && (
+          {isDisabled && disabledTooltipText && (
             <InformativeContainer disabled>
-              <LabelInfoTooltip text={extraRenderers.disableTooltipText ?? ""} />
+              <LabelInfoTooltip text={disabledTooltipText ?? ""} />
             </InformativeContainer>
           )}
         </Box>

--- a/src/renderer/components/Select/index.js
+++ b/src/renderer/components/Select/index.js
@@ -46,7 +46,8 @@ export type Props = {
   rowHeight: number,
   error: ?Error, // NB at least a different rendering for now
   stylesMap: CreateStylesReturnType => CreateStylesReturnType,
-  extraRenderers?: { disableTooltipText?: string, [string]: (props: *) => React$ElementType }, // Allows overriding react-select components. See: https://react-select.com/components
+  extraRenderers?: { [string]: (props: *) => React$ElementType }, // Allows overriding react-select components. See: https://react-select.com/components
+  disabledTooltipText?: string,
 };
 
 const Row = styled.div`

--- a/src/renderer/components/SelectAccount.js
+++ b/src/renderer/components/SelectAccount.js
@@ -87,11 +87,13 @@ type AccountOptionProps = {
   account: AccountLike,
   isValue?: boolean,
   disabled?: boolean,
+  singleLineLayout?: boolean,
 };
 export const AccountOption = React.memo<AccountOptionProps>(function AccountOption({
   account,
   isValue,
   disabled,
+  singleLineLayout = true,
 }: AccountOptionProps) {
   const currency = getAccountCurrency(account);
   const unit = getAccountUnit(account);
@@ -102,10 +104,8 @@ export const AccountOption = React.memo<AccountOptionProps>(function AccountOpti
       ? account.spendableBalance
       : account.balance;
 
-  return (
-    <Box grow horizontal alignItems="center" flow={2} style={{ opacity: disabled ? 0.2 : 1 }}>
-      {!isValue && nested ? tokenTick : null}
-      <CryptoCurrencyIcon currency={currency} size={16} />
+  const textContents = singleLineLayout ? (
+    <>
       <Box flex="1" horizontal alignItems="center">
         <Box flex="0 1 auto">
           <Ellipsis ff="Inter|SemiBold" fontSize={4}>
@@ -117,6 +117,35 @@ export const AccountOption = React.memo<AccountOptionProps>(function AccountOpti
       <Box>
         <FormattedVal color="palette.text.shade60" val={balance} unit={unit} showCode />
       </Box>
+    </>
+  ) : (
+    <Box flex="1">
+      <Box flex="1" horizontal alignItems="center">
+        <Box flex="0 1 auto">
+          <Ellipsis ff="Inter|SemiBold" fontSize={4} color="palette.text.shade100">
+            {name}
+          </Ellipsis>
+        </Box>
+        <AccountTagDerivationMode account={account} margin="0 0 0 8px" />
+      </Box>
+      <Box>
+        <FormattedVal
+          color="palette.text.shade50"
+          ff="Inter|Medium"
+          fontSize={3}
+          val={balance}
+          unit={unit}
+          showCode
+        />
+      </Box>
+    </Box>
+  );
+
+  return (
+    <Box grow horizontal alignItems="center" flow={2} style={{ opacity: disabled ? 0.2 : 1 }}>
+      {!isValue && nested ? tokenTick : null}
+      <CryptoCurrencyIcon currency={currency} size={16} />
+      {textContents}
     </Box>
   );
 });
@@ -254,10 +283,9 @@ export const RawSelectAccount = ({
     let extraProps = {};
 
     if (showAddAccount) extraProps = { ...extraProps, ...extraAddAccountRenderer(props.small) };
-    if (disableTooltipText) extraProps = { ...extraProps, disableTooltipText };
 
     return extraProps;
-  }, [showAddAccount, props.small, disableTooltipText]);
+  }, [showAddAccount, props.small]);
 
   const structuredResults = manualFilter();
   return (

--- a/src/renderer/components/SelectAccount.js
+++ b/src/renderer/components/SelectAccount.js
@@ -88,11 +88,13 @@ type AccountOptionProps = {
   isValue?: boolean,
   disabled?: boolean,
   singleLineLayout?: boolean,
+  hideDerivationTag?: boolean,
 };
 export const AccountOption = React.memo<AccountOptionProps>(function AccountOption({
   account,
   isValue,
   disabled,
+  hideDerivationTag = false,
   singleLineLayout = true,
 }: AccountOptionProps) {
   const currency = getAccountCurrency(account);
@@ -112,7 +114,7 @@ export const AccountOption = React.memo<AccountOptionProps>(function AccountOpti
             {name}
           </Ellipsis>
         </Box>
-        <AccountTagDerivationMode account={account} />
+        {!hideDerivationTag && <AccountTagDerivationMode account={account} />}
       </Box>
       <Box>
         <FormattedVal color="palette.text.shade60" val={balance} unit={unit} showCode />
@@ -126,7 +128,7 @@ export const AccountOption = React.memo<AccountOptionProps>(function AccountOpti
             {name}
           </Ellipsis>
         </Box>
-        <AccountTagDerivationMode account={account} margin={0} />
+        {!hideDerivationTag && <AccountTagDerivationMode account={account} margin="0" />}
       </Box>
       <Box>
         <FormattedVal

--- a/src/renderer/components/SelectAccount.js
+++ b/src/renderer/components/SelectAccount.js
@@ -83,6 +83,10 @@ const filterOption = o => (candidate, input) => {
   return [false, false];
 };
 
+const OptionMultilineContainer = styled(Box)`
+  line-height: 1.3em;
+`;
+
 type AccountOptionProps = {
   account: AccountLike,
   isValue?: boolean,
@@ -121,7 +125,7 @@ export const AccountOption = React.memo<AccountOptionProps>(function AccountOpti
       </Box>
     </>
   ) : (
-    <Box flex="1">
+    <OptionMultilineContainer flex="1">
       <Box flex="1" horizontal alignItems="center">
         <Box flex="0 1 auto">
           <Ellipsis ff="Inter|SemiBold" fontSize={4} color="palette.text.shade100">
@@ -140,7 +144,7 @@ export const AccountOption = React.memo<AccountOptionProps>(function AccountOpti
           showCode
         />
       </Box>
-    </Box>
+    </OptionMultilineContainer>
   );
 
   return (

--- a/src/renderer/components/SelectAccount.js
+++ b/src/renderer/components/SelectAccount.js
@@ -183,7 +183,7 @@ type OwnProps = {
   renderOption?: typeof defaultRenderOption,
   placeholder?: string,
   showAddAccount?: boolean,
-  disableTooltipText?: string,
+  disabledTooltipText?: string,
 };
 
 type Props = OwnProps & {
@@ -202,7 +202,7 @@ export const RawSelectAccount = ({
   renderOption,
   placeholder,
   showAddAccount = false,
-  disableTooltipText,
+  disabledTooltipText,
   t,
   ...props
 }: Props & { t: TFunction }) => {
@@ -278,6 +278,7 @@ export const RawSelectAccount = ({
       }
       onChange={onChangeCallback}
       extraRenderers={extraRenderers}
+      disabledTooltipText={disabledTooltipText}
     />
   );
 };

--- a/src/renderer/components/SelectAccount.js
+++ b/src/renderer/components/SelectAccount.js
@@ -126,7 +126,7 @@ export const AccountOption = React.memo<AccountOptionProps>(function AccountOpti
             {name}
           </Ellipsis>
         </Box>
-        <AccountTagDerivationMode account={account} margin="0 0 0 8px" />
+        <AccountTagDerivationMode account={account} margin={0} />
       </Box>
       <Box>
         <FormattedVal

--- a/src/renderer/components/SelectCurrency.js
+++ b/src/renderer/components/SelectCurrency.js
@@ -117,6 +117,9 @@ const SelectCurrency = <C: Currency>({
   );
 };
 
+const OptionMultilineContainer = styled(Box)`
+  line-height: 1.3em;
+`;
 const CurrencyLabel = styled(Text).attrs(() => ({
   color: "palette.text.shade60",
   ff: "Inter|SemiBold",
@@ -152,7 +155,7 @@ export function CurrencyOption({
     </>
   ) : (
     <>
-      <Box flex="1">
+      <OptionMultilineContainer flex="1">
         <Text ff="Inter|SemiBold" fontSize={4} color="palette.text.shade100">
           {currency.name}
         </Text>
@@ -161,7 +164,7 @@ export function CurrencyOption({
             {currency.ticker}
           </Text>
         </Box>
-      </Box>
+      </OptionMultilineContainer>
       {currency.parentCurrency ? (
         <CurrencyLabel>{currency.parentCurrency.name}</CurrencyLabel>
       ) : null}

--- a/src/renderer/components/SelectCurrency.js
+++ b/src/renderer/components/SelectCurrency.js
@@ -27,6 +27,7 @@ type Props<C: Currency> = {
   isDisabled?: boolean,
   id?: string,
   renderOptionOverride?: (option: Option) => any,
+  renderValueOverride?: (option: Option) => any,
   stylesMap?: CreateStylesReturnType => CreateStylesReturnType,
 };
 
@@ -43,6 +44,7 @@ const SelectCurrency = <C: Currency>({
   width,
   rowHeight = 47,
   renderOptionOverride,
+  renderValueOverride,
   isCurrencyDisabled,
   isDisabled,
   id,
@@ -100,7 +102,7 @@ const SelectCurrency = <C: Currency>({
       filterOption={false}
       getOptionValue={getOptionValue}
       renderOption={renderOptionOverride || renderOption}
-      renderValue={renderOptionOverride || renderOption}
+      renderValue={renderValueOverride || renderOptionOverride || renderOption}
       onInputChange={v => setSearchInputValue(v)}
       inputValue={searchInputValue}
       placeholder={placeholder || t("common.selectCurrency")}
@@ -132,14 +134,47 @@ const CurrencyLabel = styled(Text).attrs(() => ({
   box-sizing: content-box;
 `;
 
-const renderOption = ({ data: currency }: Option) => (
-  <Box grow horizontal alignItems="center" flow={2}>
-    <CryptoCurrencyIcon circle currency={currency} size={26} />
-    <Box grow ff="Inter|SemiBold" color="palette.text.shade100" fontSize={4}>
-      {`${currency.name} (${currency.ticker})`}
+export function CurrencyOption({
+  currency,
+  singleLineLayout = true,
+}: {
+  currency: Currency,
+  singleLineLayout?: boolean,
+}) {
+  const textContents = singleLineLayout ? (
+    <>
+      <Box grow ff="Inter|SemiBold" color="palette.text.shade100" fontSize={4}>
+        {`${currency.name} (${currency.ticker})`}
+      </Box>
+      {currency.parentCurrency ? (
+        <CurrencyLabel>{currency.parentCurrency.name}</CurrencyLabel>
+      ) : null}
+    </>
+  ) : (
+    <>
+      <Box flex="1">
+        <Text ff="Inter|SemiBold" fontSize={4} color="palette.text.shade100">
+          {currency.name}
+        </Text>
+        <Box horizontal alignItems="center">
+          <Text color="palette.text.shade50" ff="Inter|Medium" fontSize={3}>
+            {currency.ticker}
+          </Text>
+        </Box>
+      </Box>
+      {currency.parentCurrency ? (
+        <CurrencyLabel>{currency.parentCurrency.name}</CurrencyLabel>
+      ) : null}
+    </>
+  );
+
+  return (
+    <Box grow horizontal alignItems="center" flow={2}>
+      <CryptoCurrencyIcon circle currency={currency} size={26} />
+      {textContents}
     </Box>
-    {currency.parentCurrency ? <CurrencyLabel>{currency.parentCurrency.name}</CurrencyLabel> : null}
-  </Box>
-);
+  );
+}
+const renderOption = ({ data: currency }: Option) => <CurrencyOption currency={currency} />;
 
 export default memo<Props<*>>(SelectCurrency);

--- a/src/renderer/components/SelectCurrency.js
+++ b/src/renderer/components/SelectCurrency.js
@@ -140,16 +140,18 @@ const CurrencyLabel = styled(Text).attrs(() => ({
 export function CurrencyOption({
   currency,
   singleLineLayout = true,
+  hideParentTag = false,
 }: {
   currency: Currency,
   singleLineLayout?: boolean,
+  hideParentTag?: boolean,
 }) {
   const textContents = singleLineLayout ? (
     <>
       <Box grow ff="Inter|SemiBold" color="palette.text.shade100" fontSize={4}>
         {`${currency.name} (${currency.ticker})`}
       </Box>
-      {currency.parentCurrency ? (
+      {!hideParentTag && currency.parentCurrency ? (
         <CurrencyLabel>{currency.parentCurrency.name}</CurrencyLabel>
       ) : null}
     </>
@@ -165,7 +167,7 @@ export function CurrencyOption({
           </Text>
         </Box>
       </OptionMultilineContainer>
-      {currency.parentCurrency ? (
+      {!hideParentTag && currency.parentCurrency ? (
         <CurrencyLabel>{currency.parentCurrency.name}</CurrencyLabel>
       ) : null}
     </>

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.js
@@ -69,7 +69,7 @@ function FromRow({
             placeholder={t("swap2.form.from.accountPlaceholder")}
             showAddAccount
             isSearchable={false}
-            disableTooltipText={t("swap2.form.from.currencyDisabledTooltip")}
+            disabledTooltipText={t("swap2.form.from.currencyDisabledTooltip")}
           />
         </Box>
         <Box width="50%">

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.js
@@ -10,7 +10,7 @@ import { SelectAccount } from "~/renderer/components/SelectAccount";
 import Switch from "~/renderer/components/Switch";
 import Text from "~/renderer/components/Text";
 import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
-import { amountInputContainerProps, selectRowStylesMap } from "./utils";
+import { amountInputContainerProps, renderAccountValue, selectRowStylesMap } from "./utils";
 import { FormLabel } from "./FormLabel";
 import type {
   SwapSelectorStateType,
@@ -70,6 +70,7 @@ function FromRow({
             showAddAccount
             isSearchable={false}
             disabledTooltipText={t("swap2.form.from.currencyDisabledTooltip")}
+            renderValue={renderAccountValue}
           />
         </Box>
         <Box width="50%">

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/ToRow.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/ToRow.js
@@ -4,7 +4,7 @@ import { Trans } from "react-i18next";
 import Box from "~/renderer/components/Box/Box";
 import InputCurrency from "~/renderer/components/InputCurrency";
 import SelectCurrency from "~/renderer/components/SelectCurrency";
-import { amountInputContainerProps, selectRowStylesMap } from "./utils";
+import { amountInputContainerProps, renderCurrencyValue, selectRowStylesMap } from "./utils";
 import { FormLabel } from "./FormLabel";
 import { toSelector } from "~/renderer/actions/swap";
 import { useSelector } from "react-redux";
@@ -62,6 +62,7 @@ export default function ToRow({ toCurrency, setToAccount, toAmount, fromAccount 
             value={selectState.currency}
             stylesMap={selectRowStylesMap}
             isDisabled={!fromAccount}
+            renderValueOverride={renderCurrencyValue}
           />
         </Box>
         <Box width="50%">

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/utils.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/utils.js
@@ -1,5 +1,8 @@
 // @flow
+import React from "react";
 import type { CreateStylesReturnType } from "~/renderer/components/Select/createStyles";
+import { AccountOption } from "~/renderer/components/SelectAccount";
+import type { Option } from "~/renderer/components/SelectAccount";
 
 export const selectRowStylesMap: CreateStylesReturnType => CreateStylesReturnType = styles => ({
   ...styles,
@@ -12,8 +15,15 @@ export const selectRowStylesMap: CreateStylesReturnType => CreateStylesReturnTyp
     ...styles.menu(provided),
     width: "200%",
   }),
+  valueContainer: (styles: Object) => ({
+    ...styles,
+    height: "100%",
+  }),
 });
 
 export const amountInputContainerProps = {
   noBorderLeftRadius: true,
 };
+
+export const renderAccountValue = ({ data }: { data: Option }) =>
+  data.account ? <AccountOption account={data.account} isValue singleLineLayout={false} /> : null;

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/utils.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/utils.js
@@ -33,5 +33,7 @@ export const renderAccountValue = ({ data }: { data: SelectAccountOption }) =>
   ) : null;
 
 export const renderCurrencyValue = ({ data: currency }: { data: Currency }) => {
-  return currency ? <CurrencyOption currency={currency} singleLineLayout={false} /> : null;
+  return currency ? (
+    <CurrencyOption currency={currency} singleLineLayout={false} hideParentTag />
+  ) : null;
 };

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/utils.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/utils.js
@@ -28,7 +28,9 @@ export const amountInputContainerProps = {
 };
 
 export const renderAccountValue = ({ data }: { data: SelectAccountOption }) =>
-  data.account ? <AccountOption account={data.account} isValue singleLineLayout={false} /> : null;
+  data.account ? (
+    <AccountOption account={data.account} isValue singleLineLayout={false} hideDerivationTag />
+  ) : null;
 
 export const renderCurrencyValue = ({ data: currency }: { data: Currency }) => {
   return currency ? <CurrencyOption currency={currency} singleLineLayout={false} /> : null;

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/utils.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/utils.js
@@ -1,8 +1,10 @@
 // @flow
 import React from "react";
+import type { Currency } from "@ledgerhq/live-common/lib/types";
 import type { CreateStylesReturnType } from "~/renderer/components/Select/createStyles";
 import { AccountOption } from "~/renderer/components/SelectAccount";
-import type { Option } from "~/renderer/components/SelectAccount";
+import { CurrencyOption } from "~/renderer/components/SelectCurrency";
+import type { Option as SelectAccountOption } from "~/renderer/components/SelectAccount";
 
 export const selectRowStylesMap: CreateStylesReturnType => CreateStylesReturnType = styles => ({
   ...styles,
@@ -25,5 +27,9 @@ export const amountInputContainerProps = {
   noBorderLeftRadius: true,
 };
 
-export const renderAccountValue = ({ data }: { data: Option }) =>
+export const renderAccountValue = ({ data }: { data: SelectAccountOption }) =>
   data.account ? <AccountOption account={data.account} isValue singleLineLayout={false} /> : null;
+
+export const renderCurrencyValue = ({ data: currency }: { data: Currency }) => {
+  return currency ? <CurrencyOption currency={currency} singleLineLayout={false} /> : null;
+};


### PR DESCRIPTION
## 🦒 Context (issues, jira)

To suit the design, changes the account/currency selectors values to display 2 lines of text for the selected item.
Also fixes (kinda) the overlap issue with the BTC derivation mode tag.

[LL-6359]
[LL-7010]

## 💻  Description / Demo (image or video)

<img width="436" alt="Capture d’écran 2021-09-02 à 17 29 22" src="https://user-images.githubusercontent.com/86958797/131873172-2d495e65-3a8a-4ee3-9f3b-1cdf78b93bdb.png">
<img width="439" alt="Capture d’écran 2021-09-02 à 17 29 29" src="https://user-images.githubusercontent.com/86958797/131873173-57f58b9f-1fa9-433b-890d-fd6da6684c0a.png">
<img width="445" alt="Capture d’écran 2021-09-02 à 17 29 33" src="https://user-images.githubusercontent.com/86958797/131873176-53376ab2-4b48-4177-b47b-7b3c6811ee6b.png">


## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
