### PR TITLE
(chore) Bump @ledgerhq/react-ui to version 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@ledgerhq/ledger-core": "6.14.5",
     "@ledgerhq/live-common": "21.20.1",
     "@ledgerhq/logs": "6.10.0",
-    "@ledgerhq/react-ui": "~0.6.0",
+    "@ledgerhq/react-ui": "~0.7.0",
     "@polkadot/react-identicon": "0.86.5",
     "@tippyjs/react": "^4.2.6",
     "@trust/keyto": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2815,10 +2815,10 @@
     commander "^8.2.0"
     mime-types "^2.1.33"
 
-"@ledgerhq/react-ui@~0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-ui/-/react-ui-0.6.0.tgz#f1e52228b9593de57ab6ae69218cb8396bddb2cc"
-  integrity sha512-VyINgOEUiX0KkyzfiFdkS/2h3XFAPhoAGLbN0PK2oJcCLua4UDSBdoBFkKJ72/0gSRlTmy0XWpb2cQiqmBIxYg==
+"@ledgerhq/react-ui@~0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-ui/-/react-ui-0.7.0.tgz#3d7ea0d471312dbc89843886a7cad1ace3a785aa"
+  integrity sha512-W5SFqVxzcfiSeTEe/F7UdUNUi2/cjhDqh3yD5xzaiG+m3HUObXNV9C7qAH0fcpzuofl+frjd4Z6ziDNgY5Evyg==
   dependencies:
     "@ledgerhq/icons-ui" "^0.2.1"
     "@ledgerhq/ui-shared" "^0.1.4"


### PR DESCRIPTION
## 🦒 Context (issues, jira)
Bumping version of the UI lib as we had a new release.


## 💻  Description / Demo (image or video)
N/A

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

