### PR TITLE
LIVE-886 (Market): add sparkline variation

### DIFF
--- a/src/renderer/screens/market/MarketItemChart.tsx
+++ b/src/renderer/screens/market/MarketItemChart.tsx
@@ -1,13 +1,22 @@
 import React, { memo } from "react";
+import { useTheme } from "styled-components";
 import { SparklineSvgData } from "@ledgerhq/live-common/lib/market/types";
 
 type Props = {
   sparklineIn7d: SparklineSvgData;
-  color?: string;
 };
 
-function SmallMarketItemChartComponent({ sparklineIn7d, color }: Props) {
-  const { path, viewBox } = sparklineIn7d;
+function SmallMarketItemChartComponent({ sparklineIn7d }: Props) {
+  // @ts-expect-error to update with next live-common update
+  const { path, viewBox, isPositive } = sparklineIn7d;
+
+  const { colors } = useTheme();
+  const color =
+    isPositive !== undefined
+      ? isPositive
+        ? colors.success.c80
+        : colors.error.c80
+      : colors.neutral.c80;
 
   return (
     <svg


### PR DESCRIPTION
- (Market): update sparkline color according to variation


## 🦒 Context (issues, jira)

[LIVE-886]

## 💻  Description / Demo (image or video)

sparkline mini chart should reflect variation with color green and red.

should automatically work once https://github.com/LedgerHQ/ledger-live-common/pull/1700
is merged and integrated within LLD

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

PR must pass CI, merge develop if conflicts, do not force push. Thanks!

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LIVE-886]: https://ledgerhq.atlassian.net/browse/LIVE-886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ