### PR TITLE
LL-8039 - REBORN - Proxying modal components using pop-in

### DIFF
--- a/src/renderer/components/Modal/ModalBody.tsx
+++ b/src/renderer/components/Modal/ModalBody.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+import { Popin, Text, Flex } from "@ledgerhq/react-ui";
+
+export type RenderProps = {
+  onClose?: () => {};
+  data: any;
+};
+
+type Props = {
+  title?: React.ReactNode;
+  subTitle?: React.ReactNode;
+  headerStyle?: any;
+  onBack?: () => {};
+  onClose?: () => {};
+  render?: (props?: RenderProps) => {};
+  renderFooter?: (props?: RenderProps) => {};
+  modalFooterStyle?: any;
+  renderProps?: RenderProps;
+  noScroll?: boolean;
+  refocusWhenChange?: any;
+  isOpen?: boolean;
+};
+
+/**
+ * This component is just a proxy to the skeleton inside the Popin component defined in @ledgerhq/react-ui.
+ * It should only be used to map leagacy props/logic from LLD to the new popin component.
+ *
+ * @deprecated Please, prefer using the Popin component from our design-system if possible.
+ */
+const ModalBody = ({
+  onBack,
+  onClose,
+  title,
+  subTitle,
+  render,
+  renderFooter,
+  renderProps,
+  modalFooterStyle,
+}: Props) => (
+  <>
+    <Popin.Header onBack={onBack} onClose={onClose}>
+      <Flex flexDirection="column">
+        {title ? <Text variant="h4">{title}</Text> : null}
+        {subTitle ? <Text variant="h5">{subTitle || null}</Text> : null}
+      </Flex>
+    </Popin.Header>
+    {render && <Popin.Body>{render(renderProps)}</Popin.Body>}
+    {renderFooter && (
+      <Popin.Footer style={modalFooterStyle}>{renderFooter(renderProps)}</Popin.Footer>
+    )}
+  </>
+);
+
+// export default React.memo(ModalBody);
+export default ModalBody;

--- a/src/renderer/components/Modal/ModalContent.tsx
+++ b/src/renderer/components/Modal/ModalContent.tsx
@@ -1,0 +1,10 @@
+import { Popin } from "@ledgerhq/react-ui";
+
+/**
+ * This component is just a proxy to the Popin.Body component defined in @ledgerhq/react-ui.
+ * It should only be used to map leagacy props/logic from LLD to the new popin component.
+ *
+ * @deprecated Please, prefer using the Popin.Body component from our design-system if possible.
+ */
+const ModalContent = Popin.Body;
+export default ModalContent;

--- a/src/renderer/components/Modal/ModalFooter.tsx
+++ b/src/renderer/components/Modal/ModalFooter.tsx
@@ -1,0 +1,10 @@
+import { Popin } from "@ledgerhq/react-ui";
+
+/**
+ * This component is just a proxy to the Popin.Footer component defined in @ledgerhq/react-ui.
+ * It should only be used to map leagacy props/logic from LLD to the new popin component.
+ *
+ * @deprecated Please, prefer using the Popin.Footer component from our design-system if possible.
+ */
+const ModalFooter = Popin.Footer;
+export default ModalFooter;

--- a/src/renderer/components/Modal/ModalHeader.tsx
+++ b/src/renderer/components/Modal/ModalHeader.tsx
@@ -1,0 +1,10 @@
+import { Popin } from "@ledgerhq/react-ui";
+
+/**
+ * This component is just a proxy to the Popin.Header component defined in @ledgerhq/react-ui.
+ * It should only be used to map leagacy props/logic from LLD to the new popin component.
+ *
+ * @deprecated Please, prefer using the Popin.Header component from our design-system if possible.
+ */
+const ModalHeader = Popin.Header;
+export default ModalHeader;

--- a/src/renderer/components/Modal/index.tsx
+++ b/src/renderer/components/Modal/index.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { connect } from "react-redux";
+import { Popin } from "@ledgerhq/react-ui";
+
+import { closeModal } from "~/renderer/actions/modals";
+import { isModalOpened as isModalOpenedSelector, getModalData } from "~/renderer/reducers/modals";
+import Snow, { isSnowTime } from "~/renderer/extra/Snow";
+import ModalBody from "./ModalBody";
+import ModalHeader from "./ModalHeader";
+import ModalFooter from "./ModalFooter";
+import ModalContent from "./ModalContent";
+
+const mapStateToProps = (state: any, { name, isOpened, onBeforeOpen }: Props): any => {
+  const data = getModalData(state, name || "");
+  const modalOpened = isOpened || (name && isModalOpenedSelector(state, name));
+
+  if (onBeforeOpen && modalOpened) {
+    onBeforeOpen({ data });
+  }
+  return {
+    isOpened: !!modalOpened,
+    data,
+  };
+};
+
+const mapDispatchToProps = (dispatch: () => {}, { name, onClose = () => {} }: Props): any => {
+  return {
+    onClose: name
+      ? () => {
+          dispatch(closeModal(name));
+          onClose();
+        }
+      : onClose,
+  };
+};
+
+export type RenderProps = {
+  onClose?: () => {};
+  data: any;
+};
+
+type Props = {
+  isOpened?: boolean;
+  children?: any;
+  centered?: boolean;
+  onClose?: () => {};
+  onHide?: () => {};
+  render?: (props: RenderProps) => React.ReactNode;
+  data?: any;
+  preventBackdropClick?: boolean;
+  width?: number;
+  theme: any;
+  name?: string;
+  onBeforeOpen?: ({ data }: { data: Pick<RenderProps, "data"> }) => {};
+  backdropColor?: boolean;
+};
+
+/**
+ * This component is just a proxy to the Popin component defined in @ledgerhq/react-ui.
+ * It should only be used to map leagacy props/logic from LLD to the new popin component.
+ *
+ * @deprecated Please, prefer using the Popin component from our design-system if possible.
+ */
+const Modal = ({ isOpened, children, onClose, render, data, width }: Props) => (
+  <Popin isOpen={!!isOpened} width={width}>
+    {isSnowTime() ? <Snow numFlakes={100} /> : null}
+    <Popin.Body>
+      {render && render({ onClose, data })}
+      {children}
+    </Popin.Body>
+  </Popin>
+);
+
+export default connect(mapStateToProps, mapDispatchToProps)(Modal);
+export { ModalBody, ModalHeader, ModalFooter, ModalContent };

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -80,7 +80,7 @@
 
   <body>
     <div id="react-root"></div>
-    <div id="ll-modal-root"></div>
+    <div id="ll-popin-root"></div>
     <div id="ll-side-root"></div>
     <div id="loader-container" class="loading">
       <div id="loader">


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LL-8039]

⚠️ This PR depends on [ui/PR#92](https://github.com/LedgerHQ/ui/pull/92). Please ensure that the UI repository is dumped to the correct version before merging this PR. ⚠️ 

## 💻  Description / Demo (image or video)


https://user-images.githubusercontent.com/33158502/142264211-9d26f975-d660-468d-ae61-51820dc2c4d7.mov



<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-8039]: https://ledgerhq.atlassian.net/browse/LL-8039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ