### PR TITLE
LL-8880 Plugin autoupdate feat

### DIFF
--- a/src/renderer/modals/SignTransaction/steps/GenericStepConnectDevice.js
+++ b/src/renderer/modals/SignTransaction/steps/GenericStepConnectDevice.js
@@ -49,6 +49,7 @@ export default function StepConnectDevice({
   onTransactionSigned,
   onTransactionError,
   dependencies,
+  requireLatestFirmware,
 }: {
   transitionTo: string => void,
   account: ?AccountLike,
@@ -59,6 +60,7 @@ export default function StepConnectDevice({
   onTransactionError: Error => void,
   onTransactionSigned: SignedOperation => void,
   dependencies?: AppRequest[],
+  requireLatestFirmware?: boolean,
 }) {
   const tokenCurrency = account && account.type === "TokenAccount" && account.token;
 
@@ -75,6 +77,7 @@ export default function StepConnectDevice({
         transaction,
         status,
         dependencies,
+        requireLatestFirmware,
       }}
       Result={Result}
       onResult={({ signedOperation, transactionSignError }) => {

--- a/src/renderer/modals/SignTransaction/steps/GenericStepConnectDevice.js
+++ b/src/renderer/modals/SignTransaction/steps/GenericStepConnectDevice.js
@@ -14,6 +14,7 @@ import type {
   TransactionStatus,
   SignedOperation,
 } from "@ledgerhq/live-common/lib/types";
+import type { AppRequest } from "@ledgerhq/live-common/lib/hw/actions/app";
 import { command } from "~/renderer/commands";
 import { getEnv } from "@ledgerhq/live-common/lib/env";
 import { mockedEventEmitter } from "~/renderer/components/debug/DebugMock";
@@ -47,6 +48,7 @@ export default function StepConnectDevice({
   transitionTo,
   onTransactionSigned,
   onTransactionError,
+  dependencies,
 }: {
   transitionTo: string => void,
   account: ?AccountLike,
@@ -56,6 +58,7 @@ export default function StepConnectDevice({
   status: TransactionStatus,
   onTransactionError: Error => void,
   onTransactionSigned: SignedOperation => void,
+  dependencies?: AppRequest[],
 }) {
   const tokenCurrency = account && account.type === "TokenAccount" && account.token;
 
@@ -71,6 +74,7 @@ export default function StepConnectDevice({
         appName: useApp,
         transaction,
         status,
+        dependencies,
       }}
       Result={Result}
       onResult={({ signedOperation, transactionSignError }) => {

--- a/src/renderer/modals/SignTransaction/steps/StepConnectDevice.js
+++ b/src/renderer/modals/SignTransaction/steps/StepConnectDevice.js
@@ -30,6 +30,7 @@ export default function StepConnectDevice({
         onTransactionError={onTransactionError}
         onTransactionSigned={onTransactionSigned}
         dependencies={dependencies}
+        requireLatestFirmware
       />
     </>
   );

--- a/src/renderer/modals/SignTransaction/steps/StepConnectDevice.js
+++ b/src/renderer/modals/SignTransaction/steps/StepConnectDevice.js
@@ -1,6 +1,7 @@
 // @flow
 import React from "react";
 import TrackPage from "~/renderer/analytics/TrackPage";
+import { getMainAccount } from "@ledgerhq/live-common/lib/account";
 import GenericStepConnectDevice from "./GenericStepConnectDevice";
 import type { StepProps } from "../types";
 
@@ -14,6 +15,8 @@ export default function StepConnectDevice({
   onTransactionError,
   onTransactionSigned,
 }: StepProps) {
+  // Nb setting the mainAccount as a dependency will ensure latest versions of plugins.
+  const dependencies = [getMainAccount(account, parentAccount)];
   return (
     <>
       <TrackPage category="Sign Transaction Flow" name="Step ConnectDevice" />
@@ -26,6 +29,7 @@ export default function StepConnectDevice({
         transitionTo={transitionTo}
         onTransactionError={onTransactionError}
         onTransactionSigned={onTransactionSigned}
+        dependencies={dependencies}
       />
     </>
   );


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-8880


## 💻  Description / Demo (image or video)
<img width="1364" alt="image" src="https://user-images.githubusercontent.com/4631227/149169159-77f80afb-7db4-4062-8ff9-f1c1a60c3545.png">

This allows any device action within the paradigm of the web platform player (discover section) to request having the latest firmware and also require the latest app and plugin versions. This means that if an update for the Paraswap app is available I should see the same behavior as for the Swap flow. The uninstallation of all plugins, uninstall ETH, install Eth, and install latest version of all plugins

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  How to test this
There are many cases covered on the task linked above, but the overall expectation is that if there's an update available I should get it, and if I'm not in the latest firmware I should be blocked from signing a transaction. Access to the live apps is not controlled by any specific device parameter, **only the signing of a transaction.**

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
