### PR TITLE
LL-9028 Handle new lastSeenDevice event on DeviceActions

### DIFF
--- a/src/renderer/analytics/segment.js
+++ b/src/renderer/analytics/segment.js
@@ -47,7 +47,7 @@ const extraProperties = store => {
     ? {
         modelId: device.modelId,
         deviceVersion: device.deviceInfo.version,
-        appLength: device.apps.length,
+        appLength: device.apps?.length,
       }
     : {};
 

--- a/src/renderer/components/DeviceAction/index.js
+++ b/src/renderer/components/DeviceAction/index.js
@@ -6,7 +6,7 @@ import { connect } from "react-redux";
 import type { Device, Action } from "@ledgerhq/live-common/lib/hw/actions/types";
 import { OutdatedApp, LatestFirmwareVersionRequired } from "@ledgerhq/live-common/lib/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
-import { setPreferredDeviceModel } from "~/renderer/actions/settings";
+import { setPreferredDeviceModel, setLastSeenDeviceInfo } from "~/renderer/actions/settings";
 import { preferredDeviceModelSelector } from "~/renderer/reducers/settings";
 import type { DeviceModelId } from "@ledgerhq/devices";
 import AutoRepair from "~/renderer/components/AutoRepair";
@@ -88,6 +88,7 @@ const DeviceAction = <R, H, P>({
     allowManagerRequestedWording,
     requestQuitApp,
     deviceInfo,
+    latestFirmware,
     repairModalOpened,
     requestOpenApp,
     allowOpeningRequestedWording,
@@ -122,6 +123,17 @@ const DeviceAction = <R, H, P>({
       dispatch(setPreferredDeviceModel(modelId));
     }
   }, [dispatch, modelId, preferredDeviceModel]);
+
+  useEffect(() => {
+    if (deviceInfo) {
+      const lastSeenDevice = {
+        modelId: device.modelId,
+        deviceInfo,
+      };
+
+      dispatch(setLastSeenDeviceInfo({ lastSeenDevice, latestFirmware }));
+    }
+  }, [dispatch, device, deviceInfo, latestFirmware]);
 
   if (displayUpgradeWarning && appAndVersion) {
     return renderWarningOutdated({ appName: appAndVersion.name, passWarning });

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -275,7 +275,10 @@ const handlers: Object = {
     { payload }: { payload: { lastSeenDevice: DeviceModelInfo, latestFirmware: any } },
   ) => ({
     ...state,
-    lastSeenDevice: payload.lastSeenDevice,
+    lastSeenDevice: {
+      ...(state.lastSeenDevice || {}),
+      ...payload.lastSeenDevice,
+    },
     latestFirmware: payload.latestFirmware,
   }),
   SET_DEEPLINK_URL: (state: SettingsState, { payload: deepLinkUrl }) => ({

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -275,10 +275,7 @@ const handlers: Object = {
     { payload }: { payload: { lastSeenDevice: DeviceModelInfo, latestFirmware: any } },
   ) => ({
     ...state,
-    lastSeenDevice: {
-      ...(state.lastSeenDevice || {}),
-      ...(payload.lastSeenDevice || {}),
-    },
+    lastSeenDevice: Object.assign({}, state.lastSeenDevice, payload.lastSeenDevice),
     latestFirmware: payload.latestFirmware,
   }),
   SET_DEEPLINK_URL: (state: SettingsState, { payload: deepLinkUrl }) => ({

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -277,7 +277,7 @@ const handlers: Object = {
     ...state,
     lastSeenDevice: {
       ...(state.lastSeenDevice || {}),
-      ...payload.lastSeenDevice,
+      ...(payload.lastSeenDevice || {}),
     },
     latestFirmware: payload.latestFirmware,
   }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -7632,7 +7632,7 @@ colors@1.0.3:
 
 colors@1.4.0, colors@^1.1.2, colors@^1.3.2, colors@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 colorspace@1.1.x:
@@ -19654,7 +19654,22 @@ winston-transport@^4.3.0, winston-transport@^4.4.2:
     readable-stream "^3.4.0"
     triple-beam "^1.2.0"
 
-winston@^3.2.1, winston@^3.4.0:
+winston@^3.2.1:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz"
+  integrity sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==
+  dependencies:
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.1.0"
+    is-stream "^2.0.0"
+    logform "^2.2.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
+
+winston@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/winston/-/winston-3.4.0.tgz#7080f24b02a0684f8a37f9d5c6afb1ac23e95b84"
   integrity sha512-FqilVj+5HKwCfIHQzMxrrd5tBIH10JTS3koFGbLVWBODjiIYq7zir08rFyBT4rrTYG/eaTqDcfSIbcjSM78YSw==


### PR DESCRIPTION
> There's a less invasive proposal on live-common that will run the firmware check without blocking, here https://github.com/LedgerHQ/ledger-live-common/pull/1637

## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-9028


## 💻  Description / Demo (image or video)

https://user-images.githubusercontent.com/4631227/150198199-50f384f0-8a8d-4717-850a-a0b802354591.mov



Starting from 21.27.0 of live-common we are emitting (in some cases) a new event in order to update more granular the last seen device information stored by the app. We use this information, alongside the `latestFirmware` available for this device, both for analytics and for handling the display of the firmware update banner.

This means we could now detect an outdated device without the need for the user to go into the manager.
Driving more userflow into the latest version. As you can see in the video, I'm being shown the firmware update banner after going through a receive flow.

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined here
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!


## 🖤  How to test

### On a device that is on the latest firmware on the selected provider
- On a fresh LLD install without connecting to the manager start a device flow
- Make sure the device is on the dashboard since this is only triggered before the `openApp` case
- After completing the flow (add accounts for instance) open your app.json file
- It is expected that there will be some data for `lastSeenDevice`

### On a device that has an available firmware update on the selected provider
- After starting any device flow, it is expected that the banner will automatically appear

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
