### PR TITLE
Fix cold launch deep link for bridge

### DIFF
--- a/src/renderer/init.js
+++ b/src/renderer/init.js
@@ -88,13 +88,17 @@ async function init() {
 
   sentry(() => sentryLogsSelector(store.getState()));
 
+  let deepLinkUrl; // Nb In some cases `fetchSettings` runs after this, voiding the deep link.
   ipcRenderer.once("deep-linking", (event, url) => {
     store.dispatch(setDeepLinkUrl(url));
+    deepLinkUrl = url;
   });
 
   const initialSettings = await getKey("app", "settings", {});
 
-  store.dispatch(fetchSettings(initialSettings));
+  store.dispatch(
+    fetchSettings(deepLinkUrl ? { ...initialSettings, deepLinkUrl } : initialSettings),
+  );
 
   const state = store.getState();
   const language = languageSelector(state);


### PR DESCRIPTION
## 🦒 Context (issues, jira)

{ MISSING  JIRA TASK }
https://ledger.slack.com/archives/C01REQQBJS3/p1632429876223500


## 💻  Description / Demo (image or video)
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/4631227/135684369-64d73300-4bfe-45c2-ba33-999d28f7b493.png">



In some cases, the loaded settings from disk override the dispatched `deepLinkurl` from launch. This is a proposal for a fix but we could probably find a cleaner one. In fact I guess we can remove the `.once` call in favor of just this variable approach but what if the order of calls is flipped? Better to be safe than sorry.

Here's a totally unnecessary excalidraw sketch of what is happening, in case my super verbose description on slack isn't clear enough, long story short we rely on a setting from the store to handle the deep linking urls and, although we detect the url correctly, we handle the dispatch before we load the initial settings from file, meaning this url is immediately overridden by null and hence doesn't trigger the necessary action.

### This should fix all deeplinking actions from cold launch, not just the bridge.

<img width="882" alt="image" src="https://user-images.githubusercontent.com/4631227/135732084-243569d3-b09b-422f-9ba1-591de3201c7c.png">


<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

### How to test
- Assign this app to open the `ledgerlive://` urls, you might need to uninstall the production build for this.
- With a closed app trigger the bridge from meta mask.
- It should open the LLD app with the bridge modal open like above.
