### PR TITLE
LL-7743 Add webpack config for v3 fonts from ui package

### DIFF
--- a/renderer.webpack.config.js
+++ b/renderer.webpack.config.js
@@ -103,10 +103,23 @@ module.exports = {
         test: /\.css$/i,
         use: ["style-loader", "css-loader"],
       },
-      {
-        test: /\.(woff|woff2|eot|ttf|otf)$/i,
-        use: ["file-loader"],
-      },
+      process.env.V3
+        ? {
+            test: /\.woff2/,
+            use: [
+              {
+                loader: "file-loader",
+                options: {
+                  name: "[name].[ext]",
+                  outputPath: "assets/fonts/",
+                },
+              },
+            ],
+          }
+        : {
+            test: /\.(woff|woff2|eot|ttf|otf)$/i,
+            use: ["file-loader"],
+          },
       {
         test: /\.(png|jpe?g|gif|svg)$/i,
         use: {

--- a/src/renderer/styles/StyleProvider.tsx
+++ b/src/renderer/styles/StyleProvider.tsx
@@ -1,5 +1,6 @@
 // @flow
 
+import "@ledgerhq/react-ui/assets/fonts";
 import React, { useMemo } from "react";
 import { ThemeProvider } from "styled-components";
 import type { StyledComponent } from "styled-components";


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LL-7743]

Configurate webpack so that the fonts from the react-ui package can be used.

## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-7743]: https://ledgerhq.atlassian.net/browse/LL-7743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ