### PR TITLE
LL-8207 Improve app size granularity on the Manager

### DIFF
--- a/src/renderer/components/ByteSize.js
+++ b/src/renderer/components/ByteSize.js
@@ -6,17 +6,19 @@ import type { DeviceModel } from "@ledgerhq/devices";
 const k = 1024; // 1kb unit
 const sizes = ["bytes", "kbUnit", "mbUnit"];
 
-/** formats a byte value into its correct size in kb or mb unit takling in account the device block size */
+/** formats a byte value into its correct size in kb or mb unit taking in account the device block size */
 const ByteSize = ({
   value,
   deviceModel,
   decimals = 2,
   firmwareVersion,
+  formatFunction,
 }: {
   value: number,
   deviceModel: DeviceModel,
   decimals?: number,
   firmwareVersion: string,
+  formatFunction?: (val: number) => number,
 }) => {
   if (!value) return "–";
 
@@ -24,19 +26,18 @@ const ByteSize = ({
 
   // FIXME it should be on live-common side
   const bytes = Math.ceil(value / blockSize) * blockSize;
-
   const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const rawSize = parseFloat(bytes / Math.pow(k, i));
+  const dm = i > 1 ? Math.max(0, decimals) : 0;
 
-  const dm = Math.max(0, decimals);
+  const divider = Math.pow(10, dm);
+  const toFormat = rawSize * divider;
+  let formattedSize = formatFunction ? formatFunction(toFormat) : toFormat;
+  formattedSize /= divider;
 
-  return (
-    <Trans
-      i18nKey={`byteSize.${sizes[i]}`}
-      values={{
-        size: parseFloat((bytes / Math.pow(k, i)).toFixed(dm)),
-      }}
-    />
-  );
+  const size = formattedSize.toFixed(dm);
+
+  return <Trans i18nKey={`byteSize.${sizes[i]}`} values={{ size }} />;
 };
 
 export default ByteSize;

--- a/src/renderer/screens/manager/AppsList/Item.js
+++ b/src/renderer/screens/manager/AppsList/Item.js
@@ -117,6 +117,7 @@ const Item: React$ComponentType<Props> = ({
                 app.bytes ||
                 0
               }
+              formatFunction={Math.ceil}
               deviceModel={deviceModel}
               firmwareVersion={deviceInfo.version}
             />

--- a/src/renderer/screens/manager/DeviceStorage/index.js
+++ b/src/renderer/screens/manager/DeviceStorage/index.js
@@ -179,7 +179,12 @@ const TooltipContent = ({
   <TooltipContentWrapper>
     <Text>{name}</Text>
     <Text>
-      <ByteSize value={bytes} deviceModel={deviceModel} firmwareVersion={deviceInfo.version} />
+      <ByteSize
+        value={bytes}
+        deviceModel={deviceModel}
+        firmwareVersion={deviceInfo.version}
+        formatFunction={Math.ceil}
+      />
     </Text>
   </TooltipContentWrapper>
 );
@@ -307,6 +312,7 @@ const DeviceStorage = ({
                 deviceModel={deviceModel}
                 value={distribution.totalAppsBytes}
                 firmwareVersion={deviceInfo.version}
+                formatFunction={Math.ceil}
               />
             </Text>
           </div>
@@ -319,6 +325,7 @@ const DeviceStorage = ({
                 deviceModel={deviceModel}
                 value={distribution.appsSpaceBytes}
                 firmwareVersion={deviceInfo.version}
+                formatFunction={Math.floor}
               />
             </Text>
           </div>
@@ -353,6 +360,7 @@ const DeviceStorage = ({
                       value={distribution.freeSpaceBytes}
                       deviceModel={deviceModel}
                       firmwareVersion={deviceInfo.version}
+                      formatFunction={Math.floor}
                     />
                     {"free"}
                   </Trans>


### PR DESCRIPTION
## 🦒 Context (issues, jira)
[LL-8207]


## 💻  Description / Demo (image or video)

1 - New device has more precise values data about storage (apps, firmware allocation, free space, etc...). We don't really need it on UI side for now. So we have to control the precision and the values to show.
2 - We wanted to better handle the rounding of data being less optimistic. When we are showing data about used space, we want to ceil the value and when it's about free space we will floor it to always unsure user will not be surprised thinking he could install something but when I do it, it fails cause missing few bytes on nano device.

![before](https://user-images.githubusercontent.com/90627435/149093808-9f7122eb-9393-48f0-9216-2f990e8af83d.png)

![after](https://user-images.githubusercontent.com/90627435/149094157-4cf02dc7-2fe3-4176-95a1-426d3941add8.png)

To test it : 
1 - Use a nano SP and go to the manager
2 - Check it works with other devices

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-8207]: https://ledgerhq.atlassian.net/browse/LL-8207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ