### PR TITLE
electron-docker-webdriver container fix

### DIFF
--- a/tests/docker-electron-webdriver/Dockerfile
+++ b/tests/docker-electron-webdriver/Dockerfile
@@ -17,7 +17,11 @@ RUN apt-get update -qqy
 #=====
 # VNC
 #=====
-RUN apt-get -qqy install \
+# Installing libcrypt1 and x11vnc on the same command line fails.
+RUN apt-get -qqy install --no-install-recommends \
+  libcrypt1
+
+RUN apt-get -qqy install --no-install-recommends \
   x11vnc
 
 #=======


### PR DESCRIPTION
Lastest image doesn't work because x11vnc is missing a library.

## 🦒 Context (issues, jira)
Quick fix for QA tools

## 🖤  Expectations to reach
Docker container builds should not fail with latest docker image.
