### PR TITLE
LL-7450 Fix regression in asset distribution bars

### DIFF
--- a/src/renderer/components/AssetDistribution/Row.js
+++ b/src/renderer/components/AssetDistribution/Row.js
@@ -101,7 +101,8 @@ const Row = ({ item: { currency, amount, distribution }, isVisible }: Props) => 
   const history = useHistory();
   const language = useSelector(languageSelector);
   const color = useCurrencyColor(currency, theme.colors.palette.background.paper);
-  const percentage = (Math.floor(distribution * 10000) / 100).toLocaleString(language, {
+  const percentage = Math.floor(distribution * 10000) / 100;
+  const percentageWording = percentage.toLocaleString(language, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
   });
@@ -132,10 +133,10 @@ const Row = ({ item: { currency, amount, distribution }, isVisible }: Props) => 
         {!!distribution && (
           <>
             <Text ff="Inter" color="palette.text.shade100" fontSize={3}>
-              {`${percentage}%`}
+              {`${percentageWording}%`}
             </Text>
             <Bar
-              progress={!process.env.SPECTRON_RUN && isVisible ? percentage : "0"}
+              progress={!process.env.SPECTRON_RUN && isVisible ? percentage.toString() : "0"}
               progressColor={color}
             />
           </>

--- a/src/renderer/components/AssetDistribution/index.js
+++ b/src/renderer/components/AssetDistribution/index.js
@@ -48,10 +48,6 @@ export default function AssetDistribution() {
   const almostAll = initialRowCount + 3 > totalRowCount;
   const subList = showAll || almostAll ? list : list.slice(0, initialRowCount);
 
-  useEffect(() => {
-    console.log("wadus", { list });
-  }, [list]);
-
   return distribution.list.length ? (
     <TableContainer>
       <TableHeader

--- a/src/renderer/components/AssetDistribution/index.js
+++ b/src/renderer/components/AssetDistribution/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useEffect, useState, useRef, useLayoutEffect } from "react";
+import React, { useState, useRef, useLayoutEffect } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import Text from "~/renderer/components/Text";

--- a/src/renderer/components/AssetDistribution/index.js
+++ b/src/renderer/components/AssetDistribution/index.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useState, useRef, useLayoutEffect } from "react";
+import React, { useEffect, useState, useRef, useLayoutEffect } from "react";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import Text from "~/renderer/components/Text";
@@ -47,6 +47,10 @@ export default function AssetDistribution() {
 
   const almostAll = initialRowCount + 3 > totalRowCount;
   const subList = showAll || almostAll ? list : list.slice(0, initialRowCount);
+
+  useEffect(() => {
+    console.log("wadus", { list });
+  }, [list]);
 
   return distribution.list.length ? (
     <TableContainer>


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-7450


## 💻  Description / Demo (image or video)
While fixing https://ledgerhq.atlassian.net/browse/LL-6579 we (I) introduced a regression in the percentage bars for distributions. By localizing the value we turned floating numbers into strings, and broke the css that determined how much _bar_ to draw colored in languages that don't use a period for the decimal point (like French). This fixes that.

It was not detected by Spectron testing since we disable the bars due to pixel discrepancies, perhaps we should try something else instead of just disabling them.


<img width="1398" alt="Screenshot 2021-09-27 at 15 47 58" src="https://user-images.githubusercontent.com/4631227/134922239-9240c7c9-f8ed-4360-9e0d-8da4699c356c.png">

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [x] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
