### PR TITLE
LL-8941 Release USB hold after 5 seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@ledgerhq/errors": "6.10.0",
     "@ledgerhq/hw-transport": "6.20.0",
     "@ledgerhq/hw-transport-http": "6.20.0",
-    "@ledgerhq/hw-transport-node-hid-singleton": "6.20.0",
+    "@ledgerhq/hw-transport-node-hid-singleton": "6.23.0",
     "@ledgerhq/ledger-core": "6.14.5",
     "@ledgerhq/live-common": "^21.26.1",
     "@ledgerhq/logs": "6.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,10 +2442,10 @@
     "@ledgerhq/logs" "^6.10.0"
     node-hid "2.1.1"
 
-"@ledgerhq/hw-transport-node-hid-singleton@6.20.0":
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid-singleton/-/hw-transport-node-hid-singleton-6.20.0.tgz#b6991cc5fe0cb0e40e967d1ba74f1fcf1f8292ec"
-  integrity sha512-VVua1hG+aDAueiTzWaS+PQc0z+X/WjUD9GuFtwE6jBE5FGGz5IbL5hsiVujyWg+nsmrjfp72YmoHv8wWt+sA+w==
+"@ledgerhq/hw-transport-node-hid-singleton@6.23.0":
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-hid-singleton/-/hw-transport-node-hid-singleton-6.23.0.tgz#383e2a4b1b980d680a2183ec33cf0493a4d2df13"
+  integrity sha512-YnqzvmPh6iNAEjGQjxbaKfNUyQwE7ReACRlkuiIxIO9yGrevV2LUSVzCC7JYTR+5A4NjSWMVoKX5qhO8EX82vA==
   dependencies:
     "@ledgerhq/devices" "^6.20.0"
     "@ledgerhq/errors" "^6.10.0"


### PR DESCRIPTION
<img width="775" alt="image" src="https://user-images.githubusercontent.com/4631227/149750512-a4177e9d-b55e-4399-aa16-27ae1f64c91d.png">


## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-8941


## 💻  Description / Demo (image or video)

This is just a bump of the singleton transport in order to benefit from the USB connection release introduced in 2.23.0
When we manage to get this merged it would allow https://github.com/MetaMask/metamask-extension or any third party application relying on the WebHID transport (or the node-hid ones for that matter) to access a device even after LLD takes a hold of the connection.

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined here
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->

## 🖤  How to test
First a foreword. The singleton connection ownership issue was only present as far as I know in Mac at this point, meaning that testing should (feel free to correct me) focus mostly on this. It is important to understand that there's a 5 second timeout before we release the control over the USB connection, 5 seconds after the last APDU exchange.

### I'm too quick case
- Launch LLD
- Access a device flow, any flow that requires APDU exchanges (manager, receive, send, add accounts)
- After your last interaction quickly switch to Chrome on https://repl.ledger.tools/ and try to connect to the device
- If done under 5 seconds it's expected to get an error message `NotAllowedError: Failed to open the device.`
- Try connecting after a few second, it is expected the connection succeeds.

### Normal case
- Launch LLD
- Access the manager
- Enter an app in your device
- It is expected that the LLD shows a screen saying another application is open in your device
- Allow a few seconds for the timeout to be reached.
- Switch to Chrome on https://repl.ledger.tools/ and try to connect to the device.
- It should connect