### PR TITLE
LIVE-881 - Fix window not opening for users who have "dusk" theme

### DIFF
--- a/src/main/window-lifecycle.js
+++ b/src/main/window-lifecycle.js
@@ -72,7 +72,10 @@ export const loadWindow = async () => {
 };
 
 export async function createMainWindow({ dimensions, positions }: any, settings: any) {
-  theme = settings && settings.theme ? settings.theme : "null";
+  theme =
+    settings && settings.theme && ["light", "dark"].includes(settings.theme)
+      ? settings.theme
+      : "null";
 
   // TODO renderer should provide the saved window rectangle
   const width = dimensions ? dimensions.width : DEFAULT_WINDOW_WIDTH;

--- a/src/preloader/index.js
+++ b/src/preloader/index.js
@@ -38,7 +38,7 @@ window.api = {
 
 const theme = new URLSearchParams(window.location.search).get("theme");
 const osTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-const palette = palettes[theme !== "null" ? theme : osTheme];
+const palette = palettes[theme !== "null" ? theme : osTheme] || palettes.dark;
 remote.getCurrentWindow().setBackgroundColor(palette.background.default);
 
 window.addEventListener("DOMContentLoaded", () => {

--- a/src/renderer/reducers/settings.js
+++ b/src/renderer/reducers/settings.js
@@ -366,7 +366,10 @@ export const developerModeSelector = (state: State): boolean => state.settings.d
 
 export const lastUsedVersionSelector = (state: State): string => state.settings.lastUsedVersion;
 
-export const userThemeSelector = (state: State): ?string => state.settings.theme;
+export const userThemeSelector = (state: State): ?string => {
+  const savedVal = state.settings.theme;
+  return ["dark", "light"].includes(savedVal) ? savedVal : "dark";
+};
 
 type LanguageAndUseSystemLanguage = {
   language: string,


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LIVE-881]
App is not starting when the theme was "dusk" (app is actually starting but the window is never created).

## 💻  Description / Demo (image or video)

A "valid" value for `settings.theme` is now either `"dark"` or `"light"` as we removed the `"dusk"` theme (https://github.com/LedgerHQ/ledger-live-desktop/pull/4667/commits/cf1e8f1bcb8823df2fbc98aded63d963dca1980e).

3 fixes:
1. in `src/main/window-lifecycle.js`, make sure to not set the `theme` query parameter as an invalid value.
2. in `preloader/index.js` adding a fallback logic (to the dark theme) in the preloader that uses that query param.
3. (bonus, not actually needed for solving this crash but I think it's safer to have it): adding a validity check in the selector so that it can be used safely anywhere.

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [x] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LIVE-881]: https://ledgerhq.atlassian.net/browse/LIVE-881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ