### PR TITLE
LL-7196 Buy - analytics

### DIFF
--- a/src/renderer/screens/exchange/CoinifyWidget.js
+++ b/src/renderer/screens/exchange/CoinifyWidget.js
@@ -126,7 +126,23 @@ const CoinifyWidget = ({ account, parentAccount, mode, onReset }: Props) => {
           coinifyConfig.host,
         );
         if (currency) {
-          track("Coinify Confirm Buy End", { currencyName: currency.name });
+          const receiveBuyMessage = event => {
+            if (
+              event.origin === "https://trade-ui.coinify.com" ||
+              event.origin === "https://trade-ui.sandbox.coinify.com"
+            ) {
+              const widgetMessage = event.data;
+
+              if (widgetMessage.event === "trade.trade-created") {
+                track("Coinify Confirm Buy End", {
+                  currencyName: currency.name,
+                  medium: widgetMessage?.context?.transferIn?.medium,
+                });
+                window.removeEventListener("message", receiveBuyMessage, false);
+              }
+            }
+          };
+          window.addEventListener("message", receiveBuyMessage, false);
         }
       }
       if (tradeId.current && mode === "sell") {


### PR DESCRIPTION
- LL-7196 (BUY): analytics - listen to coinify events to track medium used during buy


## 🦒 Context (issues, jira)

[LL-7196]

## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->
Listen to coinify widget events after a trade is created to catch the medium data and track alongside our analytics.

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
