### PR TITLE
LL-7162 - SWAP - Harmonize grey text

### DIFF
--- a/src/renderer/components/Input.js
+++ b/src/renderer/components/Input.js
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useState } from "react";
 import styled from "styled-components";
-import { fontSize, textAlign } from "styled-system";
+import { fontSize, textAlign, fontWeight, color } from "styled-system";
 import noop from "lodash/noop";
 import fontFamily from "~/renderer/styles/styled/fontFamily";
 import Spinner from "~/renderer/components/Spinner";
@@ -25,7 +25,7 @@ const RenderRightWrapper: ThemedComponent<{}> = styled(Box)`
   }
 `;
 
-const Container = styled(Box).attrs(() => ({
+export const Container: ThemedComponent<*> = styled(Box).attrs(() => ({
   horizontal: true,
 }))`
   background: ${p =>
@@ -125,11 +125,13 @@ const Base = styled.input.attrs(() => ({
 }))`
   font-family: "Inter";
   font-weight: 600;
+  color: ${p => p.theme.colors.palette.text.shade100};
+  border: 0;
   ${fontFamily};
   ${fontSize};
   ${textAlign};
-  border: 0;
-  color: ${p => p.theme.colors.palette.text.shade100};
+  ${fontWeight};
+  ${color};
   height: 100%;
   outline: none;
   padding: 0;

--- a/src/renderer/components/SelectAccount.js
+++ b/src/renderer/components/SelectAccount.js
@@ -136,7 +136,7 @@ export const AccountOption = React.memo<AccountOptionProps>(function AccountOpti
       </Box>
       <Box>
         <FormattedVal
-          color="palette.text.shade50"
+          color="palette.text.shade40"
           ff="Inter|Medium"
           fontSize={3}
           val={balance}

--- a/src/renderer/components/SelectCurrency.js
+++ b/src/renderer/components/SelectCurrency.js
@@ -162,7 +162,7 @@ export function CurrencyOption({
           {currency.name}
         </Text>
         <Box horizontal alignItems="center">
-          <Text color="palette.text.shade50" ff="Inter|Medium" fontSize={3}>
+          <Text color="palette.text.shade40" ff="Inter|Medium" fontSize={3}>
             {currency.ticker}
           </Text>
         </Box>

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FormInputs.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FormInputs.js
@@ -62,7 +62,7 @@ export default function FormInputs({
           fromAmountError={fromAmountError}
         />
       </Box>
-      <Box horizontal justifyContent="center" alignContent="center" mb={3}>
+      <Box horizontal justifyContent="center" alignContent="center" mb={1}>
         <SwapButton />
       </Box>
       <Box mb={2}>

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FormLabel.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FormLabel.js
@@ -4,7 +4,7 @@ import Text from "~/renderer/components/Text";
 
 export function FormLabel({ children }: { children?: React$Node }) {
   return (
-    <Text ff="Inter|SemiBold" color="palette.text.shade50" fontWeight="600">
+    <Text ff="Inter|Medium" color="palette.text.shade40">
       {children}
     </Text>
   );

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FromRow.js
@@ -49,15 +49,15 @@ function FromRow({
         justifyContent="space-between"
         alignItems="flex-end"
         fontSize={3}
-        mb={2}
+        mb={1}
         color={"palette.text.shade40"}
       >
         <FormLabel>{t("swap2.form.from.title")}</FormLabel>
         <Box horizontal alignItems="center">
-          <Text marginRight={1} fontWeight="500">
+          <Text ff="Inter|Medium" marginRight={1} fontSize={2}>
             {t("swap2.form.from.max")}
           </Text>
-          <Switch medium isChecked={isMaxEnabled} onChange={toggleMax} disabled={!fromAccount} />
+          <Switch small isChecked={isMaxEnabled} onChange={toggleMax} disabled={!fromAccount} />
         </Box>
       </Box>
       <Box horizontal boxShadow="0px 2px 4px rgba(0, 0, 0, 0.05);">
@@ -82,6 +82,7 @@ function FromRow({
             disabled={!fromAccount || isMaxEnabled}
             placeholder="0"
             textAlign="right"
+            fontWeight={600}
             containerProps={amountInputContainerProps}
             // $FlowFixMe
             unit={unit}

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/ToRow.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/ToRow.js
@@ -18,6 +18,8 @@ import type {
   SwapTransactionType,
 } from "~/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction";
 import { shallowAccountsSelector } from "~/renderer/reducers/accounts";
+import { Container as InputContainer } from "~/renderer/components/Input";
+import styled from "styled-components";
 
 type Props = {
   fromAccount: $PropertyType<SwapSelectorStateType, "account">,
@@ -25,6 +27,12 @@ type Props = {
   setToAccount: $PropertyType<SwapTransactionType, "setToAccount">,
   toAmount: $PropertyType<SwapSelectorStateType, "amount">,
 };
+
+const InputCurrencyContainer = styled(Box)`
+  ${InputContainer} {
+    background: none !important;
+  }
+`;
 
 export default function ToRow({ toCurrency, setToAccount, toAmount, fromAccount }: Props) {
   const fromCurrencyId = fromAccount ? getAccountCurrency(fromAccount).id : null;
@@ -61,7 +69,7 @@ export default function ToRow({ toCurrency, setToAccount, toAmount, fromAccount 
 
   return (
     <>
-      <Box horizontal color={"palette.text.shade40"} fontSize={3}>
+      <Box horizontal color={"palette.text.shade40"} fontSize={3} mb={1}>
         <FormLabel>
           <Trans i18nKey="swap2.form.to.title" />
         </FormLabel>
@@ -77,7 +85,7 @@ export default function ToRow({ toCurrency, setToAccount, toAmount, fromAccount 
             renderValueOverride={renderCurrencyValue}
           />
         </Box>
-        <Box width="50%">
+        <InputCurrencyContainer width="50%">
           <InputCurrency
             // @DEV: onChange props is required by the composant, there is no read-only logic
             onChange={() => {}}
@@ -85,12 +93,14 @@ export default function ToRow({ toCurrency, setToAccount, toAmount, fromAccount 
             disabled
             placeholder="-"
             textAlign="right"
+            fontWeight={600}
+            color="palette.text.shade40"
             containerProps={amountInputContainerProps}
             unit={unit}
             // Flow complains if this prop is missing…
             renderRight={null}
           />
-        </Box>
+        </InputCurrencyContainer>
       </Box>
     </>
   );

--- a/src/renderer/screens/exchange/Swap2/Form/RatesDrawer/Rate.js
+++ b/src/renderer/screens/exchange/Swap2/Form/RatesDrawer/Rate.js
@@ -84,7 +84,7 @@ function Rate({ value, selected, onSelect, swapTransaction }: Props) {
           justifyContent="space-between"
           fontSize={3}
           fontWeight={500}
-          color="palette.text.shade50"
+          color="palette.text.shade40"
         >
           <Box horizontal alignItems="center">
             <Box mr={1}>
@@ -105,7 +105,7 @@ function Rate({ value, selected, onSelect, swapTransaction }: Props) {
             value={amount}
             disableRounding
             showCode
-            color="palette.text.shade50"
+            color="palette.text.shade40"
           />
         </Box>
       </Box>


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LL-7162]

- Harmonize grey text to `shade40` instead of `shade50`
- Fix form inputs font weight and text/background color
- Fix max toggle/font size
- Fix "swap from/to" button margin

## 💻  Description / Demo (image or video)

<img width="1440" alt="Capture d’écran 2021-09-14 à 14 53 54" src="https://user-images.githubusercontent.com/86958797/133261238-84c58aaa-9427-49af-b1b4-c5dc6c105ba9.png">

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-7162]: https://ledgerhq.atlassian.net/browse/LL-7162