### PR TITLE
Account footer for Celo integration

### DIFF
--- a/src/live-common-set-supported-currencies.js
+++ b/src/live-common-set-supported-currencies.js
@@ -37,4 +37,5 @@ setSupportedCurrencies([
   "bitcoin_testnet",
   "ethereum_ropsten",
   "cosmos_testnet",
+  "celo",
 ]);

--- a/src/live-common-set-supported-currencies.js
+++ b/src/live-common-set-supported-currencies.js
@@ -37,5 +37,4 @@ setSupportedCurrencies([
   "bitcoin_testnet",
   "ethereum_ropsten",
   "cosmos_testnet",
-  "celo",
 ]);

--- a/src/renderer/families/celo/AccountBalanceSummaryFooter.js
+++ b/src/renderer/families/celo/AccountBalanceSummaryFooter.js
@@ -1,0 +1,100 @@
+// @flow
+
+import React from "react";
+import styled from "styled-components";
+import { useSelector } from "react-redux";
+
+import { Trans } from "react-i18next";
+import { getAccountUnit } from "@ledgerhq/live-common/lib/account";
+import { formatCurrencyUnit } from "@ledgerhq/live-common/lib/currencies";
+
+import type { ThemedComponent } from "~/renderer/styles/StyleProvider";
+
+import { localeSelector } from "~/renderer/reducers/settings";
+
+import Discreet, { useDiscreetMode } from "~/renderer/components/Discreet";
+
+import Box from "~/renderer/components/Box/Box";
+import Text from "~/renderer/components/Text";
+import InfoCircle from "~/renderer/icons/InfoCircle";
+import ToolTip from "~/renderer/components/Tooltip";
+
+const Wrapper: ThemedComponent<*> = styled(Box).attrs(() => ({
+  horizontal: true,
+  mt: 4,
+  p: 5,
+  pb: 0,
+}))`
+  border-top: 1px solid ${p => p.theme.colors.palette.text.shade10};
+`;
+
+const BalanceDetail = styled(Box).attrs(() => ({
+  flex: "0.25 0 auto",
+  vertical: true,
+  alignItems: "start",
+}))`
+  &:nth-child(n + 3) {
+    flex: 0.75;
+  }
+`;
+
+const TitleWrapper = styled(Box).attrs(() => ({ horizontal: true, alignItems: "center", mb: 1 }))``;
+
+const Title = styled(Text).attrs(() => ({
+  fontSize: 4,
+  ff: "Inter|Medium",
+  color: "palette.text.shade60",
+}))`
+  line-height: ${p => p.theme.space[4]}px;
+  margin-right: ${p => p.theme.space[1]}px;
+`;
+
+const AmountValue = styled(Text).attrs(() => ({
+  fontSize: 6,
+  ff: "Inter|SemiBold",
+  color: "palette.text.shade100",
+}))``;
+
+type Props = {
+  account: any,
+  countervalue: any,
+};
+
+const AccountBalanceSummaryFooter = ({ account, countervalue }: Props) => {
+  const discreet = useDiscreetMode();
+  const locale = useSelector(localeSelector);
+
+  const { spendableBalance: _spendableBalance } = account;
+
+  const unit = getAccountUnit(account);
+
+  const formatConfig = {
+    disableRounding: true,
+    alwaysShowSign: false,
+    showCode: true,
+    discreet,
+    locale,
+  };
+
+  const spendableBalance = formatCurrencyUnit(unit, _spendableBalance, formatConfig);
+
+  return (
+    <Wrapper>
+      <BalanceDetail>
+        <ToolTip content={<Trans i18nKey="account.availableBalanceTooltip" />}>
+          <TitleWrapper>
+            <Title>
+              <Trans i18nKey="account.availableBalance" />
+            </Title>
+            <InfoCircle size={13} />
+          </TitleWrapper>
+        </ToolTip>
+        <AmountValue>
+          <Discreet>{spendableBalance}</Discreet>
+        </AmountValue>
+      </BalanceDetail>
+    </Wrapper>
+  );
+};
+
+export default AccountBalanceSummaryFooter;


### PR DESCRIPTION
## 🦒 Context (issues, jira)
This PR:
1. Adds Celo to list of supported currencies, enabling Celo Sync, Send and Receive features implemented in ledger-live-common https://github.com/LedgerHQ/ledger-live-common/pull/1536 - **it has to be merged first**
2. Adds an `Available balance` footer to Celo account view, as discussed with Fabrice.

## 💻  Description / Demo (image or video)

![CleanShot 2021-12-07 at 13 20 02](https://user-images.githubusercontent.com/1530318/145029411-654da650-a7f1-45ed-a4bf-4ffeac49f59f.jpeg)
![CleanShot 2021-12-07 at 13 20 15](https://user-images.githubusercontent.com/1530318/145029435-33a0f0f4-bcb5-44cc-9a54-15e45d339c4e.jpeg)
![CleanShot 2021-12-07 at 13 22 02](https://user-images.githubusercontent.com/1530318/145029446-ab3e59e6-0bb9-41ec-89a3-c7244dff1937.jpeg)

These screenshots don't include `Available balance` footer, it has been added later:
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 25 03" src="https://user-images.githubusercontent.com/1530318/143250657-dd30e76c-20d8-40ff-9702-4980acd8aa4e.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 25 13" src="https://user-images.githubusercontent.com/1530318/143250663-84424a47-f01f-4902-9273-61bdf8e59a34.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 25 33" src="https://user-images.githubusercontent.com/1530318/143250665-0fe9234d-224e-44cb-9d3a-4266275415a4.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 25 53" src="https://user-images.githubusercontent.com/1530318/143250670-e5ddeee0-971d-46e6-bf80-93eab753a9f8.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 26 48" src="https://user-images.githubusercontent.com/1530318/143250674-8980e87b-97e6-4aa8-9c34-b7fa549dfe98.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 26 58" src="https://user-images.githubusercontent.com/1530318/143250676-afc4d132-42ce-4c9e-ac85-0f3ea92c4896.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 27 08" src="https://user-images.githubusercontent.com/1530318/143250680-c5209862-dae2-47d8-a1de-fc7328c075f8.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 27 28" src="https://user-images.githubusercontent.com/1530318/143250681-a4e863a5-32cc-4bb4-992c-68c098d9ab37.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 27 38" src="https://user-images.githubusercontent.com/1530318/143250685-09bc022a-a55e-4ff0-ab7c-59e96b0f556a.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 27 43" src="https://user-images.githubusercontent.com/1530318/143250687-a44428c3-31e9-4e46-9ee7-d7af358fbe47.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 27 47" src="https://user-images.githubusercontent.com/1530318/143250689-7e994915-302f-4143-95aa-6b60dc268178.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 29 55" src="https://user-images.githubusercontent.com/1530318/143250695-44c6dd12-212b-4d60-8fd5-cf87b03f8cd2.png">
<img width="1021" alt="Zrzut ekranu 2021-11-24 o 13 30 02" src="https://user-images.githubusercontent.com/1530318/143250696-03f1590e-0971-43dc-b37a-e06164efd55b.png">

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
