### PR TITLE
improved UI; added optional param field in manifest

### DIFF
--- a/src/renderer/components/Platform/AppDetails.js
+++ b/src/renderer/components/Platform/AppDetails.js
@@ -80,7 +80,6 @@ const BranchBadge: ThemedComponent<{}> = styled(Box).attrs(p => ({
 
 type Props = {
   manifest: AppManifest,
-  full: Boolean,
 };
 
 const AppDetails = ({ manifest }: Props) => {

--- a/src/renderer/components/Platform/AppDetails.js
+++ b/src/renderer/components/Platform/AppDetails.js
@@ -80,14 +80,13 @@ const BranchBadge: ThemedComponent<{}> = styled(Box).attrs(p => ({
 
 type Props = {
   manifest: AppManifest,
+  full: Boolean,
 };
 
 const AppDetails = ({ manifest }: Props) => {
   const { t } = useTranslation();
-  const description = t(
-    `manager.apps.content.${manifest.id}.shortDescription`,
-    manifest.content.shortDescription, // default description in case of missing translations
-  );
+  console.log(manifest);
+  const description = manifest.content.description.en;
 
   return (
     <>

--- a/src/renderer/components/Platform/AppDetails.js
+++ b/src/renderer/components/Platform/AppDetails.js
@@ -85,7 +85,6 @@ type Props = {
 
 const AppDetails = ({ manifest }: Props) => {
   const { t } = useTranslation();
-  console.log(manifest);
   const description = manifest.content.description.en;
 
   return (

--- a/src/renderer/components/WebPlatformPlayer/TopBar.js
+++ b/src/renderer/components/WebPlatformPlayer/TopBar.js
@@ -26,8 +26,9 @@ const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({
   grow: 0,
   alignItems: "center",
 }))`
-  padding: 16px 16px 16px 24px;
+  padding: 10px 16px;
   background-color: ${p => p.theme.colors.palette.background.paper};
+  border-bottom: 1px solid ${p => p.theme.colors.palette.text.shade10};
 `;
 
 const TitleContainer: ThemedComponent<{}> = styled(Box).attrs(() => ({
@@ -93,7 +94,10 @@ const ItemContainer: ThemedComponent<{
 
 const ItemContent: ThemedComponent<{}> = styled(Box).attrs(() => ({
   ff: "Inter|SemiBold",
-}))``;
+}))`
+  font-size: 14px;
+  line-height: 20px;
+`;
 
 export const Separator: ThemedComponent<*> = styled.div`
   margin-right: 16px;
@@ -124,7 +128,7 @@ const WebPlatformTopBar = ({ manifest, onReload, onHelp, onClose, onOpenDevTools
   return (
     <Container>
       <TitleContainer>
-        <LiveAppIcon name={name} icon={icon || undefined} size={24} />
+        <LiveAppIcon name={name} icon={icon || undefined} size={20} />
         <ItemContent>{name}</ItemContent>
       </TitleContainer>
       <Separator />

--- a/src/renderer/components/WebPlatformPlayer/index.js
+++ b/src/renderer/components/WebPlatformPlayer/index.js
@@ -108,9 +108,12 @@ const WebPlatformPlayer = ({ manifest, onClose, inputs }: Props) => {
 
     urlObj.searchParams.set("backgroundColor", theme.background.paper);
     urlObj.searchParams.set("textColor", theme.text.shade100);
+    if (manifest.params) {
+      urlObj.searchParams.set("params", JSON.stringify(manifest.params));
+    }
 
     return urlObj;
-  }, [manifest.url, theme, inputs]);
+  }, [manifest.url, theme, inputs, manifest.params]);
 
   const listAccounts = useCallback(() => {
     return accounts.map(account => serializePlatformAccount(accountToPlatformAccount(account)));

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -1382,44 +1382,6 @@
       }
     },
     "apps": {
-      "content": {
-        "paraswap": {
-          "shortDescription": "Swap your crypto with ParaSwap that aggregates and provides the best quotes on decentralised exchanges.",
-          "description": "Swap your crypto with ParaSwap that aggregates and provides the best quotes on decentralised exchanges."
-        },
-        "wyre_buy": {
-          "shortDescription": "Purchase Bitcoin, Ethereum and more crypto with Wyre, only available to our US customers.",
-          "description": "Purchase Bitcoin, Ethereum and more crypto with Wyre, only available to our US customers."
-        },
-        "lido": {
-          "shortDescription": "Stake your ETH with Lido to earn daily staking rewards.",
-          "description": "Stake your ETH with Lido to earn daily staking rewards."
-        },
-        "zerion": {
-          "shortDescription": "The smart way to manage your DeFi portfolio.",
-          "description": "The smart way to manage your DeFi portfolio."
-        },
-        "rainbow": {
-          "description": "An easy way to visualize the NFT secured by your hardware wallet.",
-          "shortDescription": "An easy way to visualize the NFT secured by your hardware wallet."
-        },
-        "aave": {
-          "description": "Lend or Borrow your crypto through a liquidity market protocol and stay in control of your funds.",
-          "shortDescription": "Lend or Borrow your crypto through a liquidity market protocol and stay in control of your funds."
-        },
-        "compound": {
-          "shortDescription": "Lend or Borrow your crypto via a completely decentralized and open-source protocol.",
-          "description": "Lend or Borrow your crypto via a completely decentralized and open-source protocol."
-        },
-        "deversifi": {
-          "shortDescription": "Trade through a self-custody decentralized exchange on Ethereum layer-2.",
-          "description": "Trade through a self-custody decentralized exchange on Ethereum layer-2."
-        },
-        "1inch": {
-          "shortDescription": "Exchange crypto via a Defi/DEX aggregator on Ethereum.",
-          "description": "Exchange crypto via a Defi/DEX aggregator on Ethereum."
-        }
-      },
       "dependencyInstall": {
         "title": "{{dependency}} app is required",
         "description": "The {{dependency}} app will also be installed because the {{app}} app needs it.",


### PR DESCRIPTION
## 🦒 Context (issues, jira)

LL-6407

## 💻  Description / Demo (image or video)

Latest dapp browser version support multi eth network and allow to specify configuration regarding: "rpcURL", "currency" and "chainId". This is becoming hard to generate the urls by hand in the app manifest, so I added a "params" field that gets automatically JSON.stringified and passed to the platform app through the "params" query param.

Also, visual fixes that were asked by design team.

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
