### PR TITLE
LL-7275 Make full account row clickable (again)

### DIFF
--- a/src/renderer/screens/accounts/AccountRowItem/index.js
+++ b/src/renderer/screens/accounts/AccountRowItem/index.js
@@ -42,7 +42,6 @@ const Row: ThemedComponent<{}> = styled(Box)`
   font-weight: 600;
   justify-content: flex-start;
   margin-bottom: 9px;
-  padding: 16px 20px;
   position: relative;
   transition: background-color ease-in-out 200ms;
   :hover {
@@ -63,7 +62,7 @@ const RowContent: ThemedComponent<{
   flex-direction: row;
   flex-grow: 1;
   opacity: ${p => (p.disabled ? 0.3 : 1)};
-  padding-bottom: ${p => (p.isSubAccountsExpanded ? "20px" : "0")};
+  padding: 16px 20px;
   & * {
     color: ${p => (p.disabled ? p.theme.colors.palette.text.shade100 : "auto")};
     fill: ${p => (p.disabled ? p.theme.colors.palette.text.shade100 : "auto")};
@@ -72,6 +71,7 @@ const RowContent: ThemedComponent<{
 
 const TokenContent = styled.div`
   display: flex;
+  padding: 4px 20px 15px;
   flex-direction: column;
   flex-grow: 1;
 `;
@@ -84,18 +84,18 @@ const TokenBarIndicator: ThemedComponent<{}> = styled.div`
   width: 15px;
   border-left: 1px solid ${p => p.theme.colors.palette.divider};
   z-index: 2;
-  margin-left: 9px;
+  margin-left: 29px;
   position: absolute;
   left: 0;
-  margin-top: -20px;
-  height: calc(100% + 20px);
+  margin-top: -16px;
+  height: 100%;
   &:hover {
     border-color: ${p => p.theme.colors.palette.text.shade60};
   }
 `;
 
 const TokenShowMoreIndicator: ThemedComponent<{ expanded?: boolean }> = styled(Button)`
-  margin: 15px -20px -16px;
+  margin: ${p => (p.expanded ? 0 : -1)}px 0 0;
   display: flex;
   color: ${p => p.theme.colors.wallet};
   align-items: center;


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-7275


## 💻  Description / Demo (image or video)
Clicking in the padding area of the account row did not trigger the click callback. I had to do some style juggling and hopefully kept it pixel perfect so ci doesn't complain but realistically it will complain and I'll have to update the screenshots


https://user-images.githubusercontent.com/4631227/134546261-7001733c-4232-4aef-b47b-fe8aae720279.mov


## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
