### PR TITLE
LL-9023 Fix token-id display

### DIFF
--- a/src/renderer/drawers/NFTViewerDrawer/CopiableField.js
+++ b/src/renderer/drawers/NFTViewerDrawer/CopiableField.js
@@ -27,6 +27,7 @@ const CopiableFieldContainer: ThemedComponent<{}> = styled.div`
 
 type CopiableFieldProps = {
   value: string,
+  children?: React$Node,
 };
 
 export function CopiableField({ value, children }: CopiableFieldProps) {

--- a/src/renderer/drawers/NFTViewerDrawer/CopiableField.js
+++ b/src/renderer/drawers/NFTViewerDrawer/CopiableField.js
@@ -6,12 +6,12 @@ import React from "react";
 import styled from "styled-components";
 import { GradientHover } from "~/renderer/drawers/OperationDetails/styledComponents";
 import CopyWithFeedback from "~/renderer/components/CopyWithFeedback";
-import { SplitAddress } from "~/renderer/components/OperationsList/AddressCell";
 
 const CopiableFieldContainer: ThemedComponent<{}> = styled.div`
   display: inline-flex;
   position: relative;
   max-width: 100%;
+  min-width: 12ex;
 
   ${GradientHover} {
     display: none;
@@ -25,24 +25,15 @@ const CopiableFieldContainer: ThemedComponent<{}> = styled.div`
   }
 `;
 
-const HashContainer: ThemedComponent<{}> = styled.div`
-  word-break: break-all;
-  user-select: text;
-  width: 100%;
-  min-width: 100px;
-  user-select: none;
-`;
-
 type CopiableFieldProps = {
   value: string,
 };
 
-export function CopiableField({ value }: CopiableFieldProps) {
+export function CopiableField({ value, children }: CopiableFieldProps) {
+  console.log(value);
   return (
     <CopiableFieldContainer>
-      <HashContainer>
-        <SplitAddress value={value} ff="Inter|Regular" />
-      </HashContainer>
+      {children}
       <GradientHover>
         <CopyWithFeedback text={value} />
       </GradientHover>

--- a/src/renderer/drawers/NFTViewerDrawer/CopiableField.js
+++ b/src/renderer/drawers/NFTViewerDrawer/CopiableField.js
@@ -31,7 +31,6 @@ type CopiableFieldProps = {
 };
 
 export function CopiableField({ value, children }: CopiableFieldProps) {
-  console.log(value);
   return (
     <CopiableFieldContainer>
       {children}

--- a/src/renderer/drawers/NFTViewerDrawer/index.js
+++ b/src/renderer/drawers/NFTViewerDrawer/index.js
@@ -21,6 +21,7 @@ import { useNftMetadata } from "@ledgerhq/live-common/lib/nft/NftMetadataProvide
 import { space, layout, position } from "styled-system";
 import { openModal } from "~/renderer/actions/modals";
 import { setDrawer } from "~/renderer/drawers/Provider";
+import { SplitAddress } from "~/renderer/components/OperationsList/AddressCell";
 
 const NFTViewerDrawerContainer = styled.div`
   flex: 1;
@@ -81,6 +82,14 @@ const NFTAttributes = styled.div`
   margin: 24px 0px;
   display: flex;
   flex-direction: column;
+`;
+
+const HashContainer: ThemedComponent<{}> = styled.div`
+  word-break: break-all;
+  user-select: text;
+  width: 100%;
+  min-width: 100px;
+  user-select: none;
 `;
 
 function NFTAttribute({
@@ -221,7 +230,11 @@ export function NFTViewerDrawer({
               {t("NFT.viewer.attributes.tokenAddress")}
             </Text>
             <Text lineHeight="15.73px" fontSize={4} color="palette.text.shade100" fontWeight="600">
-              <CopiableField value={nft.collection.contract} />
+              <CopiableField value={nft.collection.contract}>
+                <HashContainer>
+                  <SplitAddress value={nft.collection.contract} ff="Inter|Regular" />
+                </HashContainer>
+              </CopiableField>
             </Text>
             <Separator />
             <Text
@@ -234,7 +247,7 @@ export function NFTViewerDrawer({
               {t("NFT.viewer.attributes.tokenId")}
             </Text>
             <Text lineHeight="15.73px" fontSize={4} color="palette.text.shade100" fontWeight="600">
-              <CopiableField value={nft.tokenId} />
+              <CopiableField value={nft.tokenId}>{nft.tokenId}</CopiableField>
             </Text>
             {nft.collection.standard === "ERC1155" ? (
               <React.Fragment>

--- a/src/renderer/drawers/NFTViewerDrawer/index.js
+++ b/src/renderer/drawers/NFTViewerDrawer/index.js
@@ -84,7 +84,7 @@ const NFTAttributes = styled.div`
   flex-direction: column;
 `;
 
-const HashContainer: ThemedComponent<{}> = styled.div`
+const HashContainer = styled.div`
   word-break: break-all;
   user-select: text;
   width: 100%;

--- a/src/renderer/drawers/NFTViewerDrawer/index.js
+++ b/src/renderer/drawers/NFTViewerDrawer/index.js
@@ -137,11 +137,7 @@ type NFTViewerDrawerProps = {
   onRequestClose: () => void,
 };
 
-export function NFTViewerDrawer({
-  account,
-  nftId,
-  height,
-}: NFTViewerDrawerProps) {
+export function NFTViewerDrawer({ account, nftId, height }: NFTViewerDrawerProps) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 

--- a/src/renderer/drawers/NFTViewerDrawer/index.js
+++ b/src/renderer/drawers/NFTViewerDrawer/index.js
@@ -140,8 +140,6 @@ type NFTViewerDrawerProps = {
 export function NFTViewerDrawer({
   account,
   nftId,
-  isOpen,
-  onRequestClose,
   height,
 }: NFTViewerDrawerProps) {
   const { t } = useTranslation();
@@ -247,7 +245,16 @@ export function NFTViewerDrawer({
               {t("NFT.viewer.attributes.tokenId")}
             </Text>
             <Text lineHeight="15.73px" fontSize={4} color="palette.text.shade100" fontWeight="600">
-              <CopiableField value={nft.tokenId}>{nft.tokenId}</CopiableField>
+              <CopiableField value={nft.tokenId}>
+                {// only needed for very long tokenIds but works with any length > 4
+                nft.tokenId?.length >= 4 ? (
+                  <HashContainer>
+                    <SplitAddress value={nft.tokenId} />
+                  </HashContainer>
+                ) : (
+                  nft.tokenId
+                )}
+              </CopiableField>
             </Text>
             {nft.collection.standard === "ERC1155" ? (
               <React.Fragment>


### PR DESCRIPTION
## 🦒 Context (issues, jira)
[LL-9023]

The issue was happening because we were assuming that any copiable field would be addresses and we were using a specific component for hash adresses inside the copiable field component. The PR makes the Copiable field component generic for any children and moves the logic for addresses up in the tree.


## 💻  Description / Demo (image or video)
![fix-token-id-display](https://user-images.githubusercontent.com/6013294/149166182-02305bf6-d90b-411b-8768-9725c7ef670a.gif)


## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-8694]: https://ledgerhq.atlassian.net/browse/LL-8694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LL-9023]: https://ledgerhq.atlassian.net/browse/LL-9023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ