### PR TITLE
LL-8948 - Regions default behavior update + locale selectors cleanup

### DIFF
--- a/src/config/languages.js
+++ b/src/config/languages.js
@@ -25,5 +25,7 @@ export const allLanguages = [
 
 export const prodStableLanguages = ["en", "fr", "es", "ru", "zh", "de", "tr", "ja", "ko"];
 
+export const pushedLanguages = ["fr", "ru"];
+
 export const getLanguages = () =>
   getEnv("EXPERIMENTAL_LANGUAGES") ? allLanguages : prodStableLanguages;

--- a/src/config/languages.js
+++ b/src/config/languages.js
@@ -29,3 +29,25 @@ export const pushedLanguages = ["fr", "ru"];
 
 export const getLanguages = () =>
   getEnv("EXPERIMENTAL_LANGUAGES") ? allLanguages : prodStableLanguages;
+
+export const defaultLocaleForLanguage = {
+  de: "de-DE",
+  el: "el-GR",
+  en: "en-US",
+  es: "es-ES",
+  fi: "fi-FI",
+  fr: "fr-FR",
+  hu: "hu-HU",
+  it: "it-IT",
+  ja: "ja-JP",
+  ko: "ko-KR",
+  nl: "nl-NL",
+  no: "no-NO",
+  pl: "pl-PL",
+  pt: "pt-PT",
+  ru: "ru-RU",
+  sr: "sr-SR",
+  sv: "sv-SV",
+  tr: "tr-TR",
+  zh: "zh-CN",
+};

--- a/src/renderer/actions/settings.js
+++ b/src/renderer/actions/settings.js
@@ -55,7 +55,6 @@ export const setCounterValue = (counterValue: string) =>
   });
 export const setLanguage = (language: ?string) => saveSettings({ language });
 export const setTheme = (theme: ?string) => saveSettings({ theme });
-export const setRegion = (region: ?string) => saveSettings({ region });
 export const setLocale = (locale: string) => saveSettings({ locale });
 export const setUSBTroubleshootingIndex = (USBTroubleshootingIndex?: number) =>
   saveSettings({ USBTroubleshootingIndex });

--- a/src/renderer/analytics/segment.js
+++ b/src/renderer/analytics/segment.js
@@ -8,9 +8,10 @@ import { getSystemLocale } from "~/helpers/systemLocale";
 import user from "~/helpers/user";
 import {
   sidebarCollapsedSelector,
-  langAndRegionSelector,
   shareAnalyticsSelector,
   lastSeenDeviceSelector,
+  localeSelector,
+  languageSelector,
 } from "~/renderer/reducers/settings";
 import type { State } from "~/renderer/reducers";
 
@@ -38,7 +39,8 @@ const getContext = _store => ({
 
 const extraProperties = store => {
   const state: State = store.getState();
-  const { language, region } = langAndRegionSelector(state);
+  const language = languageSelector(state);
+  const region = (localeSelector(state).split("-")[1] || "").toUpperCase() || null;
   const systemLocale = getSystemLocale();
   const device = lastSeenDeviceSelector(state);
   const deviceInfo = device

--- a/src/renderer/components/IsSystemLanguageAvailable.js
+++ b/src/renderer/components/IsSystemLanguageAvailable.js
@@ -4,7 +4,8 @@ import { useDispatch, useSelector } from "react-redux";
 
 import { openModal } from "~/renderer/actions/modals";
 import { getSystemLocale } from "~/helpers/systemLocale";
-import { languageSelector, pushedLanguages } from "~/renderer/reducers/settings";
+import { languageSelector } from "~/renderer/reducers/settings";
+import { pushedLanguages } from "~/config/languages";
 
 // To reset os language proposition, change this date !
 const lastAskedLanguageAvailable = "2021-09-23";

--- a/src/renderer/components/Onboarding/LangSwitcher.js
+++ b/src/renderer/components/Onboarding/LangSwitcher.js
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { setLanguage } from "~/renderer/actions/settings";
 import useTheme from "~/renderer/hooks/useTheme";
 import { rgba } from "~/renderer/styles/helpers";
-import { langAndRegionSelector } from "~/renderer/reducers/settings";
+import { languageSelector } from "~/renderer/reducers/settings";
 import { useDispatch, useSelector } from "react-redux";
 import { languageLabels } from "~/renderer/screens/settings/sections/General/LanguageSelect";
 
@@ -104,7 +104,7 @@ const styleFn = theme => ({
 const LangSwitcher = () => {
   const theme = useTheme();
   const styles = useMemo(() => styleFn(theme), [theme]);
-  const { language } = useSelector(langAndRegionSelector);
+  const language = useSelector(languageSelector);
   const dispatch = useDispatch();
   const { i18n } = useTranslation();
 

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -14,11 +14,10 @@ import type { CryptoCurrency, Currency } from "@ledgerhq/live-common/lib/types";
 import type { DeviceModelInfo } from "@ledgerhq/live-common/lib/types/manager";
 import type { PortfolioRange } from "@ledgerhq/live-common/lib/portfolio/v2/types";
 import { getEnv } from "@ledgerhq/live-common/lib/env";
-import { getLanguages } from "~/config/languages";
+import { getLanguages, defaultLocaleForLanguage } from "~/config/languages";
 import type { State } from ".";
 import { osLangAndRegionSelector } from "~/renderer/reducers/application";
 import regionsByKey from "../screens/settings/sections/General/regions.json";
-
 export type CurrencySettings = {
   confirmationsNb: number,
 };
@@ -73,6 +72,7 @@ export type SettingsState = {
   latestFirmware: any,
   language: ?string,
   theme: ?string,
+  /** DEPRECATED, use field `locale` instead */
   region: ?string,
   locale: ?string,
   orderAccounts: string,
@@ -132,22 +132,25 @@ const defaultsForCurrency: Currency => CurrencySettings = crypto => {
   };
 };
 
-const DEFAULT_LOCALE = "en-US";
+const DEFAULT_LANGUAGE_LOCALE = "en";
+export const getInitialLanguageLocale = (fallbackLocale: string = DEFAULT_LANGUAGE_LOCALE) => {
+  const detectedLanguage = window.navigator?.language || fallbackLocale;
+  return getLanguages().find(lang => detectedLanguage.startsWith(lang)) || fallbackLocale;
+};
 
-export const pushedLanguages = ["fr", "ru"];
-export const defaultLanguage: () => string = () => {
-  // Nb If the os language is in the list [fr, ru] (LL-7027) default to it
-  const detectedLanguage = window.navigator?.language || "en";
-  return pushedLanguages.find(lang => detectedLanguage.startsWith(lang)) || "en";
+const DEFAULT_LOCALE = "en-US";
+export const getInitialLocale = () => {
+  const initialLanguageLocale = getInitialLanguageLocale();
+  return defaultLocaleForLanguage[initialLanguageLocale] || DEFAULT_LOCALE;
 };
 
 const INITIAL_STATE: SettingsState = {
   hasCompletedOnboarding: false,
   counterValue: "USD",
-  language: defaultLanguage(),
+  language: getInitialLanguageLocale(),
   theme: null,
   region: null,
-  locale: DEFAULT_LOCALE,
+  locale: getInitialLocale(),
   orderAccounts: "balance|desc",
   countervalueFirst: false,
   autoLockTimeout: 10,
@@ -367,7 +370,7 @@ export const lastUsedVersionSelector = (state: State): string => state.settings.
 
 export const userThemeSelector = (state: State): ?string => state.settings.theme;
 
-export const userLangAndRegionSelector = (
+const userLangAndRegionSelector = (
   state: State,
 ): ?{ language: string, region: ?string, useSystem: boolean } => {
   const languages = getLanguages();
@@ -376,6 +379,20 @@ export const userLangAndRegionSelector = (
     return { language, region, useSystem: false };
   }
 };
+
+export const langAndRegionSelector: OutputSelector<State, void, LangAndRegion> = createSelector(
+  userLangAndRegionSelector,
+  osLangAndRegionSelector,
+  (userLang, osLang) => {
+    return userLang || osLang;
+  },
+);
+
+/** Use this for translations */
+export const languageSelector: OutputSelector<State, void, string> = createSelector(
+  langAndRegionSelector,
+  o => o.language,
+);
 
 const isValidRegionLocale = (locale: string) => {
   return regionsByKey.hasOwnProperty(locale);
@@ -396,19 +413,7 @@ const localeFallbackToLanguageSelector = (state: State): { locale: string } => {
   return { locale: language || DEFAULT_LOCALE };
 };
 
-export const langAndRegionSelector: OutputSelector<State, void, LangAndRegion> = createSelector(
-  userLangAndRegionSelector,
-  osLangAndRegionSelector,
-  (userLang, osLang) => {
-    return userLang || osLang;
-  },
-);
-
-export const languageSelector: OutputSelector<State, void, string> = createSelector(
-  langAndRegionSelector,
-  o => o.language,
-);
-
+/** Use this for number and dates formatting. */
 export const localeSelector: OutputSelector<State, void, string> = createSelector(
   localeFallbackToLanguageSelector,
   o => o.locale,

--- a/src/renderer/screens/settings/sections/General/LanguageSelect.js
+++ b/src/renderer/screens/settings/sections/General/LanguageSelect.js
@@ -6,7 +6,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { allLanguages, prodStableLanguages } from "~/config/languages";
 import useEnv from "~/renderer/hooks/useEnv";
 import { setLanguage } from "~/renderer/actions/settings";
-import { langAndRegionSelector } from "~/renderer/reducers/settings";
+import { useSystemLanguageSelector, languageSelector } from "~/renderer/reducers/settings";
 import Select from "~/renderer/components/Select";
 import Track from "~/renderer/analytics/Track";
 
@@ -36,7 +36,8 @@ type LangKeys = $Keys<typeof languageLabels>;
 type ChangeLangArgs = { value: LangKeys, label: string };
 
 const LanguageSelect = () => {
-  const { useSystem, language } = useSelector(langAndRegionSelector);
+  const useSystem = useSelector(useSystemLanguageSelector);
+  const language = useSelector(languageSelector);
   const { t, i18n } = useTranslation();
   const dispatch = useDispatch();
 

--- a/src/renderer/screens/settings/sections/General/RegionSelect.js
+++ b/src/renderer/screens/settings/sections/General/RegionSelect.js
@@ -38,7 +38,10 @@ const RegionSelect = () => {
     [dispatch],
   );
 
-  const currentRegionOption = useMemo(() => (regionsOptions.find(o => o.value === locale) || getRegionOption(locale)), [locale]);
+  const currentRegionOption = useMemo(
+    () => regionsOptions.find(o => o.value === locale) || getRegionOption(locale),
+    [locale],
+  );
 
   return (
     <>

--- a/src/renderer/screens/settings/sections/General/RegionSelect.js
+++ b/src/renderer/screens/settings/sections/General/RegionSelect.js
@@ -28,9 +28,8 @@ const RegionSelect = () => {
   const locale = useSelector(localeSelector);
 
   const handleChangeRegion = useCallback(
-    ({ locale, region }: { locale: string, region: string }) => {
+    ({ locale }: { locale: string }) => {
       moment.locale(locale);
-      dispatch(setRegion(region));
       dispatch(setLocale(locale));
     },
     [dispatch],

--- a/src/renderer/screens/settings/sections/General/RegionSelect.js
+++ b/src/renderer/screens/settings/sections/General/RegionSelect.js
@@ -38,7 +38,7 @@ const RegionSelect = () => {
     [dispatch],
   );
 
-  const currentRegionOption = useMemo(() => getRegionOption(locale), [locale]);
+  const currentRegionOption = useMemo(() => (regionsOptions.find(o => o.value === locale) || getRegionOption(locale)), [locale]);
 
   return (
     <>

--- a/src/renderer/screens/settings/sections/General/RegionSelect.js
+++ b/src/renderer/screens/settings/sections/General/RegionSelect.js
@@ -1,26 +1,29 @@
 // @flow
 
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import moment from "moment";
 import { upperFirst } from "lodash";
-import { setLocale, setRegion } from "~/renderer/actions/settings";
+import { setLocale } from "~/renderer/actions/settings";
 import { localeSelector } from "~/renderer/reducers/settings";
 import Select from "~/renderer/components/Select";
 import Track from "~/renderer/analytics/Track";
 import regionsByKey from "./regions.json";
 
-const regions = Object.keys(regionsByKey)
-  .map(key => {
-    const [language, region] = key.split("-");
-    const locale = key;
-    const languageDisplayName = new window.Intl.DisplayNames([locale], { type: "language" }).of(
-      language,
-    );
-    const regionDisplayName = new window.Intl.DisplayNames([locale], { type: "region" }).of(region);
-    const label = `${upperFirst(regionDisplayName)} (${upperFirst(languageDisplayName)})`;
-    return { value: key, locale: key, language, region, label };
-  })
+const getRegionOption = locale => {
+  const [language, region = ""] = locale.split("-");
+  const languageDisplayName = new window.Intl.DisplayNames([locale], { type: "language" }).of(
+    language,
+  );
+  const regionDisplayName = new window.Intl.DisplayNames([locale], { type: "region" }).of(region);
+  const labelPrefix = upperFirst(regionDisplayName);
+  const labelSuffix = regionDisplayName ? ` (${upperFirst(languageDisplayName)})` : "";
+  const label = `${labelPrefix}${labelSuffix}`;
+  return { value: locale, locale, language, region, label };
+};
+
+const regionsOptions = Object.keys(regionsByKey)
+  .map(getRegionOption)
   .sort((a, b) => a.label.localeCompare(b.label));
 
 const RegionSelect = () => {
@@ -35,18 +38,18 @@ const RegionSelect = () => {
     [dispatch],
   );
 
-  const currentRegion = regions.find(item => item.locale === locale) || regions[0];
+  const currentRegionOption = useMemo(() => getRegionOption(locale), [locale]);
 
   return (
     <>
-      <Track onUpdate event="RegionSelectChange" currentRegion={currentRegion.region} />
+      <Track onUpdate event="RegionSelectChange" currentRegion={currentRegionOption.region} />
       <Select
         small
         minWidth={260}
         onChange={handleChangeRegion}
         renderSelected={item => item && item.name}
-        value={currentRegion}
-        options={regions}
+        value={currentRegionOption}
+        options={regionsOptions}
       />
     </>
   );

--- a/src/renderer/screens/settings/sections/General/index.js
+++ b/src/renderer/screens/settings/sections/General/index.js
@@ -4,7 +4,6 @@ import React from "react";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { EXPERIMENTAL_MARKET_INDICATOR_SETTINGS } from "~/config/constants";
-import { langAndRegionSelector } from "~/renderer/reducers/settings";
 import TrackPage from "~/renderer/analytics/TrackPage";
 import { SettingsSectionBody as Body, SettingsSectionRow as Row } from "../../SettingsSection";
 import CounterValueSelect from "./CounterValueSelect";
@@ -20,7 +19,6 @@ import CarouselVisibility from "./CarouselVisibility";
 import { hasPasswordSelector } from "~/renderer/reducers/application";
 
 const SectionGeneral = () => {
-  const { useSystem } = useSelector(langAndRegionSelector);
   const hasPassword = useSelector(hasPasswordSelector);
   const { t } = useTranslation();
 
@@ -38,11 +36,10 @@ const SectionGeneral = () => {
         <Row title={t("settings.display.language")} desc={t("settings.display.languageDesc")}>
           <LanguageSelect />
         </Row>
-        {useSystem ? null : (
-          <Row title={t("settings.display.region")} desc={t("settings.display.regionDesc")}>
-            <RegionSelect />
-          </Row>
-        )}
+
+        <Row title={t("settings.display.region")} desc={t("settings.display.regionDesc")}>
+          <RegionSelect />
+        </Row>
 
         <Row title={t("settings.display.theme")} desc={t("settings.display.themeDesc")}>
           <ThemeSelect />


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LL-8948]


## 💻  Description / Demo (image or video)

When a user opens Ledger Live for the first time, the "region" locale (`settings.locale`) now defaults to the system's locale IF it is one of the supported languages, falling back to "en-US".
That way we avoid weird initial setups where for instance the user's system language is not available so translations are in english but formatted dates & numbers are in his system language.

I also refactored some of the language & region selectors, which I actually should have done in my previous PR on this topic https://github.com/LedgerHQ/ledger-live-desktop/pull/4308.
The result of that refactoring is that the logic for selecting the language locale (and falling back to a default) and selecting the region locale (and falling back to a default) is now in one place (the `reducers/settings.js` file), and legacy functions that were built when the logic for "language" and "region" locales were more tightly coupled are now removed (for instance `userLangAndRegionSelector`), hopefully saving us from confusion in the future when reading these functions names.

**I would advise reviewers to check the list of commits and their changes if you want more context and explanations for each change (in commit messages), It will probably be more digestible than checking the entire diff at once** 


## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-8948]: https://ledgerhq.atlassian.net/browse/LL-8948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ