### PR TITLE
LL-6359 - SWAP - Displays error when the amount is lower than the fees

### DIFF
--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -265,6 +265,9 @@
             "rejected": "KYC rejected"
           }
         }
+      },
+      "error": {
+        "SwapExchangeRateAmountIncludingFeesTooLow": "Including fees, the amount is too low to proceed a swap"
       }
     },
     "history": {


### PR DESCRIPTION
That covers the case when the amount received from the backend is lower
than the fees itself. In that case, we're returning an dedicated error
and we filter the provider.


## 🦒 Context (issues, jira)

[LL-6359]

## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-6359]: https://ledgerhq.atlassian.net/browse/LL-6359