### PR TITLE
LL-8171 hide tokens which have their parent currency disabled

### DIFF
--- a/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.js
+++ b/src/renderer/modals/AddAccounts/steps/StepChooseCurrency.js
@@ -2,7 +2,11 @@
 
 import React, { useMemo, useCallback } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { listSupportedCurrencies, listTokens } from "@ledgerhq/live-common/lib/currencies";
+import {
+  listSupportedCurrencies,
+  listTokens,
+  isCurrencySupported,
+} from "@ledgerhq/live-common/lib/currencies";
 import { findTokenAccountByCurrency } from "@ledgerhq/live-common/lib/account";
 import { supportLinkByTokenType } from "~/config/urls";
 import TrackPage from "~/renderer/analytics/TrackPage";
@@ -20,8 +24,10 @@ import useSatStackStatus from "~/renderer/hooks/useSatStackStatus";
 import useEnv from "~/renderer/hooks/useEnv";
 import type { SatStackStatus } from "@ledgerhq/live-common/lib/families/bitcoin/satstack";
 
+const listSupportedTokens = () => listTokens().filter(t => isCurrencySupported(t.parentCurrency));
+
 const StepChooseCurrency = ({ currency, setCurrency }: StepProps) => {
-  const currencies = useMemo(() => listSupportedCurrencies().concat(listTokens()), []);
+  const currencies = useMemo(() => listSupportedCurrencies().concat(listSupportedTokens()), []);
 
   const url =
     currency && currency.type === "TokenCurrency"

--- a/src/renderer/screens/manager/AppsList/Placeholder.js
+++ b/src/renderer/screens/manager/AppsList/Placeholder.js
@@ -5,7 +5,7 @@ import { Trans } from "react-i18next";
 import type { Action, InstalledItem } from "@ledgerhq/live-common/lib/apps/types";
 import type { App } from "@ledgerhq/live-common/lib/types/manager";
 
-import { listTokens } from "@ledgerhq/live-common/lib/currencies";
+import { listTokens, isCurrencySupported } from "@ledgerhq/live-common/lib/currencies";
 import manager from "@ledgerhq/live-common/lib/manager";
 
 import Text from "~/renderer/components/Text";
@@ -29,8 +29,9 @@ const Placeholder = ({ query, addAccount, dispatch, installed, apps }: Props) =>
     () =>
       tokens.find(
         token =>
-          token.name.toLowerCase().includes(query.toLowerCase()) ||
-          token.ticker.toLowerCase().includes(query.toLowerCase()),
+          isCurrencySupported(token.parentCurrency) &&
+          (token.name.toLowerCase().includes(query.toLowerCase()) ||
+            token.ticker.toLowerCase().includes(query.toLowerCase())),
       ),
     [query],
   );


### PR DESCRIPTION
## 🦒 Context (issues, jira)

LL-8171

## 💻  Description / Demo (image or video)

Fixes some tokens to be visible even when their parent currency wheren't yet enabled (polygon).

- fix in Add Account flow
- fix in Manager app list when you search for a token name

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
