### PR TITLE
Fix unhandled click on context menu for accounts

### DIFF
--- a/src/renderer/components/ContextMenu/ContextMenuWrapper.js
+++ b/src/renderer/components/ContextMenu/ContextMenuWrapper.js
@@ -60,6 +60,9 @@ const ContextMenuItemContainer: ThemedComponent<{}> = styled(Box).attrs(() => ({
   font-size: 12px;
   font-weight: 500;
 
+  & > * {
+    pointer-events: none;
+  }
   &:hover {
     cursor: pointer;
     background: ${p => p.theme.colors.palette.background.default};


### PR DESCRIPTION
## 🦒 Context (issues, jira)


https://user-images.githubusercontent.com/4631227/138128550-825cba0a-f179-4334-9f4b-e650078d8b21.mov



## 💻  Description / Demo (image or video)

For an unknown amount of time, the context menu of accounts has been broken if we click on the icon or the text, sometimes it worked on the text 🤷🏼 but it always worked when clicking on the white area to the right. This pr fixes that by disabling the inner element click handlers.

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [x] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
