### PR TITLE
LL-7460 use s3 as main hosting and remove github for nightly

### DIFF
--- a/electron-builder-nightly.yml
+++ b/electron-builder-nightly.yml
@@ -59,7 +59,6 @@ files:
   # Exclude modules
 
 publish:
-  - provider: github
   - provider: s3
     bucket: ledger-live-download-sandbox
     region: eu-west-1


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LL-7460]

## 💻  Description / Demo (image or video)

Now that we can push the build to S3, switch to it as default for nightly build so we can start testing auto updates

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-7460]: https://ledgerhq.atlassian.net/browse/LL-7460