### PR TITLE
LL-7239 Swap form add some animations while loading first rates

### DIFF
--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
@@ -5,7 +5,7 @@ import { useSelector } from "react-redux";
 import { getAccountUnit } from "@ledgerhq/live-common/lib/account";
 import { context } from "~/renderer/drawers/Provider";
 import SummaryLabel from "./SummaryLabel";
-import SummaryValue from "./SummaryValue";
+import SummaryValue, { NoValuePlaceholder } from "./SummaryValue";
 import SummarySection from "./SummarySection";
 import FeesDrawer from "../FeesDrawer";
 import sendAmountByFamily from "~/renderer/generated/SendAmountFields";
@@ -56,6 +56,7 @@ type Props = {
   updateTransaction: $PropertyType<SwapTransactionType, "updateTransaction">,
   setTransaction: $PropertyType<SwapTransactionType, "setTransaction">,
   provider: ?string,
+  hasRates: boolean,
 };
 const SectionFees = ({
   transaction,
@@ -66,6 +67,7 @@ const SectionFees = ({
   updateTransaction,
   setTransaction,
   provider,
+  hasRates,
 }: Props) => {
   const { t } = useTranslation();
   const { setDrawer } = React.useContext(context);
@@ -74,6 +76,7 @@ const SectionFees = ({
   const estimatedFees = status?.estimatedFees;
   const showSummaryValue = fromAccountUnit && estimatedFees && estimatedFees.gt(0);
   const canEdit =
+    hasRates &&
     showSummaryValue &&
     transaction?.networkInfo &&
     account &&
@@ -145,9 +148,7 @@ const SectionFees = ({
       />
     </>
   ) : (
-    <Text color="palette.text.shade100" fontSize={4}>
-      {"-"}
-    </Text>
+    <NoValuePlaceholder />
   );
 
   return (

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionProvider.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionProvider.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react";
 import SummaryLabel from "./SummaryLabel";
-import SummaryValue from "./SummaryValue";
+import SummaryValue, { NoValuePlaceholder } from "./SummaryValue";
 import SummarySection from "./SummarySection";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
@@ -64,9 +64,9 @@ const SectionProvider = ({ provider, status }: SectionProviderProps) => {
           {status ? <ProviderStatusTag status={status} /> : null}
         </div>
       )) || (
-        <Text color="palette.text.shade100" fontSize={4}>
-          {"-"}
-        </Text>
+        <SummaryValue>
+          <NoValuePlaceholder />
+        </SummaryValue>
       )}
     </SummarySection>
   );

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionRate.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionRate.js
@@ -2,7 +2,7 @@
 import React, { useContext, useMemo } from "react";
 import { useSelector } from "react-redux";
 import SummaryLabel from "./SummaryLabel";
-import SummaryValue from "./SummaryValue";
+import SummaryValue, { NoValuePlaceholder } from "./SummaryValue";
 import { useTranslation } from "react-i18next";
 import IconLock from "~/renderer/icons/Lock";
 import IconLockOpen from "~/renderer/icons/LockOpen";
@@ -16,7 +16,6 @@ import type {
 } from "../../utils/shared/useSwapTransaction";
 import Price from "~/renderer/components/Price";
 import { rateSelector, rateExpirationSelector } from "~/renderer/actions/swap";
-import Text from "~/renderer/components/Text";
 import Spinner from "~/renderer/components/Spinner";
 import CountdownTimer from "~/renderer/components/CountdownTimer";
 import Box from "~/renderer/components/Box";
@@ -52,7 +51,7 @@ const SectionRate = ({ fromCurrency, toCurrency, ratesState, refetchRates, provi
 
   const summaryValue =
     ratesState.status === "loading" ? (
-      <Spinner size={17} color="palette.text.shade40" my="1px" />
+      <Spinner size={17} color="palette.text.shade40" my="1px" mr="10px" />
     ) : exchangeRate && fromCurrency && toCurrency ? (
       <SummaryValue handleChange={handleChange}>
         {ratesExpiration && exchangeRate.tradeMethod === "fixed" && (
@@ -77,9 +76,7 @@ const SectionRate = ({ fromCurrency, toCurrency, ratesState, refetchRates, provi
         />
       </SummaryValue>
     ) : (
-      <Text color="palette.text.shade100" fontSize={4}>
-        {"-"}
-      </Text>
+      <NoValuePlaceholder />
     );
 
   return (

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionTarget.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionTarget.js
@@ -3,7 +3,7 @@ import React, { useEffect, useRef } from "react";
 import { useDispatch } from "react-redux";
 import SummaryLabel from "./SummaryLabel";
 import SectionInformative from "./SectionInformative";
-import SummaryValue from "./SummaryValue";
+import SummaryValue, { NoValuePlaceholder } from "./SummaryValue";
 import { useTranslation } from "react-i18next";
 import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
 import { getAccountName } from "@ledgerhq/live-common/lib/account";
@@ -46,7 +46,9 @@ const PlaceholderSection = () => {
   return (
     <SummarySection>
       <SummaryLabel label={t("swap2.form.details.label.target")} />
-      <SummaryValue />
+      <SummaryValue>
+        <NoValuePlaceholder />
+      </SummaryValue>
     </SummarySection>
   );
 };
@@ -56,8 +58,15 @@ type SectionTargetProps = {
   currency: $PropertyType<SwapSelectorStateType, "currency">,
   setToAccount: $PropertyType<SwapTransactionType, "setToAccount">,
   targetAccounts: $PropertyType<SwapTransactionType, "targetAccounts">,
+  hasRates: boolean,
 };
-const SectionTarget = ({ account, currency, setToAccount, targetAccounts }: SectionTargetProps) => {
+const SectionTarget = ({
+  account,
+  currency,
+  setToAccount,
+  targetAccounts,
+  hasRates,
+}: SectionTargetProps) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const { setDrawer } = React.useContext(context);
@@ -84,7 +93,7 @@ const SectionTarget = ({ account, currency, setToAccount, targetAccounts }: Sect
     });
   const handleEditAccount = hideEdit ? null : showDrawer;
 
-  if (!currency) return <PlaceholderSection />;
+  if (!currency || !hasRates) return <PlaceholderSection />;
   if (!account)
     return (
       <SectionInformative

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SummaryValue.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SummaryValue.js
@@ -32,6 +32,12 @@ const Button: ThemedComponent<{}> = styled(ButtonBase).attrs(() => ({
   height: unset;
 `;
 
+export const NoValuePlaceholder = () => (
+  <TextBase color="palette.text.shade40" mr={3} fontSize={4} fontWeight={600}>
+    {"-"}
+  </TextBase>
+);
+
 const SummaryValue = ({
   value,
   handleChange,

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React from "react";
+import React, { useEffect, useState } from "react";
 import SectionProvider from "./SectionProvider";
 import SectionRate from "./SectionRate";
 import SectionFees from "./SectionFees";
@@ -9,10 +9,19 @@ import styled from "styled-components";
 import type { SwapTransactionType } from "~/renderer/screens/exchange/Swap2/utils/shared/useSwapTransaction";
 import type { SectionProviderProps } from "./SectionProvider";
 
-const Form: ThemedComponent<{}> = styled.section`
+const Form: ThemedComponent<{}> = styled.section.attrs(({ ready }) => ({
+  style: ready ? { opacity: 1, maxHeight: "100vh", overflow: "auto" } : {},
+}))`
   display: grid;
   row-gap: 1.375rem;
   color: white;
+  transition: max-height 800ms cubic-bezier(0.47, 0, 0.75, 0.72),
+    opacity 400ms 400ms cubic-bezier(0.47, 0, 0.75, 0.72);
+  transform-origin: top;
+  height: auto;
+  opacity: 0;
+  max-height: 0;
+  overflow: hidden;
 `;
 
 type SwapFormSummaryProps = {
@@ -36,9 +45,15 @@ const SwapFormSummary = ({ swapTransaction, kycStatus, provider }: SwapFormSumma
   } = swapTransaction.swap.from;
   const { currency: toCurrency, account: toAccount } = swapTransaction.swap.to;
   const ratesState = swapTransaction.swap.rates;
+  const hasRates = ratesState?.value.length > 0;
   const refetchRates = swapTransaction.swap.refetchRates;
+
+  const [hasFetchedRates, setHasFetchedRates] = useState(hasRates);
+
+  useEffect(() => setHasFetchedRates(v => (!v ? hasRates : v)), [hasRates]);
+
   return (
-    <Form>
+    <Form ready={hasFetchedRates}>
       <SectionProvider provider={provider} status={kycStatus} />
       <SectionRate
         fromCurrency={fromCurrency}
@@ -56,12 +71,14 @@ const SwapFormSummary = ({ swapTransaction, kycStatus, provider }: SwapFormSumma
         updateTransaction={updateTransaction}
         setTransaction={setTransaction}
         provider={provider}
+        hasRates={hasRates}
       />
       <SectionTarget
         account={toAccount}
         currency={toCurrency}
         setToAccount={setToAccount}
         targetAccounts={targetAccounts}
+        hasRates={hasRates}
       />
     </Form>
   );


### PR DESCRIPTION
## 🦒 Context (issues, jira)
[LL-7239]

updated form with rates summary section animated


## 💻  Description / Demo (image or video)

<details>
  <summary>Video :movie_camera:  </summary>

 

https://user-images.githubusercontent.com/11752937/134166107-c823a0e5-2798-428e-b936-0ec027c5df5c.mp4


 </details>

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-7239]: https://ledgerhq.atlassian.net/browse/LL-7239