### PR TITLE
LL-6906 LL-6917 Wording fixes and polishes

### DIFF
--- a/src/renderer/components/Select/createStyles.js
+++ b/src/renderer/components/Select/createStyles.js
@@ -117,4 +117,9 @@ export default (
     ...styles,
     fontSize: small ? 12 : 13,
   }),
+  placeholder: (styles: Object) => ({
+    ...styles,
+    whiteSpace: "nowrap",
+    hyphens: "none",
+  }),
 });

--- a/src/renderer/components/WebPlatformPlayer/LiveAppDisclaimer.js
+++ b/src/renderer/components/WebPlatformPlayer/LiveAppDisclaimer.js
@@ -56,7 +56,7 @@ const Title: ThemedComponent<{}> = styled(Text).attrs(p => ({
 }))``;
 
 const Description: ThemedComponent<{}> = styled(Text).attrs(p => ({
-  color: rgba(p.theme.colors.dark, 0.6),
+  color: p.theme.colors.palette.text.shade60,
   ff: "Inter|Regular",
   mb: 12,
   textAlign: "center",

--- a/src/renderer/components/WebPlatformPlayer/LiveAppDrawer.js
+++ b/src/renderer/components/WebPlatformPlayer/LiveAppDrawer.js
@@ -23,7 +23,7 @@ import ExternalLink from "../ExternalLink/index";
 import LiveAppDisclaimer from "./LiveAppDisclaimer";
 
 const Divider = styled(Box)`
-  border: 1px solid #f5f5f5;
+  border: 1px solid ${p => p.theme.colors.palette.divider};
 `;
 
 export const LiveAppDrawer = () => {


### PR DESCRIPTION
## 🦒 Context (issues, jira)

- https://ledgerhq.atlassian.net/browse/LL-6917
- https://ledgerhq.atlassian.net/browse/LL-6906

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
**- LL-6906** Nothing to test, current wording doesn't trigger the bug
**- LL-6917**
  - Launch the app with the `DEBUG_THEME` env for easy theme switching
  - Go into discover/paraswap
  - See that we display a side drawer warning. If not, go into your app.json and remove the `PlatformAppDisclaimer` entry from the `dismissedBanners` array.
  - Switch the theme and see if all the text remains visible