### PR TITLE
8190/remove fw requirement for swap

### DIFF
--- a/src/renderer/screens/exchange/Swap2/Form/ExchangeDrawer/SwapAction.js
+++ b/src/renderer/screens/exchange/Swap2/Form/ExchangeDrawer/SwapAction.js
@@ -118,7 +118,6 @@ export default function SwapAction({
         transaction,
         status,
         device: deviceRef,
-        requireLatestFirmware: true,
         userId: providerKYC?.id,
       }}
       onResult={({ initSwapResult, initSwapError, ...rest }) => {


### PR DESCRIPTION
Currently, users without an old firmware version are not able to do a swap because the swap requires the latest firmware version.
This creates problems:
- for every new FW version, swappers a forced to update their FW
- even if the stack is still operational, Live forces the user to upgrade FW despite having a stack that does work. 
- pushes down addressable swap userbase to 0 the moment there is a new FW version

This PR simply removes the requirement for swap by deleting the line that creates such constrain as per https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/3518464073/SWAP-FW-UPDATE+-+Problem+intro


## 🦒 Context (issues, jira)
[LL-8190](https://ledgerhq.atlassian.net/browse/LL-8190)


## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

QA to test
- e2e swap with latest firmware
- if possible e2e swap with firmware n-1

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
