### PR TITLE
LL-8044 - Rebranding - Checkbox & Switch

### DIFF
--- a/src/renderer/components/CheckBox.tsx
+++ b/src/renderer/components/CheckBox.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Checkbox } from "@ledgerhq/react-ui";
+import type { CheckboxProps } from "@ledgerhq/react-ui/components/form/Checkbox/Checkbox"
+
+export interface Props extends Omit<HTMLInputElement, "disabled">, CheckboxProps {
+  isChecked: boolean;
+  disabled?: boolean;
+}
+
+export default function CheckBox({ disabled, isChecked, ...checkboxProps }: Props) {
+  return <Checkbox isDisabled={disabled} isChecked={isChecked} {...checkboxProps} />;
+}

--- a/src/renderer/components/Switch.tsx
+++ b/src/renderer/components/Switch.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import noop from "lodash/noop";
+import { Switch as BaseSwitch } from "@ledgerhq/react-ui";
+import type { SwitchProps } from "@ledgerhq/react-ui/components/form/Switch/Switch"
+
+export interface Props extends Omit<SwitchProps, "onChange" | "checked"> {
+  isChecked: boolean,
+  small?: boolean,
+  medium?: boolean,
+  onChange?: (value: boolean) => void
+}
+
+export default function Switch({ isChecked, small, medium, onChange = noop, ...switchProps } : Props) {
+  return <BaseSwitch {...switchProps} checked={isChecked} onChange={() => onChange(!isChecked) } size={small ? "small": "normal"} />;
+}


### PR DESCRIPTION
## 🦒 Context (issues, jira)

Add simple `<CheckBox />` and `<Switch />` proxy components.

[LL-8044]

## 💻  Description / Demo (image or video)

<img width="1181" alt="Capture d’écran 2021-11-12 à 16 13 56" src="https://user-images.githubusercontent.com/86958797/141489741-5fd7861c-dd6a-49b0-9cbc-f77e5e8dc240.png">

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-8044]: https://ledgerhq.atlassian.net/browse/LL-8044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ