### PR TITLE
Fix missing palette in design system lib

### DIFF
--- a/src/renderer/styles/StyleProvider.tsx
+++ b/src/renderer/styles/StyleProvider.tsx
@@ -28,6 +28,7 @@ const StyleProvider = ({ children, selectedPalette }: Props) => {
       ...V3dDfaultTheme,
       colors: {
         ...defaultTheme.colors,
+        ...V3Palettes[selectedPalette],
         palette: { ...palettesAny[selectedPalette], ...V3Palettes[selectedPalette] },
       },
     }),


### PR DESCRIPTION
## 🦒 Context (issues, jira)
Due to the way we're developing using both V2 and V3 themes and to https://github.com/LedgerHQ/ui/pull/99, this is needed in order to upgrade the lib without breaking current V3.


