### PR TITLE
LL-7960 make sync synchronising as soon as the tx is broadcasted

### DIFF
--- a/src/renderer/modals/Send/Body.js
+++ b/src/renderer/modals/Send/Body.js
@@ -271,7 +271,7 @@ const Body = ({
 
   return (
     <Stepper {...stepperProps}>
-      <SyncSkipUnderPriority priority={100} />
+      {stepId === "confirmation" ? null : <SyncSkipUnderPriority priority={100} />}
       <Track onUnmount event="CloseModalSend" />
     </Stepper>
   );


### PR DESCRIPTION
## 🦒 Context (issues, jira)

LL-7960

## 💻  Description / Demo (image or video)

when using send flow, the whole send flow is blocking background synchronisation
this allows the send flow to not block sync on the "success" step, which will help fixing issue of "sending two txs in a row".

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
