### PR TITLE
LL-7328 - SWAP - Automatically close fees drawer on choice

### DIFF
--- a/src/renderer/drawers/Provider.js
+++ b/src/renderer/drawers/Provider.js
@@ -27,11 +27,13 @@ const initialState: State = {
 type ContextValue = {
   state: State,
   setDrawer: (Component?: React$ComponentType<*>, props?: *) => void,
+  closeDrawer: () => void,
 };
 
 export const context = React.createContext<ContextValue>({
   state: initialState,
   setDrawer: () => {},
+  closeDrawer: () => {},
 });
 
 const DrawerProvider = ({ children }: { children: React$Node }) => {
@@ -40,12 +42,20 @@ const DrawerProvider = ({ children }: { children: React$Node }) => {
     (Component, props) => dispatch({ Component, props, open: !!Component }),
     [],
   );
+  const _closeDrawer = useCallback(
+    () => dispatch({ Component: undefined, props: {}, open: false }),
+    [],
+  );
 
   useEffect(() => {
     setDrawer = _setDrawer;
   }, [_setDrawer]);
 
-  return <context.Provider value={{ state, setDrawer: _setDrawer }}>{children}</context.Provider>;
+  return (
+    <context.Provider value={{ state, setDrawer: _setDrawer, closeDrawer: _closeDrawer }}>
+      {children}
+    </context.Provider>
+  );
 };
 
 export default DrawerProvider;

--- a/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.js
@@ -21,6 +21,7 @@ type Props = {
   status: $PropertyType<SwapTransactionType, "status">,
   disableSlowStrategy?: boolean,
   provider: ?string,
+  closeDrawer: () => void,
 };
 export default function FeesDrawer({
   setTransaction,
@@ -31,6 +32,7 @@ export default function FeesDrawer({
   status,
   provider,
   disableSlowStrategy = false,
+  closeDrawer,
 }: Props) {
   const transaction = useSelector(transactionSelector);
 
@@ -39,6 +41,11 @@ export default function FeesDrawer({
       strategy.label === "slow" && disableSlowStrategy ? { ...strategy, disabled: true } : strategy,
     [disableSlowStrategy],
   );
+
+  const handleTransactionUpdate = (newTransaction: typeof transaction): void => {
+    updateTransaction(newTransaction);
+    closeDrawer();
+  };
 
   return (
     <Box height="100%">
@@ -58,7 +65,7 @@ export default function FeesDrawer({
             status={status}
             transaction={transaction}
             onChange={setTransaction}
-            updateTransaction={updateTransaction}
+            updateTransaction={handleTransactionUpdate}
             mapStrategies={mapStrategies}
           />
         )}

--- a/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FeesDrawer/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import { useSelector } from "react-redux";
 import Box from "~/renderer/components/Box";
 import SendAmountFields from "~/renderer/modals/Send/SendAmountFields";
@@ -34,18 +34,24 @@ export default function FeesDrawer({
   disableSlowStrategy = false,
   closeDrawer,
 }: Props) {
+  const isFirstRender = useRef(true);
   const transaction = useSelector(transactionSelector);
-
   const mapStrategies = useCallback(
     strategy =>
       strategy.label === "slow" && disableSlowStrategy ? { ...strategy, disabled: true } : strategy,
     [disableSlowStrategy],
   );
 
-  const handleTransactionUpdate = (newTransaction: typeof transaction): void => {
-    updateTransaction(newTransaction);
-    closeDrawer();
-  };
+  useEffect(() => {
+    // do nothing on first render
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    // close the drawer when the new selected strategy isn't "advanced"
+    if (transaction.feesStrategy && transaction.feesStrategy !== "advanced") closeDrawer();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [transaction]);
 
   return (
     <Box height="100%">
@@ -65,7 +71,7 @@ export default function FeesDrawer({
             status={status}
             transaction={transaction}
             onChange={setTransaction}
-            updateTransaction={handleTransactionUpdate}
+            updateTransaction={updateTransaction}
             mapStrategies={mapStrategies}
           />
         )}

--- a/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
+++ b/src/renderer/screens/exchange/Swap2/Form/FormSummary/SectionFees.js
@@ -70,7 +70,7 @@ const SectionFees = ({
   hasRates,
 }: Props) => {
   const { t } = useTranslation();
-  const { setDrawer } = React.useContext(context);
+  const { setDrawer, closeDrawer } = React.useContext(context);
   const exchangeRate = useSelector(rateSelector);
   const fromAccountUnit = account && getAccountUnit(account);
   const mainFromAccount = account && getMainAccount(account, parentAccount);
@@ -116,10 +116,12 @@ const SectionFees = ({
           status,
           disableSlowStrategy: exchangeRate?.tradeMethod === "fixed",
           provider,
+          closeDrawer,
         })),
     [
       canEdit,
       setDrawer,
+      closeDrawer,
       setTransaction,
       updateTransaction,
       account,


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LL-7328]


## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->


https://user-images.githubusercontent.com/33158502/134682006-7d26abae-0d3c-406f-b755-20101f7de4b1.mov


## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-7328]: https://ledgerhq.atlassian.net/browse/LL-7328