### PR TITLE
LL-7588 endless loop bug fixes

### DIFF
--- a/src/renderer/screens/manager/Disconnected.js
+++ b/src/renderer/screens/manager/Disconnected.js
@@ -1,14 +1,21 @@
 // @flow
-import React, { useCallback } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import { useSelector } from "react-redux";
 import { lastSeenDeviceSelector } from "~/renderer/reducers/settings";
 
-import { Wrapper, Title, SubTitle } from "~/renderer/components/DeviceAction/rendering";
+import {
+  Wrapper,
+  Title,
+  SubTitle,
+  renderLoading,
+} from "~/renderer/components/DeviceAction/rendering";
 import { Trans } from "react-i18next";
 import styled from "styled-components";
 import Box from "~/renderer/components/Box";
 import Button from "~/renderer/components/Button";
 import { useHistory } from "react-router-dom";
+import { getCurrentDevice } from "~/renderer/reducers/devices";
+import { command } from "~/renderer/commands";
 
 import nanoX from "./assets/nanoX.png";
 import nanoS from "./assets/nanoS.png";
@@ -29,6 +36,9 @@ const NanoS = styled.div`
 
 const Disconnected = ({ onTryAgain }: { onTryAgain: boolean => void }) => {
   const lastSeenDevice = useSelector(lastSeenDeviceSelector);
+  const [readyToDecide, setReadyToDecide] = useState(false);
+  const [showSpinner, setShowSpinner] = useState(true);
+  const device = useSelector(getCurrentDevice);
   const history = useHistory();
 
   const onReopenManager = useCallback(() => {
@@ -38,6 +48,38 @@ const Disconnected = ({ onTryAgain }: { onTryAgain: boolean => void }) => {
   const onBackToPortfolio = useCallback(() => {
     history.push({ pathname: "/" });
   }, [history]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setReadyToDecide(true);
+    }, 2000);
+  }, []);
+
+  useEffect(() => {
+    let sub;
+    if (readyToDecide) {
+      if (!device) {
+        onTryAgain(false); // Device is disconnected
+      } else {
+        sub = command("getAppAndVersion")(device).subscribe({
+          next: appAndVersion => {
+            if (["BOLOS", "OLOS\u0000"].includes(appAndVersion?.name)) {
+              onTryAgain(false); // Device is in dashboard
+            } else {
+              setShowSpinner(false);
+            }
+          },
+          error: () => onTryAgain(false), // Fallback if error
+        });
+      }
+    }
+    return () => {
+      if (sub) sub.unsubscribe();
+    };
+  }, [readyToDecide, device, onTryAgain]);
+
+  if (showSpinner)
+    return <Wrapper>{renderLoading({ modelId: lastSeenDevice?.modelId || "nanoS" })}</Wrapper>;
 
   return (
     <Wrapper>

--- a/src/renderer/screens/manager/Disconnected.js
+++ b/src/renderer/screens/manager/Disconnected.js
@@ -52,7 +52,7 @@ const Disconnected = ({ onTryAgain }: { onTryAgain: boolean => void }) => {
   useEffect(() => {
     setTimeout(() => {
       setReadyToDecide(true);
-    }, 2000);
+    }, 3000);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/144233061-07c146f6-1cb6-4073-8a23-ffd9f7d301f9.png)

## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-7588

## 💻  Description / Demo (image or video)
After some QA we discovered that it wasn't handling some other cases like disconnecting a device and the auto reinstall of apps after a firmware update. This attempts to solve that by adding a buffer between the disconnect and the message screen where we attempt to run a `getAppAndVersion` command on a device if available and depending on the outcome (or whether we have a device or not) choose the best course of action.

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
