### PR TITLE
NFTs collections only visible if account has nfts

### DIFF
--- a/src/renderer/screens/account/index.js
+++ b/src/renderer/screens/account/index.js
@@ -135,12 +135,8 @@ const AccountPage = ({
           {isCompoundEnabled && account.type === "TokenAccount" && parentAccount ? (
             <CompoundBodyHeader account={account} parentAccount={parentAccount} />
           ) : null}
-          {account.type === "Account" ? (
-            <>
-              <Collections account={account} />
-              <TokensList account={account} />
-            </>
-          ) : null}
+          {account?.nfts?.length ? <Collections account={account} /> : null}
+          {account.type === "Account" ? <TokensList account={account} /> : null}
           <OperationsList
             account={account}
             parentAccount={parentAccount}


### PR DESCRIPTION
## 🦒 Context (issues, jira)

Fix for NFTs collection module being visible on accounts where you don't have nfts

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
