### PR TITLE
LL-8044 - Rebranding - Base Input proxy component

### DIFF
--- a/src/renderer/components/Input.tsx
+++ b/src/renderer/components/Input.tsx
@@ -1,0 +1,77 @@
+import React, { useCallback, useMemo } from "react"
+import { useTranslation } from "react-i18next";
+import styled from "styled-components";
+import { Flex, InfiniteLoader, Input as BaseInput } from "@ledgerhq/react-ui";
+import type { InputProps } from "@ledgerhq/react-ui/components/form/BaseInput"
+
+export interface Props extends Omit<InputProps, "error" | "warning"> {
+  onEnter?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  onEsc?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  loading?: boolean,
+  error?: Error | string,
+  warning?: Error | string,
+};
+
+export default function Input({ onEnter, onEsc, error, warning, loading, ...baseInputProps} : Props) {
+  const { t } = useTranslation();
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.code === "Enter" && onEnter) {
+        onEnter(e);
+      } else if (e.code === "Escape" && onEsc) {
+        onEsc(e);
+      }
+    },
+    [onEnter, onEsc],
+  );
+
+  const [errorMsg, warningMsg] = useMemo(() => (
+    [error, warning].map(elt => {
+      if(!elt || typeof elt === "string")
+        return elt as string | undefined
+      const field = "title";
+      const arg = Object.assign({ message: elt.message, returnObjects: true }, elt);
+      if (elt.name) {
+        const translation = t(`errors.${elt.name}.${field}`, arg);
+        if (translation !== `errors.${elt.name}.${field}`) {
+          // It is translated
+          if (translation && typeof translation === "object") {
+            // It is a list
+            return Object.values(translation).map(str =>
+              typeof str === "string" ? str : null,
+            ).filter(Boolean).join("\n");
+          }
+          return translation;
+        }
+      }
+
+      const genericTranslation = t(`errors.generic.${field}`, arg);
+      return genericTranslation === `errors.generic.${field}` ? undefined : genericTranslation;
+    })
+  ), [error, warning])
+
+  if(loading) {
+    const right = (props) => (
+      <Flex alignItems="center" pr={4}>
+        <InfiniteLoader />
+        { typeof baseInputProps.renderRight === "function" ? baseInputProps.renderRight(props) : baseInputProps.renderRight }
+      </Flex>
+    )
+    return (
+      <BaseInput
+        error={errorMsg}
+        warning={warningMsg}
+        onKeyDown={handleKeyDown}
+        {...baseInputProps}
+        renderRight={right}
+        placeholder={loading ? "" : baseInputProps.placeholder}
+        value={loading ? "" : baseInputProps.value}
+      />
+    )
+  } else {
+    return <BaseInput error={errorMsg} warning={warningMsg} onKeyDown={handleKeyDown} {...baseInputProps} />
+  }
+
+
+}


### PR DESCRIPTION
## 🦒 Context (issues, jira)

Adds a proxy `<Input />` component that acts as an adapter to one from `@ledgerhq/react-ui`.

[LL-8044]

## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-8044]: https://ledgerhq.atlassian.net/browse/LL-8044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ