### PR TITLE
LL-3480 Add warning when resetting app + deleting account about swap

### DIFF
--- a/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.js
+++ b/src/renderer/modals/SettingsAccount/AccountSettingRenderBody.js
@@ -216,7 +216,14 @@ class AccountSettingRenderBody extends PureComponent<Props, State> {
               onConfirm={() => this.handleRemoveAccount(account)}
               title={t("settings.removeAccountModal.title")}
               subTitle={t("common.areYouSure")}
-              desc={t("settings.removeAccountModal.desc")}
+              desc={
+                <Box>
+                  {t("settings.removeAccountModal.desc")}
+                  <Alert type="warning" mt={4}>
+                    {t("settings.removeAccountModal.warning")}
+                  </Alert>
+                </Box>
+              }
             />
             <Space of={20} />
           </>

--- a/src/renderer/screens/settings/sections/Help/ResetButton.js
+++ b/src/renderer/screens/settings/sections/Help/ResetButton.js
@@ -10,6 +10,7 @@ import ResetFallbackModal from "~/renderer/modals/ResetFallbackModal";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/lib/bridge/react";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
+import Alert from "~/renderer/components/Alert";
 import IconTriangleWarning from "~/renderer/icons/TriangleWarning";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import { useActionModal } from "./logic";
@@ -51,7 +52,14 @@ export default function ResetButton() {
         onConfirm={onConfirm}
         confirmText={t("common.reset")}
         title={t("settings.hardResetModal.title")}
-        desc={t("settings.hardResetModal.desc")}
+        desc={
+          <Box>
+            {t("settings.hardResetModal.desc")}
+            <Alert type="warning" mt={4}>
+              {t("settings.hardResetModal.warning")}
+            </Alert>
+          </Box>
+        }
         renderIcon={() => (
           // FIXME why not pass in directly the DOM 🤷🏻
           <IconWrapperCircle color="alertRed">

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -2516,7 +2516,8 @@
     },
     "hardResetModal": {
       "title": "Reset Ledger Live",
-      "desc": "Reset Ledger Live to erase all settings and accounts on your computer. You can then choose your password and add your accounts back with your Ledger device. The private keys giving access to your crypto assets remain secure on your Ledger device and are backed up by your recovery phrase."
+      "desc": "Reset Ledger Live to erase all settings and accounts on your computer. You can then choose your password and add your accounts back with your Ledger device. The private keys giving access to your crypto assets remain secure on your Ledger device and are backed up by your recovery phrase.",
+      "warning": "Reseting Ledger Live will delete your swap transaction history for all your accounts."
     },
     "softResetModal": {
       "title": "Clear cache",
@@ -2532,7 +2533,8 @@
     },
     "removeAccountModal": {
       "title": "Remove account",
-      "desc": "This will not affect your crypto assets. Existing accounts can always be added again."
+      "desc": "This will not affect your crypto assets. Existing accounts can always be added again.",
+      "warning": "Deleting this account will delete your swap transaction history for this account as well."
     },
     "openUserDataDirectory": {
       "title": "View user data",

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -2517,7 +2517,7 @@
     "hardResetModal": {
       "title": "Reset Ledger Live",
       "desc": "Reset Ledger Live to erase all settings and accounts on your computer. You can then choose your password and add your accounts back with your Ledger device. The private keys giving access to your crypto assets remain secure on your Ledger device and are backed up by your recovery phrase.",
-      "warning": "Reseting Ledger Live will delete your swap transaction history for all your accounts."
+      "warning": "Reseting Ledger Live will erase your swap transaction history for all your accounts."
     },
     "softResetModal": {
       "title": "Clear cache",
@@ -2534,7 +2534,7 @@
     "removeAccountModal": {
       "title": "Remove account",
       "desc": "This will not affect your crypto assets. Existing accounts can always be added again.",
-      "warning": "Deleting this account will delete your swap transaction history for this account as well."
+      "warning": "Deleting this account will erase your swap transaction history associated to it."
     },
     "openUserDataDirectory": {
       "title": "View user data",

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -2517,7 +2517,7 @@
     "hardResetModal": {
       "title": "Reset Ledger Live",
       "desc": "Reset Ledger Live to erase all settings and accounts on your computer. You can then choose your password and add your accounts back with your Ledger device. The private keys giving access to your crypto assets remain secure on your Ledger device and are backed up by your recovery phrase.",
-      "warning": "Reseting Ledger Live will erase your swap transaction history for all your accounts."
+      "warning": "Resetting Ledger Live will erase your swap transaction history for all your accounts."
     },
     "softResetModal": {
       "title": "Clear cache",


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-3480


## 💻  Description / Demo (image or video)

<img width="1398" alt="Screenshot 2021-09-27 at 16 09 58" src="https://user-images.githubusercontent.com/4631227/134925184-b5af3b7e-5f74-474c-920d-b18de047d612.png">
<img width="1398" alt="Screenshot 2021-09-27 at 16 09 50" src="https://user-images.githubusercontent.com/4631227/134925238-0bab3335-1cdb-44cc-a7d4-aa0bee52e768.png">

~~Can't be merged until we have a URL or confirmation that we can ship without a learn more link. Also need confirmation on whether the wording should refer to swap as swap or exchange, since there was a shift in that wording globally and this could potentially be confusing depending on when it's merged. Hence the draft~~

Introduces two UI changes that warn the user about losing their swap history when deleting an account or resetting the Live.


<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [x] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
