### PR TITLE
LL-7774 Fix broken access to USBTroubleshooting

### DIFF
--- a/src/renderer/components/ConnectTroubleshootingHelpButton.js
+++ b/src/renderer/components/ConnectTroubleshootingHelpButton.js
@@ -19,7 +19,7 @@ const ConnectTroubleshootingHelpButton = ({ buttonProps, textColor }: Props) => 
   const dispatch = useDispatch();
 
   const onStartTroubleshootingFlow = useCallback(() => {
-    history.push({ pathname: "USBTroubleshooting" });
+    history.push({ pathname: "/USBTroubleshooting" });
     dispatch(closeAllModal());
   }, [dispatch, history]);
 


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-7774


## 💻  Description / Demo (image or video)

The "Fix me" cta that triggers the USB Troubleshooting had no effect when we were inside an account screen. The reason for this was that the pathname user was taken as a relative path by `react-router-dom` so, while it worked on a top level path such as `/` or `accounts` it would try loading `account/USBTroubleshooting` if we were already in an account screen. Since that account doesn't exist, and we have some code to redirect to the account list screen in that case, it seemed like the cta did nothing.

https://github.com/LedgerHQ/ledger-live-desktop/blob/dcfec876d51432d37670d9094aa3efccc283bd66/src/renderer/screens/account/index.js#L91-L93

## How to test
- Without a device connected, go to the portfolio screen
- Launch the receive flow and reach the device step
- Wait until the timeout passes and shows the Fix me button
- Click on it
- It is expected that the USB Troubleshooting wizard is launched
- Repeat the same process while in a nested route such as a specific account screen.
- The result is expected to be the same.

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined here
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
