### PR TITLE
LL-6788 Group snackbars when there are more than one

### DIFF
--- a/src/renderer/components/ToastOverlay/Toast.js
+++ b/src/renderer/components/ToastOverlay/Toast.js
@@ -3,6 +3,7 @@
 import React, { useEffect } from "react";
 import styled from "styled-components";
 import Text from "~/renderer/components/Text";
+import FakeLink from "~/renderer/components/FakeLink";
 import IconCross from "~/renderer/icons/Cross";
 import { TimeBasedProgressBar } from "./TimeBasedProgressBar";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
@@ -67,19 +68,23 @@ const icons = {
 export function Toast({
   duration,
   onDismiss,
+  dismissable = true,
   callback,
   type,
   title,
+  cta,
   text,
   icon,
   id,
 }: {
   duration?: number,
   onDismiss: (id: string) => void,
+  dismissable?: boolean,
   callback: any,
-  type: string,
+  type?: string,
   title: string,
-  text: string,
+  cta?: string,
+  text?: string,
   icon: string,
   id: string,
 }) {
@@ -127,38 +132,49 @@ export function Toast({
           <Icon size={19} />
         </IconContainer>
         <TextContainer>
-          <Text
-            ff="Inter|Bold"
-            fontSize="8px"
-            lineHeight="9.68px"
-            uppercase
-            letterSpacing="0.2em"
-            style={{ opacity: 0.4 }}
-          >
-            {t(`toastOverlay.toastType.${type}`)}
-          </Text>
-          <Text mt="2px" ff="Inter|SemiBold" fontSize="14px" lineHeight="16.94px">
-            {title}
-          </Text>
-          <Text
-            mt="10px"
-            ff="Inter|Regular"
-            fontSize="13px"
-            lineHeight="18px"
-            style={{
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-              opacity: 0.5,
-            }}
-          >
-            {text}
-          </Text>
+          {type ? (
+            <Text
+              ff="Inter|Bold"
+              fontSize="8px"
+              lineHeight="9.68px"
+              uppercase
+              letterSpacing="0.2em"
+              style={{ opacity: 0.4 }}
+            >
+              {t(`toastOverlay.toastType.${type}`)}
+            </Text>
+          ) : null}
+          <Box horizontal mt="2px" justifyContent="space-between" alignItems="center">
+            <Text ff="Inter|SemiBold" fontSize="14px" lineHeight="19px">
+              {title}
+            </Text>
+            {cta ? (
+              <FakeLink onClick={callback} ff="Inter|Regular" fontSize="13px" lineHeight="18px">
+                {cta}
+              </FakeLink>
+            ) : null}
+          </Box>
+          {text ? (
+            <Text
+              mt="10px"
+              ff="Inter|Regular"
+              fontSize="13px"
+              lineHeight="18px"
+              style={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                opacity: 0.5,
+              }}
+            >
+              {text}
+            </Text>
+          ) : null}
         </TextContainer>
       </Content>
       {duration ? (
         <TimeBasedProgressBar duration={duration} />
-      ) : (
+      ) : dismissable ? (
         <DismissWrapper
           onClick={event => {
             onDismiss(id);
@@ -167,7 +183,7 @@ export function Toast({
         >
           <IconCross size={12} />
         </DismissWrapper>
-      )}
+      ) : null}
     </Wrapper>
   ));
 }

--- a/src/renderer/components/ToastOverlay/index.js
+++ b/src/renderer/components/ToastOverlay/index.js
@@ -1,10 +1,14 @@
 // @flow
 
-import React from "react";
+import React, { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import { Toast } from "./Toast";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import { useToasts } from "@ledgerhq/live-common/lib/notifications/ToastProvider";
+import { v4 as uuidv4 } from "uuid";
+import { openInformationCenter } from "~/renderer/actions/UI";
 
 const Wrapper: ThemedComponent<{}> = styled.div`
   position: absolute;
@@ -18,20 +22,39 @@ const Wrapper: ThemedComponent<{}> = styled.div`
 
 export function ToastOverlay() {
   const { toasts, dismissToast } = useToasts();
+  const dispatch = useDispatch();
+  const { t } = useTranslation();
+  const onOpenInformationCenter = useCallback(
+    () => dispatch(openInformationCenter("announcement")),
+    [],
+  );
+
   return (
     <Wrapper>
-      {toasts.map(({ id, type, title, text, icon, callback }) => (
+      {toasts.length < 2 ? (
+        toasts.map(({ id, type, title, text, icon, callback }) => (
+          <Toast
+            id={id}
+            type={type}
+            title={title}
+            icon={icon}
+            text={text}
+            callback={callback}
+            onDismiss={dismissToast}
+            key={id}
+          />
+        ))
+      ) : (
         <Toast
-          id={id}
-          type={type}
-          title={title}
-          icon={icon}
-          text={text}
-          callback={callback}
+          id={uuidv4()}
+          icon="info"
+          title={t("toastOverlay.groupedToast.text", { count: toasts.length })}
+          cta={t("toastOverlay.groupedToast.cta")}
           onDismiss={dismissToast}
-          key={id}
+          dismissable={false}
+          callback={onOpenInformationCenter}
         />
-      ))}
+      )}
     </Wrapper>
   );
 }

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -2683,6 +2683,10 @@
       "announcement": "News",
       "operation": "Operation",
       "achievement": "Achievement Unlocked"
+    },
+    "groupedToast": {
+      "text": "You have {{count}} unread notifications",
+      "cta": "See details"
     }
   },
   "informationCenter": {


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-6788


## 💻  Description / Demo (image or video)
Whenever there's more than one snack-bar notification, group them into one that opens the notification side panel following the design from figma.

https://user-images.githubusercontent.com/4631227/133070892-3cde7676-2394-4ade-b919-5be380143b75.mov



## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two check-boxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two check-boxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->

- Launch the app with `MOCK=1`
- Trigger a notification, it should show the title and description, and work as usual on click
- Trigger a second notification, it should show a grouped snackbar with a counter
- Click on that notification or on the cta, it should open the sidebar and dismiss all notifications.

>**Note** that the auto dismiss behavior was already there in place and requires you to "see" the notification on the sidebar, so maybe you need to scroll if it doesn't dismiss automatically.