### PR TITLE
LL-8157 Exit manager if we enter app, avoid loop

### DIFF
--- a/src/renderer/screens/manager/Dashboard.js
+++ b/src/renderer/screens/manager/Dashboard.js
@@ -20,7 +20,7 @@ type Props = {
   device: Device,
   deviceInfo: DeviceInfo,
   result: ?ListAppsResult,
-  onReset: (?(string[])) => void,
+  onReset: (?(string[]), ?boolean) => void,
   appsToRestore: string[],
 };
 
@@ -56,7 +56,7 @@ const Dashboard = ({ device, deviceInfo, result, onReset, appsToRestore }: Props
 
     // we need to reset only if device is unplugged OR a disconnection happened during firmware update
     if (!currentDevice || hasDisconnectedDuringFU.current) {
-      onReset();
+      onReset([], firmwareUpdateOpened);
     }
   }, [onReset, firmwareUpdateOpened, currentDevice]);
 

--- a/src/renderer/screens/manager/index.js
+++ b/src/renderer/screens/manager/index.js
@@ -7,6 +7,7 @@ import DeviceAction from "~/renderer/components/DeviceAction";
 import { command } from "~/renderer/commands";
 import { mockedEventEmitter } from "~/renderer/components/debug/DebugMock";
 import { getEnv } from "@ledgerhq/live-common/lib/env";
+import { Redirect } from "react-router";
 
 const connectManagerExec = command("connectManager");
 const action = createAction(getEnv("MOCK") ? mockedEventEmitter : connectManagerExec);
@@ -14,9 +15,11 @@ const action = createAction(getEnv("MOCK") ? mockedEventEmitter : connectManager
 const Manager = () => {
   const [appsToRestore, setRestoreApps] = useState();
   const [result, setResult] = useState(null);
-  const onReset = useCallback(apps => {
+  const [hasReset, setHasReset] = useState(false);
+  const onReset = useCallback((apps, firmwareUpdateOpened) => {
     setRestoreApps(apps);
     setResult(null);
+    if (!firmwareUpdateOpened) setHasReset(true);
   }, []);
   const onResult = useCallback(result => setResult(result), []);
 
@@ -25,8 +28,10 @@ const Manager = () => {
       <SyncSkipUnderPriority priority={999} />
       {result ? (
         <Dashboard {...result} onReset={onReset} appsToRestore={appsToRestore} />
-      ) : (
+      ) : !hasReset ? (
         <DeviceAction onResult={onResult} action={action} request={null} />
+      ) : (
+        <Redirect to="/" />
       )}
     </>
   );


### PR DESCRIPTION
## 🦒 Context (issues, jira)
When in the manager and not in a firmware update flow, consider a disconnect as the user interacting with the app some other way, and exit the manager.

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

## How to test

### Test 1
- Access the manager with a device
- When in the manager, enter an app in the device
- Expected we redirect to the portfolio

### Test 2
- Do the same with a device that has a firmware update
- Disconnect the device while the firmware update modal is open.
- Expected we show the device action to reconnect the device instead of redirecting

-------

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
