### PR TITLE
LL-7608 - SWAP - Prevent sidedrawer backdrop click

### DIFF
--- a/src/renderer/components/SideDrawer.js
+++ b/src/renderer/components/SideDrawer.js
@@ -109,7 +109,7 @@ const DrawerContainer = styled.div.attrs(({ state }) => ({
   z-index: 50;
 `;
 
-type DrawerProps = {
+export type DrawerProps = {
   children?: React$Node,
   isOpen?: boolean,
   onRequestClose?: (*) => void,
@@ -117,6 +117,7 @@ type DrawerProps = {
   direction?: "right" | "left",
   paper?: boolean,
   title?: string,
+  preventBackdropClick?: boolean,
 };
 
 export function SideDrawer({
@@ -126,18 +127,19 @@ export function SideDrawer({
   onRequestBack,
   direction = "right",
   title,
+  preventBackdropClick = false,
   ...props
 }: DrawerProps) {
   const [isMounted, setMounted] = useState(false);
 
   const onKeyPress = useCallback(
     e => {
-      if (isOpen && e.key === "Escape" && onRequestClose) {
+      if (isOpen && !preventBackdropClick && e.key === "Escape" && onRequestClose) {
         e.preventDefault();
         onRequestClose(e);
       }
     },
-    [onRequestClose, isOpen],
+    [onRequestClose, isOpen, preventBackdropClick],
   );
 
   useEffect(() => {
@@ -241,7 +243,10 @@ export function SideDrawer({
             ) : null}
             {children}
           </DrawerContent>
-          <DrawerBackdrop state={state} onClick={onRequestClose || undefined} />
+          <DrawerBackdrop
+            state={state}
+            onClick={preventBackdropClick ? undefined : onRequestClose}
+          />
         </DrawerContainer>
       )}
     </Transition>

--- a/src/renderer/drawers/Drawer.js
+++ b/src/renderer/drawers/Drawer.js
@@ -66,6 +66,7 @@ export const Drawer = () => {
       onRequestClose={onRequestClose}
       onRequestBack={state?.props?.onRequestBack}
       direction="left"
+      {...state.options}
     >
       <>
         <TransitionGroup>

--- a/src/renderer/drawers/Provider.js
+++ b/src/renderer/drawers/Provider.js
@@ -1,15 +1,21 @@
 /* @flow */
 import React, { useReducer, useEffect, useCallback } from "react";
 
+import type { DrawerProps as SideDrawerProps } from "~/renderer/components/SideDrawer";
 type State = {
   Component: ?React$ComponentType<*>,
-  props?: *,
+  props?: null | *,
   open: boolean,
+  options: $Diff<SideDrawerProps, { children: *, isOpen: *, onRequestBack: *, onRequestClose: * }>,
 };
 
 // actions
 // it makes them available and current from connector events handlers
-export let setDrawer: (Component?: *, props?: *) => void = () => {};
+export let setDrawer: (
+  Component?: $PropertyType<State, "Component">,
+  props?: $PropertyType<State, "props">,
+  options?: $PropertyType<State, "options">,
+) => void = () => {};
 
 // reducer
 const reducer = (state: State, update) => {
@@ -18,16 +24,9 @@ const reducer = (state: State, update) => {
     ...update,
   };
 };
-const initialState: State = {
-  Component: null,
-  props: null,
-  open: false,
-};
+const initialState: State = { Component: null, props: null, open: false, options: {} };
 
-type ContextValue = {
-  state: State,
-  setDrawer: (Component?: React$ComponentType<*>, props?: *) => void,
-};
+type ContextValue = { state: State, setDrawer: typeof setDrawer };
 
 export const context = React.createContext<ContextValue>({
   state: initialState,
@@ -36,8 +35,8 @@ export const context = React.createContext<ContextValue>({
 
 const DrawerProvider = ({ children }: { children: React$Node }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const _setDrawer = useCallback(
-    (Component, props) => dispatch({ Component, props, open: !!Component }),
+  const _setDrawer: typeof setDrawer = useCallback(
+    (Component, props, options = {}) => dispatch({ Component, props, open: !!Component, options }),
     [],
   );
 

--- a/src/renderer/screens/exchange/Swap2/Form/index.js
+++ b/src/renderer/screens/exchange/Swap2/Form/index.js
@@ -155,10 +155,7 @@ const SwapForm = () => {
       provider,
       swapVersion: SWAP_VERSION,
     });
-    setDrawer(ExchangeDrawer, {
-      swapTransaction,
-      exchangeRate,
-    });
+    setDrawer(ExchangeDrawer, { swapTransaction, exchangeRate }, { preventBackdropClick: true });
   };
 
   const sourceAccount = swapTransaction.swap.from.account;


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LL-7608]

Added a new parameter to the setDrawer function to allow passing some options to the side drawer component.
Added new props called `preventBackdropClick` to the side drawer component to prevent backdrop click and "esc" keypress. When passing this prop, the only way to exit a drawer is to click on the cross button.

## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-7608]: https://ledgerhq.atlassian.net/browse/LL-7608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ