### PR TITLE
LL-6567 - SWAP - Tracking Events

### DIFF
--- a/src/renderer/components/DeviceAction/rendering.js
+++ b/src/renderer/components/DeviceAction/rendering.js
@@ -41,12 +41,13 @@ import SupportLinkError from "~/renderer/components/SupportLinkError";
 import { urls } from "~/config/urls";
 import CurrencyUnitValue from "~/renderer/components/CurrencyUnitValue";
 import ExternalLinkButton from "../ExternalLinkButton";
-import { setTrackingSource } from "~/renderer/analytics/TrackPage";
+import TrackPage, { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import { Rotating } from "~/renderer/components/Spinner";
 import ProgressCircle from "~/renderer/components/ProgressCircle";
 import CrossCircle from "~/renderer/icons/CrossCircle";
 import { getProviderIcon } from "~/renderer/screens/exchange/Swap2/utils";
 import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
+import { SWAP_VERSION } from "~/renderer/screens/exchange/Swap2/utils/index";
 
 const AnimationWrapper: ThemedComponent<{ modelId?: DeviceModelId }> = styled.div`
   width: 600px;
@@ -630,6 +631,14 @@ export const renderSwapDeviceConfirmationV2 = ({
   ];
   return (
     <>
+      <TrackPage
+        category="Swap"
+        name={`ModalStep-summary`}
+        sourcecurrency={sourceAccountCurrency?.name}
+        targetcurrency={targetAccountCurrency?.name}
+        provider={exchangeRate.provider}
+        swapVersion={SWAP_VERSION}
+      />
       <Box flex={0}>
         <Alert type="primary" learnMoreUrl={urls.swap.learnMore} mb={7} mx={4}>
           <Trans i18nKey="DeviceAction.swap.notice" />

--- a/src/renderer/screens/exchange/Swap2/Form/ExchangeDrawer/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/ExchangeDrawer/index.js
@@ -19,9 +19,10 @@ import { updateAccountWithUpdater } from "~/renderer/actions/accounts";
 import SwapCompleted from "./SwapCompleted";
 import Button from "~/renderer/components/Button";
 import { setDrawer } from "~/renderer/drawers/Provider";
-import { useRedirectToSwapHistory } from "../../utils/index";
+import { SWAP_VERSION, useRedirectToSwapHistory } from "../../utils/index";
 import { Separator } from "../Separator";
 import { DrawerTitle } from "../DrawerTitle";
+import TrackPage from "~/renderer/analytics/TrackPage";
 
 const ContentBox = styled(Box)`
   ${DeviceActionHeader} {
@@ -45,7 +46,7 @@ export default function ExchangeDrawer({ swapTransaction, exchangeRate, onComple
   const {
     transaction,
     swap: {
-      from: { account: fromAccount, parentAccount: fromParentAccount },
+      from: { account: fromAccount, parentAccount: fromParentAccount, currency: sourceCurrency },
       to: { account: toAccount, parentAccount: toParentAccount, currency: targetCurrency },
     },
   } = swapTransaction;
@@ -109,6 +110,14 @@ export default function ExchangeDrawer({ swapTransaction, exchangeRate, onComple
   if (error) {
     return (
       <Box height="100%" justifyContent="space-between">
+        <TrackPage
+          category="Swap"
+          name={`ModalStep-confirmationfail`}
+          sourcecurrency={sourceCurrency?.name}
+          targetcurrency={targetCurrency?.name}
+          provider={exchangeRate.provider}
+          swapVersion={SWAP_VERSION}
+        />
         <Box justifyContent="center" flex={1}>
           <ErrorDisplay error={error} />
         </Box>
@@ -127,9 +136,17 @@ export default function ExchangeDrawer({ swapTransaction, exchangeRate, onComple
   if (result) {
     return (
       <Box height="100%" justifyContent="space-between">
+        <TrackPage
+          category="Swap"
+          name={`ModalStep-finished`}
+          sourcecurrency={sourceCurrency?.name}
+          targetcurrency={targetCurrency?.name}
+          provider={exchangeRate.provider}
+          swapVersion={SWAP_VERSION}
+        />
         <Box justifyContent="center" flex={1}>
           <SwapCompleted
-            swapId="122144134"
+            swapId={result?.swapId}
             provider={exchangeRate.provider}
             targetCurrency={targetCurrency.name}
           />

--- a/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.js
@@ -6,12 +6,19 @@ import SendAmountFields from "~/renderer/modals/Send/SendAmountFields";
 import { transactionSelector } from "~/renderer/actions/swap";
 import type { SwapTransactionType } from "~/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction";
 import { DrawerTitle } from "../DrawerTitle";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { SWAP_VERSION } from "../../utils/index";
 
 type Props = {
   swapTransaction: SwapTransactionType,
   disableSlowStrategy?: boolean,
+  provider: ?string,
 };
-export default function FeesDrawer({ swapTransaction, disableSlowStrategy = false }: Props) {
+export default function FeesDrawer({
+  swapTransaction,
+  disableSlowStrategy = false,
+  provider,
+}: Props) {
   const { setTransaction, updateTransaction, account, parentAccount, status } = swapTransaction;
   const transaction = useSelector(transactionSelector);
 
@@ -23,6 +30,13 @@ export default function FeesDrawer({ swapTransaction, disableSlowStrategy = fals
 
   return (
     <Box height="100%">
+      <TrackPage
+        category="Swap"
+        name="Form - Edit Fees"
+        sourcecurrency={swapTransaction.swap.from.currency?.name}
+        provider={provider}
+        swapVersion={SWAP_VERSION}
+      />
       <DrawerTitle i18nKey="swap2.form.details.label.fees" />
       <Box mt={3} flow={4}>
         {transaction.networkInfo && (

--- a/src/renderer/screens/exchange/Swap2/Form/FormLoading/FormLoading.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormLoading/FormLoading.js
@@ -4,11 +4,8 @@ import React from "react";
 import Box from "~/renderer/components/Box";
 import BigSpinner from "~/renderer/components/BigSpinner";
 
-import Track from "~/renderer/analytics/Track";
-
 const FormLoading = () => (
   <Box justifyContent="center" alignItems="center">
-    <Track onMount event="LoadingProviders" />
     <BigSpinner size={75} />
   </Box>
 );

--- a/src/renderer/screens/exchange/Swap2/Form/FormNotAvailable/FormNotAvailable.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormNotAvailable/FormNotAvailable.js
@@ -7,7 +7,8 @@ import Text from "~/renderer/components/Text";
 import Box from "~/renderer/components/Box";
 import SwapCircle from "~/renderer/icons/SwapCircle";
 
-import Track from "~/renderer/analytics/Track";
+import { SWAP_VERSION } from "../../utils/index";
+import TrackPage from "~/renderer/analytics/TrackPage";
 
 const Body = styled(Box).attrs({
   alignItems: "center",
@@ -31,7 +32,7 @@ const FormNotAvailable = () => {
 
   return (
     <Box justifyContent="center" alignItems="center">
-      <Track onMount event="NotAvailable" />
+      <TrackPage category="Swap" name="NotAvailable" swapVersion={SWAP_VERSION} />
       <Body>
         <IconContainer>
           <SwapCircle size={70} />

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FormInputs.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/FormInputs.js
@@ -24,6 +24,7 @@ type FormInputsProps = {
   isMaxEnabled?: boolean,
   fromAmountError?: Error,
   isSwapReversable: boolean,
+  provider: ?string,
   loadingRates: boolean,
 };
 
@@ -57,6 +58,7 @@ export default function FormInputs({
   fromAmountError,
   reverseSwap,
   isSwapReversable,
+  provider,
   loadingRates,
 }: FormInputsProps) {
   return (
@@ -70,6 +72,7 @@ export default function FormInputs({
           isMaxEnabled={isMaxEnabled}
           toggleMax={toggleMax}
           fromAmountError={fromAmountError}
+          provider={provider}
         />
       </Box>
       <Box horizontal justifyContent="center" alignContent="center" mb={1}>
@@ -81,6 +84,7 @@ export default function FormInputs({
           setToAccount={setToAccount}
           toAmount={toAmount}
           fromAccount={fromAccount}
+          provider={provider}
           loadingRates={loadingRates}
         />
       </Box>

--- a/src/renderer/screens/exchange/Swap2/Form/FormSelectors/ToRow.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSelectors/ToRow.js
@@ -24,12 +24,15 @@ import {
 } from "~/renderer/components/Input";
 import styled from "styled-components";
 import CounterValue from "~/renderer/components/CounterValue";
+import { track } from "~/renderer/analytics/segment";
+import { SWAP_VERSION } from "../../utils/index";
 
 type Props = {
   fromAccount: $PropertyType<SwapSelectorStateType, "account">,
   toCurrency: $PropertyType<SwapSelectorStateType, "currency">,
   setToAccount: $PropertyType<SwapTransactionType, "setToAccount">,
   toAmount: $PropertyType<SwapSelectorStateType, "amount">,
+  provider: ?string,
   loadingRates: boolean,
 };
 
@@ -52,6 +55,7 @@ export default function ToRow({
   setToAccount,
   toAmount,
   fromAccount,
+  provider,
   loadingRates,
 }: Props) {
   const fromCurrencyId = fromAccount ? getAccountCurrency(fromAccount).id : null;
@@ -97,6 +101,21 @@ export default function ToRow({
 
   usePickDefaultCurrency(selectState.currencies, selectState.currency, selectState.setCurrency);
 
+  const trackEditCurrency = () =>
+    track("Page Swap Form - Edit Target Currency", {
+      targetcurrency: toCurrency,
+      provider,
+      swapVersion: SWAP_VERSION,
+    });
+  const setCurrencyAndTrack = currency => {
+    track("Page Swap Form - New Target Currency", {
+      targetcurrency: currency,
+      provider,
+      swapVersion: SWAP_VERSION,
+    });
+    selectState.setCurrency(currency);
+  };
+
   return (
     <>
       <Box horizontal color={"palette.text.shade40"} fontSize={3} mb={1}>
@@ -108,11 +127,12 @@ export default function ToRow({
         <Box width="50%">
           <SelectCurrency
             currencies={selectState.currencies}
-            onChange={selectState.setCurrency}
+            onChange={setCurrencyAndTrack}
             value={selectState.currency}
             stylesMap={selectRowStylesMap}
             isDisabled={!fromAccount}
             renderValueOverride={renderCurrencyValue}
+            onMenuOpen={trackEditCurrency}
           />
         </Box>
         <InputCurrencyContainer width="50%">

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
@@ -14,7 +14,13 @@ import { rateSelector } from "~/renderer/actions/swap";
 import FormattedVal from "~/renderer/components/FormattedVal";
 import Text from "~/renderer/components/Text";
 
-const SectionFees = ({ swapTransaction }: { swapTransaction: SwapTransactionType }) => {
+const SectionFees = ({
+  swapTransaction,
+  provider,
+}: {
+  swapTransaction: SwapTransactionType,
+  provider: ?string,
+}) => {
   const { t } = useTranslation();
   const { setDrawer } = React.useContext(context);
   const { account, transaction } = swapTransaction;
@@ -50,8 +56,9 @@ const SectionFees = ({ swapTransaction }: { swapTransaction: SwapTransactionType
         setDrawer(FeesDrawer, {
           swapTransaction,
           disableSlowStrategy: exchangeRate?.tradeMethod === "fixed",
+          provider,
         })),
-    [canEdit, setDrawer, swapTransaction, exchangeRate?.tradeMethod],
+    [canEdit, setDrawer, swapTransaction, provider, exchangeRate?.tradeMethod],
   );
 
   const summaryValue = canEdit ? (

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionRate.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionRate.js
@@ -21,8 +21,9 @@ import { ratesExpirationThreshold } from "~/renderer/reducers/swap";
 
 type Props = {
   swapTransaction: SwapTransactionType,
+  provider: ?string,
 };
-const SectionRate = ({ swapTransaction }: Props) => {
+const SectionRate = ({ swapTransaction, provider }: Props) => {
   const { t } = useTranslation();
   const { setDrawer } = useContext(context);
   const exchangeRate = useSelector(rateSelector);
@@ -36,8 +37,9 @@ const SectionRate = ({ swapTransaction }: Props) => {
       (() =>
         setDrawer(RatesDrawer, {
           swapTransaction,
+          provider,
         })),
-    [setDrawer, ratesState.value, swapTransaction],
+    [setDrawer, ratesState.value, provider, swapTransaction],
   );
 
   const summaryValue =

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/index.js
@@ -23,8 +23,8 @@ type SwapFormSummaryProps = {
 const SwapFormSummary = ({ swapTransaction, kycStatus, provider }: SwapFormSummaryProps) => (
   <Form>
     <SectionProvider provider={provider} status={kycStatus} />
-    <SectionRate swapTransaction={swapTransaction} />
-    <SectionFees swapTransaction={swapTransaction} />
+    <SectionRate provider={provider} swapTransaction={swapTransaction} />
+    <SectionFees provider={provider} swapTransaction={swapTransaction} />
     <SectionTarget
       account={swapTransaction.swap.to.parentAccount ?? swapTransaction.swap.to.account}
       currency={swapTransaction.swap.to.currency}

--- a/src/renderer/screens/exchange/Swap2/Form/RatesDrawer/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/RatesDrawer/index.js
@@ -8,10 +8,13 @@ import Rate from "./Rate";
 import type { SwapTransactionType } from "../../utils/shared/useSwapTransaction";
 import { rateSelector, updateRateAction } from "~/renderer/actions/swap";
 import { DrawerTitle } from "../DrawerTitle";
+import TrackPage from "~/renderer/analytics/TrackPage";
+import { SWAP_VERSION } from "../../utils/index";
 type Props = {
   swapTransaction: SwapTransactionType,
+  provider: ?string,
 };
-export default function ProviderRateDrawer({ swapTransaction }: Props) {
+export default function ProviderRateDrawer({ swapTransaction, provider }: Props) {
   const dispatch = useDispatch();
   const rates = swapTransaction.swap.rates.value;
   const selectedRate = useSelector(rateSelector);
@@ -25,6 +28,14 @@ export default function ProviderRateDrawer({ swapTransaction }: Props) {
 
   return (
     <Box height="100%">
+      <TrackPage
+        category="Swap"
+        name="Form - Edit Fees"
+        sourcecurrency={swapTransaction.swap.from.currency?.name}
+        targetcurrency={swapTransaction.swap.to.currency?.name}
+        provider={provider}
+        swapVersion={SWAP_VERSION}
+      />
       <DrawerTitle i18nKey="swap2.form.ratesDrawer.title" />
       <Box mt={3}>
         <Box

--- a/src/renderer/screens/exchange/Swap2/History/History.js
+++ b/src/renderer/screens/exchange/Swap2/History/History.js
@@ -27,6 +27,7 @@ import SwapOperationDetails from "~/renderer/drawers/SwapOperationDetails";
 import HistoryLoading from "./HistoryLoading";
 import HistoryPlaceholder from "./HistoryPlaceholder";
 import { useHistory } from "react-router-dom";
+import TrackPage from "~/renderer/analytics/TrackPage";
 
 const Head = styled(Box)`
   border-bottom: 1px solid ${p => p.theme.colors.palette.divider};
@@ -155,45 +156,48 @@ const History = () => {
   );
 
   return (
-    <Box p={20}>
-      <Box horizontal flow={2} alignItems="center" justifyContent="flex-end">
-        <ExportOperationsWrapper horizontal>
-          <IconDownloadCloud size={16} />
-          <Text ml={1} ff="Inter|Regular" fontSize={3}>
-            <FakeLink onClick={exporting ? undefined : onExportOperations}>
-              {exporting ? t("swap2.history.exporting") : t("swap2.history.export")}
-            </FakeLink>
-          </Text>
-        </ExportOperationsWrapper>
-      </Box>
-      {mappedSwapOperations ? (
-        mappedSwapOperations.length ? (
-          <Box>
-            <Head px={20} py={16}>
-              <Alert type="primary">{t("swap2.history.disclaimer")}</Alert>
-            </Head>
-            {mappedSwapOperations.map(section => (
-              <>
-                <SectionTitle day={section.day} />
-                <Box>
-                  {section.data.map(mappedSwapOperation => (
-                    <OperationRow
-                      key={mappedSwapOperation.swapId}
-                      mappedSwapOperation={mappedSwapOperation}
-                      openSwapOperationDetailsModal={openSwapOperationDetailsModal}
-                    />
-                  ))}
-                </Box>
-              </>
-            ))}
-          </Box>
+    <>
+      <TrackPage category="Swap" name="Device History" />
+      <Box p={20}>
+        <Box horizontal flow={2} alignItems="center" justifyContent="flex-end">
+          <ExportOperationsWrapper horizontal>
+            <IconDownloadCloud size={16} />
+            <Text ml={1} ff="Inter|Regular" fontSize={3}>
+              <FakeLink onClick={exporting ? undefined : onExportOperations}>
+                {exporting ? t("swap2.history.exporting") : t("swap2.history.export")}
+              </FakeLink>
+            </Text>
+          </ExportOperationsWrapper>
+        </Box>
+        {mappedSwapOperations ? (
+          mappedSwapOperations.length ? (
+            <Box>
+              <Head px={20} py={16}>
+                <Alert type="primary">{t("swap2.history.disclaimer")}</Alert>
+              </Head>
+              {mappedSwapOperations.map(section => (
+                <>
+                  <SectionTitle day={section.day} />
+                  <Box>
+                    {section.data.map(mappedSwapOperation => (
+                      <OperationRow
+                        key={mappedSwapOperation.swapId}
+                        mappedSwapOperation={mappedSwapOperation}
+                        openSwapOperationDetailsModal={openSwapOperationDetailsModal}
+                      />
+                    ))}
+                  </Box>
+                </>
+              ))}
+            </Box>
+          ) : (
+            <HistoryPlaceholder />
+          )
         ) : (
-          <HistoryPlaceholder />
-        )
-      ) : (
-        <HistoryLoading />
-      )}
-    </Box>
+          <HistoryLoading />
+        )}
+      </Box>
+    </>
   );
 };
 

--- a/src/renderer/screens/exchange/Swap2/KYC/Pending.js
+++ b/src/renderer/screens/exchange/Swap2/KYC/Pending.js
@@ -15,7 +15,7 @@ import IconCheck from "~/renderer/icons/Check";
 import IconClock from "~/renderer/icons/Clock";
 import Button from "~/renderer/components/Button";
 import InfoCircle from "~/renderer/icons/InfoCircle";
-import { useRedirectToSwapForm } from "../utils/index";
+import { useRedirectToSwapForm, SWAP_VERSION } from "../utils/index";
 
 export const CircleWrapper: ThemedComponent<{}> = styled.div`
   border-radius: 50%;
@@ -79,7 +79,7 @@ const Pending = () => {
         </Text>
         <InfoCircle size={13} />
       </InfoTag>
-      <TrackPage category="Swap" name="KYC Pending" />
+      <TrackPage category="Swap" name="KYC Pending" swapVersion={SWAP_VERSION} />
       <CircleWrapper size={50}>
         <IconCheck size={25} />
         <WrapperClock>

--- a/src/renderer/screens/exchange/Swap2/KYC/index.js
+++ b/src/renderer/screens/exchange/Swap2/KYC/index.js
@@ -23,7 +23,7 @@ import { swapKYCSelector } from "~/renderer/reducers/settings";
 import { setSwapKYCStatus } from "~/renderer/actions/settings";
 import Tabbable from "~/renderer/components/Box/Tabbable";
 import AngleLeft from "~/renderer/icons/AngleLeft";
-import { useRedirectToSwapForm } from "../utils/index";
+import { SWAP_VERSION, useRedirectToSwapForm } from "../utils/index";
 
 const Footer = styled.div`
   border-top: 1px solid ${p => p.theme.colors.palette.divider};
@@ -160,7 +160,7 @@ const KYC = () => {
         <Pending />
       ) : (
         <>
-          <TrackPage category="Swap" name="KYC Form" />
+          <TrackPage category="Swap" name="KYC Form" swapVersion={SWAP_VERSION} />
           <Box px={40} pt={40} mb={16} alignSelf={"normal"} alignItems={"center"}>
             <IconWyre size={32} />
             <Text ff="Inter|SemiBold" fontSize={18} color="palette.text.shade100">

--- a/src/renderer/screens/exchange/Swap2/Navbar/index.js
+++ b/src/renderer/screens/exchange/Swap2/Navbar/index.js
@@ -31,21 +31,18 @@ const Navbar = () => {
 
   const tabs = useMemo(
     () => swapRoutes.filter(route => !route.disabled).map(route => t(route.title)),
-    [],
+    [t],
   );
 
   const onWrappedTabChange = nextIndex => {
     if (currentIndex === nextIndex) return;
-
     const nextPathname = swapRoutes[nextIndex].path;
-    setTrackingSource("swap/navbar");
     history.push({ pathname: nextPathname });
   };
 
   return (
     currentIndex >= 0 && (
       <Nav>
-        <TrackPage category="swap" name={swapRoutes[currentIndex].name} />
         <TabBar tabs={tabs} onIndexChange={onWrappedTabChange} index={currentIndex} />
       </Nav>
     )

--- a/src/renderer/screens/exchange/Swap2/Navbar/routes.json
+++ b/src/renderer/screens/exchange/Swap2/Navbar/routes.json
@@ -1,11 +1,9 @@
 [
   {
-    "name": "swap",
     "path": "/swap",
     "title": "swap2.tabs.exchange"
   },
   {
-    "name": "history",
     "path": "/swap/history",
     "title": "swap2.tabs.history"
   }

--- a/src/renderer/screens/exchange/Swap2/utils/index.js
+++ b/src/renderer/screens/exchange/Swap2/utils/index.js
@@ -3,6 +3,11 @@ import { useCallback } from "react";
 import { useHistory } from "react-router-dom";
 import * as providerIcons from "~/renderer/icons/providers";
 import type { ExchangeRate } from "@ledgerhq/live-common/lib/exchange/swap/types";
+import { SwapExchangeRateAmountTooLow } from "@ledgerhq/live-common/lib/errors";
+import { NotEnoughBalance } from "@ledgerhq/errors";
+import { track } from "~/renderer/analytics/segment";
+
+export const SWAP_VERSION = "2.34";
 
 export const useRedirectToSwapForm = () => {
   const history = useHistory();
@@ -33,3 +38,17 @@ export const iconByProviderName = Object.entries(providerIcons).reduce(
 
 export const getProviderIcon = (exchangeRate: ExchangeRate) =>
   iconByProviderName[exchangeRate.provider.toLowerCase()];
+
+export const trackSwapError = (error: *, properties: * = {}) => {
+  if (!error) return;
+  if (error instanceof SwapExchangeRateAmountTooLow) {
+    track("Page Swap Form - Error Less Mini", {
+      ...properties,
+    });
+  }
+  if (error instanceof NotEnoughBalance) {
+    track("Page Swap Form - Error No Funds", {
+      ...properties,
+    });
+  }
+};

--- a/src/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction.js
+++ b/src/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction.js
@@ -41,7 +41,7 @@ export type SwapDataType = {
   refetchRates: () => void,
 };
 
-const SelectorStateDefaultValues = {
+const selectorStateDefaultValues = {
   currency: null,
   account: null,
   parentAccount: null,
@@ -87,12 +87,12 @@ const useSwapTransaction = ({
   defaultAccount?: $PropertyType<SwapSelectorStateType, "account">,
   defaultParentAccount?: $PropertyType<SwapSelectorStateType, "parentAccount">,
 } = {}): SwapTransactionType => {
-  const [toState, setToState] = useState<SwapSelectorStateType>(SelectorStateDefaultValues);
+  const [toState, setToState] = useState<SwapSelectorStateType>(selectorStateDefaultValues);
   const [fromState, setFromState] = useState<SwapSelectorStateType>({
-    ...SelectorStateDefaultValues,
-    currency: defaultCurrency ?? SelectorStateDefaultValues.currency,
-    account: defaultAccount ?? SelectorStateDefaultValues.account,
-    parentAccount: defaultParentAccount ?? SelectorStateDefaultValues.parentAccount,
+    ...selectorStateDefaultValues,
+    currency: defaultCurrency ?? selectorStateDefaultValues.currency,
+    account: defaultAccount ?? selectorStateDefaultValues.account,
+    parentAccount: defaultParentAccount ?? selectorStateDefaultValues.parentAccount,
   });
   const [isMaxEnabled, setMax] = useState<$PropertyType<SwapDataType, "isMaxEnabled">>(false);
   const [rates, dispatchRates] = useReducer(ratesReducer, ratesReducerInitialState);
@@ -129,8 +129,8 @@ const useSwapTransaction = ({
     const currency = getAccountCurrency(account);
 
     bridgeTransaction.setAccount(account, parentAccount);
-    setFromState({ ...SelectorStateDefaultValues, currency, account, parentAccount });
-    setToState(SelectorStateDefaultValues);
+    setFromState({ ...selectorStateDefaultValues, currency, account, parentAccount });
+    setToState(selectorStateDefaultValues);
 
     /* @DEV: That populates fake seed. This is required to use Transaction object */
     const mainAccount = getMainAccount(account, parentAccount);
@@ -144,7 +144,7 @@ const useSwapTransaction = ({
     currency,
     account,
     parentAccount,
-  ) => setToState({ ...SelectorStateDefaultValues, currency, account, parentAccount });
+  ) => setToState({ ...selectorStateDefaultValues, currency, account, parentAccount });
 
   const setFromAmount: $PropertyType<SwapTransactionType, "setFromAmount"> = amount => {
     bridgeTransaction.updateTransaction(transaction => ({ ...transaction, amount }));


### PR DESCRIPTION
## 🦒 Context (issues, jira)

Trying to stick to the old events name, with an additional `swapVersion` property to disambiguate.

Also:
- fixed: the swapId prop in the recap that was mocked 🤦 
- fixed: preselect the right account when coming from the accounts page

[LL-6567]

[Events Reference](https://docs.google.com/spreadsheets/d/1ECRYMrOjHh76lgtfBiY4vc5Q4Z3eu-LwAF7SiSWgwqU/edit#gid=1168302553)

## 💻  Description / Demo (image or video)

*N/A*

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-6567]: https://ledgerhq.atlassian.net/browse/LL-6567