### PR TITLE
LL-7238 - SWAP - Remove infocircles

### DIFF
--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
@@ -72,10 +72,7 @@ const SectionFees = ({ swapTransaction }: { swapTransaction: SwapTransactionType
 
   return (
     <SummarySection>
-      <SummaryLabel
-        label={t("swap2.form.details.label.fees")}
-        details={t("swap2.form.details.tooltip.fees")}
-      />
+      <SummaryLabel label={t("swap2.form.details.label.fees")} />
       <SummaryValue handleChange={handleChange}>{summaryValue}</SummaryValue>
     </SummarySection>
   );

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionProvider.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionProvider.js
@@ -57,10 +57,7 @@ const SectionProvider = ({ provider, status }: SectionProviderProps) => {
 
   return (
     <SummarySection>
-      <SummaryLabel
-        label={t("swap2.form.details.label.provider")}
-        details={t("swap2.form.details.tooltip.provider")}
-      />
+      <SummaryLabel label={t("swap2.form.details.label.provider")} />
       {(provider && (
         <div style={{ display: "flex", columnGap: "6px", alignItems: "center" }}>
           <SummaryValue value={provider}>{ProviderIcon && <ProviderIcon size={19} />}</SummaryValue>

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionRate.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionRate.js
@@ -74,10 +74,7 @@ const SectionRate = ({ swapTransaction }: Props) => {
 
   return (
     <SummarySection>
-      <SummaryLabel
-        label={t("swap2.form.details.label.rate")}
-        details={t("swap2.form.details.tooltip.rate")}
-      />
+      <SummaryLabel label={t("swap2.form.details.label.rate")} />
       {summaryValue}
     </SummarySection>
   );


### PR DESCRIPTION
## 🦒 Context (issues, jira)

Remove infocircles.

[LL-7238]

## 💻  Description / Demo (image or video)

<img width="472" alt="Capture d’écran 2021-09-14 à 15 02 08" src="https://user-images.githubusercontent.com/86958797/133262356-901ee6d8-b70a-47d4-ad8e-79eb29baf1aa.png">

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-7238]: https://ledgerhq.atlassian.net/browse/LL-7238