### PR TITLE
LL-3408 Highlight only the clicked subaccount

### DIFF
--- a/src/renderer/components/Stars/Star.js
+++ b/src/renderer/components/Stars/Star.js
@@ -38,7 +38,7 @@ export default function Star({ accountId, parentId, yellow }: Props) {
 
   return (
     <MaybeButtonWrapper filled={isAccountStarred}>
-      <StarWrapper id="account-star-button" onClick={toggleStar}>
+      <StarWrapper id="account-star-button" onClick={toggleStar} tabIndex="-1">
         {disableAnimation ? (
           <StarIcon
             yellow={yellow}

--- a/src/renderer/components/TokenRow.js
+++ b/src/renderer/components/TokenRow.js
@@ -33,8 +33,13 @@ const NestedRow: ThemedComponent<{}> = styled(Box)`
   flex-direction: row;
   cursor: pointer;
   position: relative;
+  margin: 0 -20px;
+  padding: 0 20px;
   &:last-of-type {
     margin-bottom: 0px;
+  }
+  :active {
+    background: ${p => p.theme.colors.palette.action.hover};
   }
 `;
 
@@ -50,7 +55,7 @@ class TokenRow extends PureComponent<Props> {
     const unit = currency.units[0];
     const Row = nested ? NestedRow : TableRow;
     return (
-      <Row className="token-row" index={index} onClick={this.onClick}>
+      <Row className="token-row" index={index} onClick={this.onClick} tabIndex="-1">
         <Header nested={nested} account={account} />
         <Balance unit={unit} balance={account.balance} disableRounding={disableRounding} />
         <Countervalue account={account} currency={currency} range={range} />

--- a/src/renderer/screens/accounts/AccountRowItem/index.js
+++ b/src/renderer/screens/accounts/AccountRowItem/index.js
@@ -48,7 +48,7 @@ const Row: ThemedComponent<{}> = styled(Box)`
   :hover {
     border-color: ${p => p.theme.colors.palette.text.shade20};
   }
-  :active {
+  :active:not(:focus-within) {
     border-color: ${p => p.theme.colors.palette.text.shade20};
     background: ${p => p.theme.colors.palette.action.hover};
   }


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-3408


## 💻  Description / Demo (image or video)
On the current release build and all versions before it, when clicking on a sub account row we also highlight the parent account container instead of only the clicked sub account. This is confusing UI because it seems we are clicking on the parent rather than the child. With a little bit of pseudo-selector trickery and some css we can solve this issue.

https://user-images.githubusercontent.com/4631227/134913999-b2210c7d-2c4e-423d-9950-c63f61a340f3.mov

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [x] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
