### PR TITLE
LL-7073 change CTAs on the account page to always include SEND/RECEIVE

### DIFF
--- a/src/renderer/components/Stars/Star.js
+++ b/src/renderer/components/Stars/Star.js
@@ -18,9 +18,10 @@ type Props = {
   accountId: string,
   parentId?: string,
   yellow?: boolean,
+  rounded?: boolean,
 };
 
-export default function Star({ accountId, parentId, yellow }: Props) {
+export default function Star({ accountId, parentId, yellow, rounded }: Props) {
   const isAccountStarred = useSelector(state => isStarredAccountSelector(state, { accountId }));
   const dispatch = useDispatch();
   const refreshAccountsOrdering = useRefreshAccountsOrdering();
@@ -37,8 +38,8 @@ export default function Star({ accountId, parentId, yellow }: Props) {
   const MaybeButtonWrapper = yellow ? ButtonWrapper : FloatingWrapper;
 
   return (
-    <MaybeButtonWrapper filled={isAccountStarred}>
-      <StarWrapper id="account-star-button" onClick={toggleStar} tabIndex="-1">
+    <MaybeButtonWrapper filled={isAccountStarred} rounded={rounded}>
+      <StarWrapper id="account-star-button" onClick={toggleStar} tabIndex="-1" rounded={rounded}>
         {disableAnimation ? (
           <StarIcon
             yellow={yellow}
@@ -66,13 +67,13 @@ const starBust = keyframes`
   }
 `;
 
-const ButtonWrapper: ThemedComponent<{ filled?: boolean }> = styled.div`
-  height: 34px;
-  width: 34px;
+const ButtonWrapper: ThemedComponent<{ filled?: boolean, rounded?: boolean }> = styled.div`
+  height: ${p => (p.rounded ? 40 : 34)}px};
+  width: ${p => (p.rounded ? 40 : 34)}px};
   border: 1px solid
     ${p => (p.filled ? p.theme.colors.starYellow : p.theme.colors.palette.text.shade60)};
-  border-radius: 4px;
-  padding: 8px;
+  border-radius: ${p => (p.rounded ? 20 : 4)}px;
+  padding: ${p => (p.rounded ? 14 : 8)}px;
   text-align: center;
   background: ${p => (p.filled ? p.theme.colors.starYellow : "transparent")};
   &:hover {
@@ -85,8 +86,8 @@ const ButtonWrapper: ThemedComponent<{ filled?: boolean }> = styled.div`
 const FloatingWrapper: ThemedComponent<{}> = styled.div``;
 
 // NB negative margin to allow the burst to overflow
-const StarWrapper: ThemedComponent<{}> = styled.div`
-  margin: -17px;
+const StarWrapper: ThemedComponent<{ rounded?: boolean }> = styled.div`
+  margin: -${p => (p.rounded ? 20 : 17)}px;
 `;
 
 const startBurstTiming = 800;

--- a/src/renderer/families/algorand/AccountHeaderActions.js
+++ b/src/renderer/families/algorand/AccountHeaderActions.js
@@ -1,56 +1,13 @@
 // @flow
-import React, { useCallback } from "react";
-import { useDispatch } from "react-redux";
-import styled from "styled-components";
-import { Trans } from "react-i18next";
 
-import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
-import type { Account, AccountLike } from "@ledgerhq/live-common/lib/types";
-import { getAccountUnit } from "@ledgerhq/live-common/lib/account/helpers";
-
-import { openModal } from "~/renderer/actions/modals";
-import Button from "~/renderer/components/Button";
-import Box from "~/renderer/components/Box/Box";
-import IconChartLine from "~/renderer/icons/ChartLine";
-
-const ButtonBase: ThemedComponent<*> = styled(Button)`
-  height: 34px;
-  padding-top: 0;
-  padding-bottom: 0;
-`;
-
-type Props = {
-  account: AccountLike,
-  parentAccount: ?Account,
-};
-
-const AccountHeaderActions = ({ account, parentAccount }: Props) => {
-  const dispatch = useDispatch();
-
-  const balance = account.balance;
-  const unit = getAccountUnit(account);
-  const minRewardsBalance = 10 ** unit.magnitude;
-
-  const onClick = useCallback(() => {
-    dispatch(
-      openModal("MODAL_ALGORAND_EARN_REWARDS_INFO", {
-        account,
-      }),
-    );
-  }, [dispatch, account]);
-
-  if (parentAccount || balance.gt(minRewardsBalance)) return null;
-
-  return (
-    <ButtonBase primary onClick={onClick}>
-      <Box horizontal flow={1} alignItems="center">
-        <IconChartLine size={12} />
-        <Box fontSize={3}>
-          <Trans i18nKey="delegation.title" />
-        </Box>
-      </Box>
-    </ButtonBase>
-  );
+const AccountHeaderActions = () => {
+  /**
+   * disabled because in AccountHeaderActions all the manage actions are now
+   *  out of the manage menu so this button would appear twice if it's not
+   *  disabled here
+   * # LL-7073
+   */
+  return null;
 };
 
 export default AccountHeaderActions;

--- a/src/renderer/families/cosmos/AccountHeaderActions.js
+++ b/src/renderer/families/cosmos/AccountHeaderActions.js
@@ -1,66 +1,13 @@
 // @flow
-import React, { useCallback } from "react";
-import invariant from "invariant";
-import { useDispatch } from "react-redux";
-import styled from "styled-components";
-import { Trans } from "react-i18next";
 
-import { getMainAccount } from "@ledgerhq/live-common/lib/account";
-import { canDelegate } from "@ledgerhq/live-common/lib/families/cosmos/logic";
-
-import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
-import type { Account, AccountLike } from "@ledgerhq/live-common/lib/types";
-
-import { openModal } from "~/renderer/actions/modals";
-import Button from "~/renderer/components/Button";
-import Box from "~/renderer/components/Box/Box";
-import IconChartLine from "~/renderer/icons/ChartLine";
-import ToolTip from "~/renderer/components/Tooltip";
-
-const ButtonBase: ThemedComponent<*> = styled(Button)`
-  height: 34px;
-  padding-top: 0;
-  padding-bottom: 0;
-`;
-
-type Props = {
-  account: AccountLike,
-  parentAccount: ?Account,
-};
-
-const AccountHeaderActions = ({ account, parentAccount }: Props) => {
-  const dispatch = useDispatch();
-  const mainAccount = getMainAccount(account, parentAccount);
-
-  const { cosmosResources } = mainAccount;
-  invariant(cosmosResources, "cosmos account expected");
-  const { delegations } = cosmosResources;
-  const earnRewardEnabled = canDelegate(mainAccount);
-
-  const onClick = useCallback(() => {
-    dispatch(
-      openModal("MODAL_COSMOS_REWARDS_INFO", {
-        account,
-      }),
-    );
-  }, [dispatch, account]);
-
-  if (parentAccount || delegations.length > 0) return null;
-
-  return (
-    <ToolTip
-      content={!earnRewardEnabled ? <Trans i18nKey="cosmos.delegation.minSafeWarning" /> : null}
-    >
-      <ButtonBase primary disabled={!earnRewardEnabled} onClick={onClick}>
-        <Box horizontal flow={1} alignItems="center">
-          <IconChartLine size={12} />
-          <Box fontSize={3}>
-            <Trans i18nKey="delegation.title" />
-          </Box>
-        </Box>
-      </ButtonBase>
-    </ToolTip>
-  );
+const AccountHeaderActions = () => {
+  /**
+   * disabled because in AccountHeaderActions all the manage actions are now
+   *  out of the manage menu so this button would appear twice if it's not
+   *  disabled here
+   * # LL-7073
+   */
+  return null;
 };
 
 export default AccountHeaderActions;

--- a/src/renderer/families/polkadot/AccountHeaderActions.js
+++ b/src/renderer/families/polkadot/AccountHeaderActions.js
@@ -1,109 +1,13 @@
 // @flow
-import React, { useCallback } from "react";
-import invariant from "invariant";
-import styled from "styled-components";
-import { useDispatch } from "react-redux";
-import { Trans } from "react-i18next";
 
-import { getAccountCurrency } from "@ledgerhq/live-common/lib/account";
-import type { Account } from "@ledgerhq/live-common/lib/types";
-import {
-  hasExternalController,
-  hasExternalStash,
-  hasPendingOperationType,
-} from "@ledgerhq/live-common/lib/families/polkadot/logic";
-
-import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
-import ToolTip from "~/renderer/components/Tooltip";
-import Button from "~/renderer/components/Button";
-import Box from "~/renderer/components/Box/Box";
-import IconChartLine from "~/renderer/icons/ChartLine";
-import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
-import { openModal } from "~/renderer/actions/modals";
-import useTheme from "~/renderer/hooks/useTheme";
-
-const ButtonBase: ThemedComponent<*> = styled(Button)`
-  height: 34px;
-  padding-top: 0;
-  padding-bottom: 0;
-`;
-
-type Props = {
-  account: Account,
-};
-
-const AccountHeaderActions = ({ account }: Props) => {
-  const contrastText = useTheme("colors.palette.primary.contrastText");
-  const dispatch = useDispatch();
-  const currency = getAccountCurrency(account);
-
-  const { polkadotResources } = account;
-  invariant(polkadotResources, "polkadot account expected");
-
-  const hasBondedBalance = polkadotResources.lockedBalance && polkadotResources.lockedBalance.gt(0);
-  const hasPendingBondOperation = hasPendingOperationType(account, "BOND");
-
-  const onClick = useCallback(() => {
-    if (hasBondedBalance || hasPendingBondOperation) {
-      dispatch(
-        openModal("MODAL_POLKADOT_MANAGE", {
-          account,
-        }),
-      );
-    } else {
-      dispatch(
-        openModal("MODAL_POLKADOT_REWARDS_INFO", {
-          account,
-        }),
-      );
-    }
-  }, [dispatch, account, hasBondedBalance, hasPendingBondOperation]);
-
-  const _hasExternalController = hasExternalController(account);
-  const _hasExternalStash = hasExternalStash(account);
-
-  const manageEnabled = !(
-    _hasExternalController ||
-    _hasExternalStash ||
-    (!hasBondedBalance && hasPendingBondOperation)
-  );
-
-  return (
-    <ToolTip
-      content={
-        !manageEnabled ? (
-          <Trans
-            i18nKey={
-              _hasExternalController
-                ? "polkadot.nomination.externalControllerTooltip"
-                : _hasExternalStash
-                ? "polkadot.nomination.externalStashTooltip"
-                : "polkadot.nomination.hasPendingBondOperation"
-            }
-          />
-        ) : null
-      }
-    >
-      <ButtonBase primary disabled={!manageEnabled} onClick={onClick}>
-        <Box horizontal flow={1} alignItems="center">
-          {hasBondedBalance ? (
-            <CryptoCurrencyIcon overrideColor={contrastText} currency={currency} size={12} />
-          ) : (
-            <IconChartLine size={12} />
-          )}
-          <Box fontSize={3}>
-            <Trans
-              i18nKey={
-                hasBondedBalance || hasPendingBondOperation
-                  ? "polkadot.manage.title"
-                  : "delegation.title"
-              }
-            />
-          </Box>
-        </Box>
-      </ButtonBase>
-    </ToolTip>
-  );
+const AccountHeaderActions = () => {
+  /**
+   * disabled because in AccountHeaderActions all the manage actions are now
+   *  out of the manage menu so this button would appear twice if it's not
+   *  disabled here
+   * # LL-7073
+   */
+  return null;
 };
 
 export default AccountHeaderActions;

--- a/src/renderer/families/tron/AccountHeaderActions.js
+++ b/src/renderer/families/tron/AccountHeaderActions.js
@@ -1,101 +1,13 @@
 // @flow
-import React, { useCallback } from "react";
-import invariant from "invariant";
-import styled from "styled-components";
-import { useDispatch, useSelector } from "react-redux";
-import { Trans } from "react-i18next";
-import { BigNumber } from "bignumber.js";
-import {
-  getAccountUnit,
-  getAccountCurrency,
-  getMainAccount,
-} from "@ledgerhq/live-common/lib/account";
-import { formatCurrencyUnit } from "@ledgerhq/live-common/lib/currencies";
-import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
-import type { Account, AccountLike } from "@ledgerhq/live-common/lib/types";
-import Button from "~/renderer/components/Button";
-import Box from "~/renderer/components/Box/Box";
-import IconChartLine from "~/renderer/icons/ChartLine";
-import CryptoCurrencyIcon from "~/renderer/components/CryptoCurrencyIcon";
-import { openModal } from "~/renderer/actions/modals";
-import ToolTip from "~/renderer/components/Tooltip";
-import useTheme from "~/renderer/hooks/useTheme";
-import { localeSelector } from "~/renderer/reducers/settings";
 
-const ButtonBase: ThemedComponent<*> = styled(Button)`
-  height: 34px;
-  padding-top: 0;
-  padding-bottom: 0;
-`;
-
-type Props = {
-  account: AccountLike,
-  parentAccount: ?Account,
-};
-
-const AccountHeaderActions = ({ account, parentAccount }: Props) => {
-  const contrastText = useTheme("colors.palette.primary.contrastText");
-  const dispatch = useDispatch();
-  const unit = getAccountUnit(account);
-  const currency = getAccountCurrency(account);
-  const mainAccount = getMainAccount(account, parentAccount);
-  const minAmount = 10 ** unit.magnitude;
-  const locale = useSelector(localeSelector);
-
-  const formattedMinAmount = formatCurrencyUnit(unit, BigNumber(minAmount), {
-    disableRounding: true,
-    alwaysShowSign: false,
-    showCode: true,
-    locale,
-  });
-
-  const { tronResources, spendableBalance } = mainAccount;
-  invariant(tronResources, "tron account expected");
-  const tronPower = tronResources.tronPower;
-  const earnRewardDisabled = tronPower === 0 && spendableBalance.lt(minAmount);
-
-  const onClick = useCallback(() => {
-    if (tronPower > 0) {
-      dispatch(
-        openModal("MODAL_MANAGE_TRON", {
-          parentAccount,
-          account,
-        }),
-      );
-    } else {
-      dispatch(
-        openModal("MODAL_TRON_REWARDS_INFO", {
-          parentAccount,
-          account,
-        }),
-      );
-    }
-  }, [dispatch, tronPower, account, parentAccount]);
-
-  if (parentAccount) return null;
-
-  return (
-    <ToolTip
-      content={
-        earnRewardDisabled ? (
-          <Trans i18nKey="tron.voting.warnEarnRewards" values={{ amount: formattedMinAmount }} />
-        ) : null
-      }
-    >
-      <ButtonBase primary disabled={earnRewardDisabled} onClick={onClick}>
-        <Box horizontal flow={1} alignItems="center">
-          {tronPower > 0 ? (
-            <CryptoCurrencyIcon overrideColor={contrastText} currency={currency} size={12} />
-          ) : (
-            <IconChartLine size={12} />
-          )}
-          <Box fontSize={3}>
-            <Trans i18nKey={tronPower > 0 ? "tron.voting.manageTP" : "delegation.title"} />
-          </Box>
-        </Box>
-      </ButtonBase>
-    </ToolTip>
-  );
+const AccountHeaderActions = () => {
+  /**
+   * disabled because in AccountHeaderActions all the manage actions are now
+   *  out of the manage menu so this button would appear twice if it's not
+   *  disabled here
+   * # LL-7073
+   */
+  return null;
 };
 
 export default AccountHeaderActions;

--- a/src/renderer/screens/account/AccountActionsDefault.js
+++ b/src/renderer/screens/account/AccountActionsDefault.js
@@ -7,22 +7,37 @@ import IconSwap from "~/renderer/icons/Swap";
 import IconExchange from "~/renderer/icons/Exchange";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
+import ToolTip from "~/renderer/components/Tooltip";
+import styled from "styled-components";
 
-const ActionDefault = ({
+const IconButton = styled(Button)`
+  height: 40px;
+  width: 40px;
+  border-radius: 20px;
+  justify-content: center;
+  padding: 0;
+`;
+
+export const ActionDefault = ({
   onClick,
   iconComponent,
   labelComponent,
+  event,
+  eventProperties,
 }: {
   onClick: () => void,
   iconComponent: any,
   labelComponent: any,
+  event: string,
+  eventProperties: Object,
 }) => (
-  <Button small primary onClick={onClick}>
-    <Box horizontal flow={1} alignItems="center">
-      {iconComponent}
-      <Box>{labelComponent}</Box>
-    </Box>
-  </Button>
+  <ToolTip content={labelComponent}>
+    <IconButton primary onClick={onClick}>
+      <Box horizontal alignItems="center">
+        {iconComponent}
+      </Box>
+    </IconButton>
+  </ToolTip>
 );
 
 export const SendActionDefault = ({ onClick }: { onClick: () => void }) => (

--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -107,7 +107,6 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
   const availableOnSwap =
     (providers || storedProviders) &&
     !!(providers || storedProviders).find(({ pairs }) => {
-      console.log({ pairs });
       return pairs && pairs.find(({ from, to }) => [from, to].includes(currency.id));
     });
 

--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -6,7 +6,6 @@ import { useSelector, connect } from "react-redux";
 import { withTranslation, Trans } from "react-i18next";
 import styled from "styled-components";
 import type { Account, AccountLike } from "@ledgerhq/live-common/lib/types";
-import { swapSelectableCurrenciesSelector } from "~/renderer/reducers/settings";
 import Tooltip from "~/renderer/components/Tooltip";
 import {
   isAccountEmpty,

--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -43,6 +43,8 @@ import IconAngleUp from "~/renderer/icons/AngleUp";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import useTheme from "~/renderer/hooks/useTheme";
 import useCompoundAccountEnabled from "~/renderer/screens/lend/useCompoundAccountEnabled";
+import { useSwapProviders } from "@ledgerhq/live-common/lib/exchange/swap/hooks";
+import { providersSelector } from "~/renderer/actions/swap";
 
 const ButtonSettings: ThemedComponent<{ disabled?: boolean }> = styled(Tabbable).attrs(() => ({
   alignItems: "center",
@@ -100,7 +102,16 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
   const availableOnCompound = useCompoundAccountEnabled(account, parentAccount);
 
   const availableOnBuy = isCurrencySupported("BUY", currency);
-  const availableOnSwap = useSelector(swapSelectableCurrenciesSelector).includes(currency.id);
+
+  const { providers } = useSwapProviders();
+  const storedProviders = useSelector(providersSelector);
+  const availableOnSwap =
+    (providers || storedProviders) &&
+    !!(providers || storedProviders).find(({ pairs }) => {
+      console.log({ pairs });
+      return pairs && pairs.find(({ from, to }) => [from, to].includes(currency.id));
+    });
+
   const history = useHistory();
 
   const onBuy = useCallback(() => {

--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -18,27 +18,23 @@ import type { TFunction } from "react-i18next";
 import { rgba } from "~/renderer/styles/helpers";
 import { openModal } from "~/renderer/actions/modals";
 import IconAccountSettings from "~/renderer/icons/AccountSettings";
-import perFamily from "~/renderer/generated/AccountHeaderActions";
-import perFamilyManageActions from "~/renderer/generated/AccountHeaderManageActions";
 import Box, { Tabbable } from "~/renderer/components/Box";
 import Star from "~/renderer/components/Stars/Star";
 import {
+  ActionDefault,
   BuyActionDefault,
   ReceiveActionDefault,
   SendActionDefault,
   SwapActionDefault,
 } from "./AccountActionsDefault";
 import perFamilyAccountActions from "~/renderer/generated/accountActions";
+import perFamily from "~/renderer/generated/AccountHeaderActions";
+import perFamilyManageActions from "~/renderer/generated/AccountHeaderManageActions";
 import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
 import { isCurrencySupported } from "~/renderer/screens/exchange/config";
 import { useHistory } from "react-router-dom";
 import IconWalletConnect from "~/renderer/icons/WalletConnect";
-import DropDownSelector from "~/renderer/components/DropDownSelector";
-import Button from "~/renderer/components/Button";
-import Text from "~/renderer/components/Text";
 import Graph from "~/renderer/icons/Graph";
-import IconAngleDown from "~/renderer/icons/AngleDown";
-import IconAngleUp from "~/renderer/icons/AngleUp";
 import { setTrackingSource } from "~/renderer/analytics/TrackPage";
 import useTheme from "~/renderer/hooks/useTheme";
 import useCompoundAccountEnabled from "~/renderer/screens/lend/useCompoundAccountEnabled";
@@ -49,10 +45,10 @@ const ButtonSettings: ThemedComponent<{ disabled?: boolean }> = styled(Tabbable)
   alignItems: "center",
   justifyContent: "center",
 }))`
-  width: 34px;
-  height: 34px;
+  width: 40px;
+  height: 40px;
   border: 1px solid ${p => p.theme.colors.palette.text.shade60};
-  border-radius: 4px;
+  border-radius: 20px;
   &:hover {
     color: ${p => (p.disabled ? "" : p.theme.colors.palette.text.shade100)};
     background: ${p => (p.disabled ? "" : rgba(p.theme.colors.palette.divider, 0.2))};
@@ -154,22 +150,18 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
     openModal("MODAL_RECEIVE", { parentAccount, account });
   }, [parentAccount, account, openModal]);
 
-  const renderItem = useCallback(
-    ({ item: { label, onClick, event, eventProperties, icon } }) => {
-      const Icon = icon;
-      return (
-        <Button onClick={onClick} event={event} eventProperties={eventProperties}>
-          <Box horizontal flow={1} alignItems="center">
-            {Icon && <Icon size={14} overrideColor={contrastText} currency={currency} />}
-            <Box>
-              <Text ff="Inter|SemiBold">{label}</Text>
-            </Box>
-          </Box>
-        </Button>
-      );
-    },
-    [currency, contrastText],
-  );
+  const renderAction = ({ label, onClick, event, eventProperties, icon }) => {
+    const Icon = icon;
+    return (
+      <ActionDefault
+        onClick={onClick}
+        event={event}
+        eventProperties={eventProperties}
+        iconComponent={Icon && <Icon size={14} overrideColor={contrastText} currency={currency} />}
+        labelComponent={label}
+      />
+    );
+  };
 
   const manageActions = [
     ...manageList,
@@ -202,27 +194,7 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
 
   const SwapHeader = () => <SwapActionDefault onClick={onSwap} />;
 
-  const ManageActionsHeader = () => (
-    <DropDownSelector
-      border
-      horizontal
-      items={manageActions}
-      renderItem={renderItem}
-      controlled
-      buttonId="account-actions-manage"
-    >
-      {({ isOpen }) => (
-        <Button small primary>
-          <Box horizontal flow={1} alignItems="center">
-            <Box>
-              <Trans i18nKey="common.manage" values={{ currency: currency.name }} />
-            </Box>
-            {isOpen ? <IconAngleUp size={16} /> : <IconAngleDown size={16} />}
-          </Box>
-        </Button>
-      )}
-    </DropDownSelector>
-  );
+  const ManageActionsHeader = () => manageActions.map(item => renderAction(item));
 
   const NonEmptyAccountHeader = () => (
     <>
@@ -245,6 +217,7 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
           accountId={account.id}
           parentId={account.type !== "Account" ? account.parentId : undefined}
           yellow
+          rounded
         />
       </Tooltip>
       {account.type === "Account" ? (


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LL-7073]

## 💻  Description / Demo (image or video)

[**Figma for reference**](https://www.figma.com/file/ud9Zpy1doMsgxtuxH8RxJo/LLD---Account?node-id=1871%3A61326)


- Send/Receive CTAs are now always displayed (when available) vs. previously if buy/swap was available the send/receive CTAs were only displayed in the dropdown.

- I also fixed the logic to decide whether "swap" CTA should be available as the existing logic depended on swap v1 so it wasn't working anymore.


- Change style of all buttons: rounded with no text, label shows in tooltip instead
- Remove dropdown, replaced it by normal buttons on the same row
- Remove buttons rendered by specific families' `AccountHeaderActions` or they would show up twice (as the content is the same as for the "manage" dropdown, cf. previous line)

![Combined](https://user-images.githubusercontent.com/91890529/144415200-035cbc5a-2234-4085-b891-890c540a8dcd.jpg)

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-7073]: https://ledgerhq.atlassian.net/browse/LL-7073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ