### PR TITLE
V3: use types from the new react select version

### DIFF
--- a/src/renderer/components/SelectAccount.tsx
+++ b/src/renderer/components/SelectAccount.tsx
@@ -13,15 +13,7 @@ import {
   getAccountUnit,
   listSubAccounts,
 } from "@ledgerhq/live-common/lib/account";
-
 import { Trans, useTranslation } from "react-i18next";
-import {
-  components,
-  createFilter,
-  MenuListComponentProps,
-  OptionProps,
-  SingleValueProps,
-} from "react-select";
 import { connect, useDispatch } from "react-redux";
 import { createStructuredSelector } from "reselect";
 import styled, { useTheme } from "styled-components";
@@ -32,6 +24,17 @@ import AccountTagDerivationMode from "./AccountTagDerivationMode";
 import { shallowAccountsSelector } from "../reducers/accounts";
 import { openModal } from "../actions/modals";
 import Plus from "../icons/Plus";
+
+// TODO: update react-select just before V3 gets merged instead of relying on a nested version…
+import {
+  components,
+  createFilter,
+  MenuListProps,
+  OptionProps,
+  SingleValueProps,
+  ControlProps,
+  IndicatorsContainerProps,
+} from "@ledgerhq/react-ui/node_modules/react-select";
 
 const IndentLine = styled.div`
   height: 36px;
@@ -100,7 +103,7 @@ const defaultRenderOption = (props: OptionProps<SelectOption, false>) => {
   );
 };
 
-const defaultRenderValue = (props: SingleValueProps<SelectOption>) => {
+const defaultRenderValue = (props: SingleValueProps<SelectOption, false>) => {
   const selectedOption = props.getValue()[0];
 
   if (!selectedOption) {
@@ -140,7 +143,7 @@ const AddButton = styled(Button.Unstyled)`
   }
 `;
 
-const AddAccountFooter = (props: MenuListComponentProps<SelectOption, false>) => {
+const AddAccountFooter = (props: MenuListProps<SelectOption, false>) => {
   const dispatch = useDispatch();
   const openAddAccounts = useCallback(() => {
     dispatch(openModal("MODAL_ADD_ACCOUNTS", null));
@@ -163,7 +166,9 @@ const AddAccountFooter = (props: MenuListComponentProps<SelectOption, false>) =>
   );
 };
 
-const getAccountFromProps = (props: SelectInputProps<SelectOption>): AccountLike | null => {
+const getAccountFromProps = (
+  props: ControlProps<SelectOption> | IndicatorsContainerProps<SelectOption>,
+): AccountLike | null => {
   const selectedOption = props.getValue()[0];
 
   if (!selectedOption) {
@@ -173,7 +178,7 @@ const getAccountFromProps = (props: SelectInputProps<SelectOption>): AccountLike
   return selectedOption.account ?? null;
 };
 
-const renderLeft = (props: SelectInputProps<SelectOption>) => {
+const renderLeft = (props: ControlProps<SelectOption>) => {
   const account = getAccountFromProps(props);
 
   if (!account) {
@@ -191,7 +196,7 @@ const renderLeft = (props: SelectInputProps<SelectOption>) => {
   );
 };
 
-const renderRight = (props: SelectInputProps<SelectOption>) => {
+const renderRight = (props: IndicatorsContainerProps<SelectOption>) => {
   const account = getAccountFromProps(props);
 
   if (!account) {
@@ -222,7 +227,7 @@ const renderRight = (props: SelectInputProps<SelectOption>) => {
   );
 };
 
-const defaultFilter = createFilter({
+const defaultFilter = createFilter<AccountLike>({
   stringify: ({ data: account }) => {
     const currency = getAccountCurrency(account);
     const name = getAccountName(account);
@@ -282,7 +287,6 @@ const SelectAccount = ({
   placeholder,
   autoFocus,
   filter,
-  disabledTooltipText,
   showAddAccount = false,
 }: Props) => {
   const { t } = useTranslation();
@@ -358,7 +362,6 @@ const SelectAccount = ({
       noOptionsMessage={({ inputValue }) =>
         t("common.selectAccountNoOption", { accountName: inputValue })
       }
-      disabledTooltipText={disabledTooltipText}
       menuPortalTarget={document.body}
       renderLeft={renderLeft}
       renderRight={renderRight}
@@ -387,6 +390,6 @@ const mapStateToProps = createStructuredSelector({
   accounts: shallowAccountsSelector,
 });
 
-const ConnectedSelectAccount = connect(mapStateToProps)(SelectAccount);
+const ConnectedSelectAccount = connect(mapStateToProps)(SelectAccount) as typeof SelectAccount;
 
 export default ConnectedSelectAccount;

--- a/src/renderer/components/SelectAccount.tsx
+++ b/src/renderer/components/SelectAccount.tsx
@@ -269,7 +269,7 @@ type OwnProps = {
   showAddAccount?: boolean;
   enforceHideEmptySubAccounts?: boolean;
   withSubAccounts?: boolean;
-} & SelectInputProps;
+} & Omit<SelectInputProps, "onChange">;
 
 type Props = OwnProps & {
   accounts: Account[];
@@ -390,6 +390,6 @@ const mapStateToProps = createStructuredSelector({
   accounts: shallowAccountsSelector,
 });
 
-const ConnectedSelectAccount = connect(mapStateToProps)(SelectAccount) as typeof SelectAccount;
+const ConnectedSelectAccount = connect(mapStateToProps)(SelectAccount);
 
 export default ConnectedSelectAccount;

--- a/src/renderer/components/SelectCurrency.tsx
+++ b/src/renderer/components/SelectCurrency.tsx
@@ -13,7 +13,14 @@ import {
   Props as OptionProps,
   Option,
 } from "@ledgerhq/react-ui/components/form/SelectInput/Option";
-import { components, SingleValueProps, ValueContainerProps } from "react-select";
+
+// TODO: update react-select just before V3 gets merged instead of relying on a nested version…
+import {
+  components,
+  SingleValueProps,
+  ValueContainerProps,
+  ControlProps,
+} from "@ledgerhq/react-ui/node_modules/react-select";
 
 // it seems this component only uses crypto and token currencies, not fiat ones
 // since it uses the 'id' prop that is not present on fiat currencies
@@ -31,7 +38,7 @@ type Props = {
   isCurrencyDisabled?: (currency: Currency) => boolean;
   isDisabled?: boolean;
   id?: string;
-  renderOptionOverride?: (option: OptionProps<Currency, false>) => JSX.Element;
+  renderOptionOverride?: (option: OptionProps<Currency>) => JSX.Element;
   renderValueOverride?: (option: ValueContainerProps<Currency, false>) => JSX.Element;
   stylesMap?: (styles: CreateStylesReturnType) => CreateStylesReturnType;
 };
@@ -93,7 +100,7 @@ const renderOption = (props: OptionProps<Currency, false>) => {
   return <Option {...props} render={({ data }) => <CurrencyOption currency={data} />} />;
 };
 
-const renderValue = (props: SingleValueProps<Currency>) => {
+const renderValue = (props: SingleValueProps<Currency, false>) => {
   return (
     <components.SingleValue {...props}>
       <CurrencyOption currency={props.getValue()[0]} isSelectedValue />
@@ -101,7 +108,7 @@ const renderValue = (props: SingleValueProps<Currency>) => {
   );
 };
 
-const renderLeft = (props: SelectInputProps<Currency>) => {
+const renderLeft = (props: ControlProps<Currency>) => {
   const value = props.getValue()[0];
   return (
     value && (


### PR DESCRIPTION
## 🦒 Context (issues, jira)

#### The problem:

1) `@ledgerhq/react-ui` relies on `react-select@5`
2) LLD V2 relies on `react-select@3`
3) Our select wrappers + typescript using the v3 types = 💥 

#### The solution:

Import the types from the `react-select` version nested inside the `react-ui` folder.
⚠️ This needs to be temporary and react-select will need to be properly updated once V3 fully replaces V2.

## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
