### PR TITLE
LIVE-403 tooltip price value shortened if too long

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@ledgerhq/hw-transport-http": "6.24.1",
     "@ledgerhq/hw-transport-node-hid-singleton": "6.24.1",
     "@ledgerhq/ledger-core": "6.14.5",
-    "@ledgerhq/live-common": "^21.32.4",
+    "@ledgerhq/live-common": "^21.32.5",
     "@ledgerhq/logs": "6.10.0",
     "@ledgerhq/react-ui": "^0.7.3",
     "@open-wc/webpack-import-meta-loader": "^0.4.7",

--- a/src/renderer/screens/market/MarketCoinScreen/MarketCoinChart.tsx
+++ b/src/renderer/screens/market/MarketCoinScreen/MarketCoinChart.tsx
@@ -54,6 +54,7 @@ function Tooltip({
     <Flex flexDirection="column" p={1}>
       <TooltipText variant="large">
         {counterValueFormatter({
+          shorten: String(data.value).length > 7,
           currency: counterCurrency,
           value: data.value,
           locale,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2897,10 +2897,10 @@
     bignumber.js "^9.0.1"
     json-rpc-2.0 "^0.2.16"
 
-"@ledgerhq/live-common@^21.32.4":
-  version "21.32.4"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-21.32.4.tgz#edac9ea712f4361230a0e7fad20294571dba8cfd"
-  integrity sha512-7Q2sduw6udZ8VLgMmJH9KxQmyT6FoD8EYKVkx1nkY/cjUDRBhwJjIoo77r6ww0E3mSajHfO4pjG7vqV8c8iq/g==
+"@ledgerhq/live-common@^21.32.5":
+  version "21.32.5"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-21.32.5.tgz#580b35803cf79500b7e8d724ad14b60d8523a45d"
+  integrity sha512-+Auvln68XOH3RO3yEtw+zz47bqqb/PAbARHslbT025v0TTOIaucnGVphzLgJptD9qrriGxuPYJsQTp3hAxEoYg==
   dependencies:
     "@celo/contractkit" "^1.5.1"
     "@celo/wallet-base" "^1.5.1"


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LIVE-403]

## 💻  Description / Demo (image or video)

The price was overflowing the graph tooltip container if it was too long. This PR adresses that issue by using the `shorten` option in LLC's `counterValueFormatter`.

**Before:**
<img width="811" alt="Screenshot 2022-02-21 at 12 01 50" src="https://user-images.githubusercontent.com/91890529/154944127-63b77db4-433e-4867-b6b7-3f1102f653da.png">


**After:**

<img width="819" alt="Screenshot 2022-02-21 at 12 02 44" src="https://user-images.githubusercontent.com/91890529/154944135-bf3ef093-4c89-4949-8524-abaec7d292f0.png">


## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LL-403]: https://ledgerhq.atlassian.net/browse/LL-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-403]: https://ledgerhq.atlassian.net/browse/LIVE-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ