### PR TITLE
LIVE-949 auto merge crowdin

### DIFF
--- a/.github/workflows/auto-merge-crowdin.yml
+++ b/.github/workflows/auto-merge-crowdin.yml
@@ -1,0 +1,16 @@
+name: Merge Crowdin PR
+on:
+  check_suite:
+    types: [completed]
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: auto-merge
+        if: github.event.check_suite.conclusion == "success" && github.event.check_suite.pull_requests != "" && contains(github.event.check_suite.pull_requests[0].head.ref, 'l10n')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.check_suite.pull_requests[0].number }}
+        run: |
+          gh pr merge $PR -s --admin

--- a/.github/workflows/bundle-app.yml
+++ b/.github/workflows/bundle-app.yml
@@ -85,6 +85,16 @@ jobs:
           name: ${{ steps.post-version.outputs.version }}-mac.dmg
           path: dist/${{ steps.post-version.outputs.name }}-${{ steps.post-version.outputs.version }}-mac.dmg
 
+  clean-macos-runner:
+    runs-on: [ledger-live, macos]
+    needs: [bundle-macos]
+    steps:
+      - name: Clean working directory
+        run: |
+          cd $RUNNER_WORKSPACE
+          cd ..
+          rm -r *
+
   start-runner:
     name: "[Runner] start ec2 instance"
     needs: check-if-fork


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LIVE-949] auto merge crowdin PRs

## 💻  Description / Demo (image or video)

Make is so we don't have to manually merge translations PR.
It will only merge the `l10n**` branches if they are in `pull_request` and all tests have passed.

/!\ the token used if the one provided by github actions and will _probably_ not be able to merge. As I cannot test beforehand, we will have to wait and see if it works, and if it doesn't, we will have to create a personal access token with repository permissions.

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [x] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LIVE-949]: https://ledgerhq.atlassian.net/browse/LIVE-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ