### PR TITLE
LL-7765 Add terms and conditions / privacy policy rebranded modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@ledgerhq/ledger-core": "6.13.0",
     "@ledgerhq/live-common": "^21.8.2",
     "@ledgerhq/logs": "6.2.0",
-    "@ledgerhq/react-ui": "0.1.0",
+    "@ledgerhq/react-ui": "0.1.1",
     "@polkadot/react-identicon": "0.85.3",
     "@tippyjs/react": "^4.2.5",
     "@trust/keyto": "^1.0.1",

--- a/src/renderer/components/Onboarding/Screens/Welcome/TermsAndConditionsModal.tsx
+++ b/src/renderer/components/Onboarding/Screens/Welcome/TermsAndConditionsModal.tsx
@@ -1,10 +1,9 @@
 import React, { useCallback } from "react";
-import { Popin, Text, Flex, Checkbox, Button } from "@ledgerhq/react-ui";
+import { Popin, Text, Flex, Checkbox, Button, Icons } from "@ledgerhq/react-ui";
 import { useTranslation, Trans } from "react-i18next";
 import { acceptTerms, useDynamicUrl } from "~/renderer/terms";
 import { setShareAnalytics } from "~/renderer/actions/settings";
 import { openURL } from "~/renderer/linking";
-import { Icons } from "@ledgerhq/react-ui";
 import { useDispatch } from "react-redux";
 
 const TermsAndConditionsModal: React.FC<{

--- a/src/renderer/components/Onboarding/Screens/Welcome/TermsAndConditionsModal.tsx
+++ b/src/renderer/components/Onboarding/Screens/Welcome/TermsAndConditionsModal.tsx
@@ -1,0 +1,79 @@
+import React, { useCallback } from "react";
+import { Popin, Text, Flex, Checkbox, Button } from "@ledgerhq/react-ui";
+import { useTranslation, Trans } from "react-i18next";
+import { acceptTerms, useDynamicUrl } from "~/renderer/terms";
+import { setShareAnalytics } from "~/renderer/actions/settings";
+import { openURL } from "~/renderer/linking";
+import { Icons } from "@ledgerhq/react-ui";
+import { useDispatch } from "react-redux";
+
+const TermsAndConditionsModal: React.FC<{
+  isOpen: boolean;
+  onClose: () => void;
+  sendEvent: (e: string) => void;
+}> = ({ isOpen, onClose, sendEvent }) => {
+  const { t } = useTranslation();
+
+  const [acceptedTermsOfUse, setAcceptedTermsOfUse] = React.useState(false);
+  const [acceptedPrivacyPolicy, setAcceptedPrivacyPolicy] = React.useState(false);
+
+  const termsUrl = useDynamicUrl("terms");
+  const privacyPolicyUrl = useDynamicUrl("privacyPolicy");
+
+  const dispatch = useDispatch();
+
+  const handleAcceptTermsOfUse = useCallback(() => {
+    acceptTerms();
+    dispatch(setShareAnalytics(true));
+    sendEvent("NEXT");
+  }, [dispatch, sendEvent]);
+
+  return (
+    <Popin isOpen={isOpen} onClose={onClose} width={622} height={220}>
+      <Flex justifyContent="center" mt={4} mb={3}>
+        <Text type="h2" textTransform="uppercase">
+          {t("Terms.title")}
+        </Text>
+      </Flex>
+      <Flex mt={5} ml={5}>
+        <Checkbox
+          name="termsOfUseCheckbox"
+          onChange={e => setAcceptedTermsOfUse(e.target.checked)}
+          isChecked={acceptedTermsOfUse}
+          label={
+            <Trans i18nKey="Terms.termsCheckboxLabel">
+              <></>
+              <a href="javascript: void(0)" onClick={() => openURL(termsUrl)}></a>
+            </Trans>
+          }
+        />
+      </Flex>
+      <Flex mt={2} ml={5}>
+        <Checkbox
+          name="privacyPolicyCheckbox"
+          onChange={e => setAcceptedPrivacyPolicy(e.target.checked)}
+          isChecked={acceptedPrivacyPolicy}
+          label={
+            <Trans i18nKey="Terms.privacyCheckboxLabel">
+              <></>
+              <a href="javascript: void(0)" onClick={() => openURL(privacyPolicyUrl)}></a>
+            </Trans>
+          }
+        />
+      </Flex>
+      <Flex justifyContent="center" mt={8}>
+        <Button
+          onClick={handleAcceptTermsOfUse}
+          type="main"
+          color="palette.neutral.c100"
+          Icon={() => <Icons.ArrowRightMedium size={18} />}
+          disabled={!acceptedTermsOfUse || !acceptedPrivacyPolicy}
+        >
+          {t("common.continue")}
+        </Button>
+      </Flex>
+    </Popin>
+  );
+};
+
+export default TermsAndConditionsModal;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -94,5 +94,6 @@
       </div>
     </div>
     <div id="modals"></div>
+    <div id="ll-popin-root"></div>
   </body>
 </html>

--- a/src/renderer/styles/StyleProvider.tsx
+++ b/src/renderer/styles/StyleProvider.tsx
@@ -17,13 +17,15 @@ type Props = {
 export type ThemedComponent<T> = StyledComponent<T, Theme, any>;
 
 const StyleProvider = ({ children, selectedPalette }: Props) => {
+  // V2 palettes are not typed in TS so we need to explicity type them as any
+  const palettesAny: any = palettes;
   const theme: Theme = useMemo(
     () => ({
       ...defaultTheme,
       ...V3dDfaultTheme,
       colors: {
         ...defaultTheme.colors,
-        palette: { ...palettes[selectedPalette], ...V3Palettes[selectedPalette] },
+        palette: { ...palettesAny[selectedPalette], ...V3Palettes[selectedPalette] },
       },
     }),
     [selectedPalette],

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -3385,6 +3385,8 @@
     "termsLabel": "Terms of service",
     "privacyLabel": "Privacy policy",
     "switchLabel": "I have read and accept the Terms of service and Privacy policy",
+    "termsCheckboxLabel": "<0>I have read and agree with the </0><1>Terms of Use</1>",
+    "privacyCheckboxLabel": "<0>I have read and accepted the </0><1>Privacy Policy</1>",
     "cta": "Enter Ledger app"
   },
   "families": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2495,6 +2495,11 @@
     "@ledgerhq/errors" "^5.50.0"
     events "^3.3.0"
 
+"@ledgerhq/icons-ui@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/icons-ui/-/icons-ui-0.1.1.tgz#0f6e86cd2b70de6cd42fc4f7051f47f718149bf6"
+  integrity sha512-HB+a3osBJKyPFuBUWlXNw9g7qAjI2TKY7qhfQAwMab6W3A6wYVLYOtLgdrABzfHVLhHmzFRlLuRm5bTgG8BA6A==
+
 "@ledgerhq/json-bignumber@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/json-bignumber/-/json-bignumber-1.1.0.tgz#8d3e38118060565191518ab06bd9aa5b22b25b58"
@@ -2618,11 +2623,13 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.50.0.tgz#29c6419e8379d496ab6d0426eadf3c4d100cd186"
   integrity sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA==
 
-"@ledgerhq/react-ui@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-ui/-/react-ui-0.1.0.tgz#5fd0e9f79a91d7955cf183cb2f296ff06a5145d1"
-  integrity sha512-y2qnLuJ+kWRKHidnCfxxQeffcKE0G9+NbXtAPECDaRAZezjersN/Sjw8oc53na0OXuIodE9A2ULq3G2XgmAu3A==
+"@ledgerhq/react-ui@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-ui/-/react-ui-0.1.1.tgz#1712bb5a481c7b7b02e7fbb66df602ffd27442fb"
+  integrity sha512-A9LZmHOHN26nG5Teu6WrI9fC4D8hji1zP1DdeDKuIRMsk45lFf/y4wykdAtOWz2fIDdctvQSagjQoB4CrOA8Pw==
   dependencies:
+    "@ledgerhq/icons-ui" "^0.1.0"
+    "@ledgerhq/ui-shared" "^0.1.1"
     "@tippyjs/react" "^4.2.5"
     "@types/color" "^3.0.2"
     "@types/react" "~17.0.28"
@@ -2642,6 +2649,11 @@
     react-window "^1.8.6"
     styled-components "^5.2.3"
     styled-system "^5.1.5"
+
+"@ledgerhq/ui-shared@^0.1.1":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ui-shared/-/ui-shared-0.1.2.tgz#0577f24af4d93ebf1964bfd22211a62f9cf88663"
+  integrity sha512-JegsvmuXy4DECw3YQnwA9JLohOKQtKJiS3vG8GAOU2qo7GmniasIGrh10nSAVcpxtM4GCdnmh+va6ifkxeSLPw==
 
 "@mdx-js/loader@^1.6.22":
   version "1.6.22"


### PR DESCRIPTION
## 🦒 Context (issues, jira)
[LL-7765]


## 💻  Description / Demo (image or video)
A simple modal component can be used during the rebranded onboarding.
The continue button is disabled as long as either the privacy policy or the terms of use are not accepted.
The continue button sends the "NEXT" event to the onboarding screen and sets the "acceptedTerms" value in local storage. This logic is copied from the current terms and conditions screen.
![image](https://user-images.githubusercontent.com/91940736/139417046-144f2d6c-2dc2-463f-8312-a2e96aeb7f4d.png)

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ 
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-7765]: https://ledgerhq.atlassian.net/browse/LL-7765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ