### PR TITLE
LL-6359 - SWAP - Pre-populate form

### DIFF
--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.js
@@ -16,6 +16,7 @@ import type {
   SwapSelectorStateType,
   SwapTransactionType,
 } from "~/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction";
+import { usePickDefaultAccount } from "../../utils/shared/hooks";
 
 type Props = {
   fromAccount: $PropertyType<SwapSelectorStateType, "account">,
@@ -39,6 +40,7 @@ function FromRow({
   const accounts = useSelector(fromSelector)(useSelector(shallowAccountsSelector));
   const unit = fromAccount && getAccountUnit(fromAccount);
   const { t } = useTranslation();
+  usePickDefaultAccount(accounts, fromAccount, setFromAccount);
 
   return (
     <>

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/ToRow.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/ToRow.js
@@ -8,7 +8,10 @@ import { amountInputContainerProps, renderCurrencyValue, selectRowStylesMap } fr
 import { FormLabel } from "./FormLabel";
 import { toSelector } from "~/renderer/actions/swap";
 import { useSelector } from "react-redux";
-import { useSelectableCurrencies } from "~/renderer/screens/exchange/Swap2/utils/shared/hooks";
+import {
+  usePickDefaultCurrency,
+  useSelectableCurrencies,
+} from "~/renderer/screens/exchange/Swap2/utils/shared/hooks";
 import { getAccountCurrency, getAccountUnit } from "@ledgerhq/live-common/lib/account";
 import type {
   SwapSelectorStateType,
@@ -46,6 +49,8 @@ export default function ToRow({ toCurrency, setToAccount, toAmount, fromAccount 
   useEffect(() => {
     if (selectState.currency) selectState.setCurrency(selectState.currency);
   }, [accounts]);
+
+  usePickDefaultCurrency(selectState.currencies, selectState.currency, selectState.setCurrency);
 
   return (
     <>

--- a/src/renderer/screens/exchange/Swap2/utils/shared/hooks.js
+++ b/src/renderer/screens/exchange/Swap2/utils/shared/hooks.js
@@ -2,7 +2,11 @@
 import { useReducer, useEffect, useMemo } from "react";
 import type { AvailableProviderV3 } from "@ledgerhq/live-common/lib/exchange/swap/types";
 import { getProviders, getKYCStatus } from "@ledgerhq/live-common/lib/exchange/swap";
-import type { CryptoCurrency, TokenCurrency } from "@ledgerhq/live-common/lib/types/currencies";
+import type {
+  Currency,
+  CryptoCurrency,
+  TokenCurrency,
+} from "@ledgerhq/live-common/lib/types/currencies";
 import { findCryptoCurrencyById, findTokenById } from "@ledgerhq/cryptoassets";
 import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
 import { useCurrencyAccountSelect } from "~/renderer/components/PerCurrencySelectAccount/state";
@@ -168,9 +172,10 @@ export const usePollKYCStatus = (
   );
 };
 
+// Pick a default source account if none are selected.
 export const usePickDefaultAccount = (
   accounts: AccountLike[],
-  fromAccount: AccountLike,
+  fromAccount: ?AccountLike,
   setFromAccount: AccountLike => void,
 ) => {
   useMemo(() => {
@@ -193,4 +198,20 @@ export const usePickDefaultAccount = (
       defaultAccount && setFromAccount(defaultAccount);
     }
   }, [accounts, fromAccount, setFromAccount]);
+};
+
+// Pick a default currency target if none are selected.
+export const usePickDefaultCurrency = (
+  currencies: Currency[],
+  currency: ?Currency,
+  setCurrency: Currency => void,
+) => {
+  useMemo(() => {
+    if (!currency) {
+      const defaultCurrency = currencies.find(
+        currency => currency.id === "ethereum" || currency.id === "bitcoin",
+      );
+      defaultCurrency && setCurrency(defaultCurrency);
+    }
+  }, [currency, currencies, setCurrency]);
 };

--- a/src/renderer/screens/exchange/Swap2/utils/shared/hooks.js
+++ b/src/renderer/screens/exchange/Swap2/utils/shared/hooks.js
@@ -178,14 +178,14 @@ export const usePickDefaultAccount = (
   fromAccount: ?AccountLike,
   setFromAccount: AccountLike => void,
 ) => {
-  useMemo(() => {
+  useEffect(() => {
     if (!fromAccount) {
       const possibleDefaults = accounts.reduce((acc, account) => {
         if (account.disabled) return acc;
-        if (account.currency.id === "ethereum") {
+        if (account.currency?.id === "ethereum") {
           acc[0] = account;
         }
-        if (account.currency.id === "bitcoin") {
+        if (account.currency?.id === "bitcoin") {
           acc[1] = account;
         }
         const maxFundsAccount = acc[2];
@@ -194,7 +194,7 @@ export const usePickDefaultAccount = (
         }
         return acc;
       }, []);
-      const defaultAccount = possibleDefaults.find(acc => !!acc);
+      const defaultAccount = possibleDefaults.find(Boolean);
       defaultAccount && setFromAccount(defaultAccount);
     }
   }, [accounts, fromAccount, setFromAccount]);
@@ -206,7 +206,7 @@ export const usePickDefaultCurrency = (
   currency: ?Currency,
   setCurrency: Currency => void,
 ) => {
-  useMemo(() => {
+  useEffect(() => {
     if (!currency) {
       const defaultCurrency = currencies.find(
         currency => currency.id === "ethereum" || currency.id === "bitcoin",


### PR DESCRIPTION
## 🦒 Context (issues, jira)

Pre-populate the source account and the target currency.

- Pre-selected source account would be in order of preference: ethereum / bitcoin / the one with the biggest balance.
- Pre-selected currency is either eth/btc depending on the source.

[LL-6359]

## 💻  Description / Demo (image or video)

https://user-images.githubusercontent.com/86958797/132017004-ce56ae4b-0eb4-43b4-8f4a-edf0d3559aea.mp4

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-6359]: https://ledgerhq.atlassian.net/browse/LL-6359