### PR TITLE
comment on pr instead of hash for checklist

### DIFF
--- a/.github/workflows/checklist-pr.yml
+++ b/.github/workflows/checklist-pr.yml
@@ -19,10 +19,10 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            await github.rest.repos.createCommitComment({
+            await github.rest.issues.createComment({
               owner: "LedgerHQ",
               repo: "ledger-live-desktop",
-              commit_sha: "${{ github.event.pull_request.head.sha }}",
+              issue_number: "${{ github.event.pull_request.number }}",
               body: `
               Thanks for your contribution.
               To be able to merge in _develop_ branch, you need to:
@@ -51,10 +51,10 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            await github.rest.repos.createCommitComment({
+            await github.rest.issues.createCommitComment({
               owner: "LedgerHQ",
               repo: "ledger-live-desktop",
-              commit_sha: "${{ github.event.pull_request.head.sha }}",
+              issue_number: "${{ github.event.pull_request.number }}",
               body: `
               Thanks for your contribution.
               To be groomed for next release, you need to:


### PR DESCRIPTION
## 🦒 Context (issues, jira)

To prevent the comment from being erased, comment on PR number instead of commit hash (lost in a rebase or force push)

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
