### PR TITLE
LL-7489 - Fix amount & fees hidden in discreet mode in StepSummary of any flow

### DIFF
--- a/src/renderer/modals/Send/steps/StepSummary.js
+++ b/src/renderer/modals/Send/steps/StepSummary.js
@@ -224,6 +224,7 @@ export default class StepSummary extends PureComponent<StepProps> {
                     fontSize={4}
                     inline
                     showCode
+                    alwaysShowValue
                   />
                   <Box textAlign="right">
                     <CounterValue
@@ -232,6 +233,7 @@ export default class StepSummary extends PureComponent<StepProps> {
                       currency={currency}
                       value={totalSpent}
                       alwaysShowSign={false}
+                      alwaysShowValue
                     />
                   </Box>
                 </Box>

--- a/src/renderer/modals/SignTransaction/steps/StepSummary.js
+++ b/src/renderer/modals/SignTransaction/steps/StepSummary.js
@@ -160,6 +160,7 @@ export default class StepSummary extends PureComponent<StepProps> {
                 fontSize={4}
                 inline
                 showCode
+                alwaysShowValue
               />
               <Box textAlign="right">
                 <CounterValue
@@ -169,6 +170,7 @@ export default class StepSummary extends PureComponent<StepProps> {
                   value={amount}
                   alwaysShowSign={false}
                   subMagnitude={1}
+                  alwaysShowValue
                 />
               </Box>
             </Box>
@@ -186,6 +188,7 @@ export default class StepSummary extends PureComponent<StepProps> {
                 fontSize={4}
                 inline
                 showCode
+                alwaysShowValue
               />
               <Box textAlign="right">
                 <CounterValue
@@ -195,6 +198,7 @@ export default class StepSummary extends PureComponent<StepProps> {
                   value={estimatedFees}
                   alwaysShowSign={false}
                   subMagnitude={1}
+                  alwaysShowValue
                 />
               </Box>
             </Box>
@@ -225,6 +229,7 @@ export default class StepSummary extends PureComponent<StepProps> {
                     fontSize={4}
                     inline
                     showCode
+                    alwaysShowValue
                   />
                   <Box textAlign="right">
                     <CounterValue
@@ -234,6 +239,7 @@ export default class StepSummary extends PureComponent<StepProps> {
                       value={totalSpent}
                       alwaysShowSign={false}
                       subMagnitude={1}
+                      alwaysShowValue
                     />
                   </Box>
                 </Box>

--- a/src/renderer/modals/Swap/steps/StepSummary.js
+++ b/src/renderer/modals/Swap/steps/StepSummary.js
@@ -111,6 +111,7 @@ const StepSummary = ({
               val={fromAmount}
               unit={fromUnit}
               showCode
+              alwaysShowValue
             />
           </Text>
         </Box>
@@ -142,6 +143,7 @@ const StepSummary = ({
               val={toAmount}
               unit={toUnit}
               showCode
+              alwaysShowValue
             />
           </Text>
         </Box>


### PR DESCRIPTION
## 🦒 Context (issues, jira)
[LL-7489]
Follow up of https://github.com/LedgerHQ/ledger-live-desktop/pull/4300 after QA KO because amount/fees were still hidden in the "summary" step depending on the flow:
- send flow: if total to debit !== amount, there's one more line "total to debit" and it was still hidden there
- sign transaction flow: using paraswap for instance


## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-7489]: https://ledgerhq.atlassian.net/browse/LL-7489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ