### PR TITLE
LL-9023 Remove bold from token-id in nft viewer

### DIFF
--- a/src/renderer/drawers/NFTViewerDrawer/index.js
+++ b/src/renderer/drawers/NFTViewerDrawer/index.js
@@ -240,7 +240,7 @@ export function NFTViewerDrawer({ account, nftId, height }: NFTViewerDrawerProps
             >
               {t("NFT.viewer.attributes.tokenId")}
             </Text>
-            <Text lineHeight="15.73px" fontSize={4} color="palette.text.shade100" fontWeight="600">
+            <Text lineHeight="15.73px" fontSize={4} color="palette.text.shade100">
               <CopiableField value={nft.tokenId}>
                 {// only needed for very long tokenIds but works with any length > 4
                 nft.tokenId?.length >= 4 ? (


### PR DESCRIPTION
## 🦒 Context (issues, jira)
[LL-9023] The token id shouldn't be bold


## 💻  Description / Demo (image or video)

![image](https://user-images.githubusercontent.com/6013294/151804645-cc4e55b6-4889-496c-a94d-7998d44dedfd.png)


## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)




[LL-9023]: https://ledgerhq.atlassian.net/browse/LL-9023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ