### PR TITLE
LIVE-968 - Fix ticker overlapping the swap button in market page

### DIFF
--- a/src/renderer/screens/market/MarketList.tsx
+++ b/src/renderer/screens/market/MarketList.tsx
@@ -61,7 +61,8 @@ const ChevronContainer = styled(Flex).attrs({ m: 1 })<{
   }
 `;
 
-export const miniChartThreshold = 1050;
+export const miniChartThreshold = 1150;
+export const miniMarketCapThreshold = 1050;
 
 export const SortTableCell = ({
   onClick,
@@ -133,9 +134,15 @@ export const TableRow = styled(Flex).attrs({
     flex: 1 0 150px;
     justify-content: flex-end;
   }
-  ${TableCellBase}:nth-child(4),
-  ${TableCellBase}:nth-child(5) {
+  ${TableCellBase}:nth-child(4) {
     flex: 1 0 100px;
+    justify-content: flex-end;
+  }
+  ${TableCellBase}:nth-child(5) {
+    @media (min-width: ${miniMarketCapThreshold}px) {
+      flex: 1 0 150px;
+    }
+    flex: 1 0 70px;
     justify-content: flex-end;
   }
   ${TableCellBase}:nth-child(6) {
@@ -199,6 +206,7 @@ const CurrencyRow = memo(function CurrencyRowItem({
   swapAvailableIds,
   style,
   displayChart,
+  displayMarketCap,
 }: any) {
   const currency = data ? data[index] : null;
   const isStarred = currency && starredMarketCoins.includes(currency.id);
@@ -218,6 +226,7 @@ const CurrencyRow = memo(function CurrencyRowItem({
       availableOnSwap={availableOnSwap}
       style={{ ...style }}
       displayChart={displayChart}
+      displayMarketCap={displayMarketCap}
     />
   );
 });
@@ -315,7 +324,9 @@ function MarketList({
             <TableCell disabled>{t("market.marketList.crypto")}</TableCell>
             <TableCell disabled>{t("market.marketList.price")}</TableCell>
             <TableCell disabled>{t("market.marketList.change")}</TableCell>
-            <TableCell disabled>{t("market.marketList.marketCap")}</TableCell>
+            {width > miniMarketCapThreshold && (
+              <TableCell disabled>{t("market.marketList.marketCap")}</TableCell>
+            )}
             {width > miniChartThreshold && (
               <TableCell disabled>{t("market.marketList.last7d")}</TableCell>
             )}
@@ -380,6 +391,7 @@ function MarketList({
                             locale={locale}
                             swapAvailableIds={swapAvailableIds}
                             displayChart={width > miniChartThreshold}
+                            displayMarketCap={width > miniMarketCapThreshold}
                           />
                         )}
                       </List>

--- a/src/renderer/screens/market/MarketList.tsx
+++ b/src/renderer/screens/market/MarketList.tsx
@@ -126,7 +126,7 @@ export const TableRow = styled(Flex).attrs({
     padding-left: 5px;
   }
   ${TableCellBase}:nth-child(2) {
-    flex: 1 0 150px;
+    flex: 1 0 250px;
     justify-content: flex-start;
   }
   ${TableCellBase}:nth-child(3) {

--- a/src/renderer/screens/market/MarketRowItem.tsx
+++ b/src/renderer/screens/market/MarketRowItem.tsx
@@ -39,6 +39,7 @@ type Props = {
   availableOnBuy: boolean;
   availableOnSwap: boolean;
   displayChart: boolean;
+  displayMarketCap: boolean;
 };
 
 function MarketRowItem({
@@ -53,6 +54,7 @@ function MarketRowItem({
   availableOnBuy,
   availableOnSwap,
   displayChart,
+  displayMarketCap,
 }: Props) {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -197,16 +199,18 @@ function MarketRowItem({
               />
             )}
           </TableCell>
-          <TableCell>
-            <Text>
-              {counterValueFormatter({
-                shorten: true,
-                currency: counterCurrency,
-                value: currency.marketcap,
-                locale,
-              })}
-            </Text>
-          </TableCell>
+          {displayMarketCap && (
+            <TableCell>
+              <Text>
+                {counterValueFormatter({
+                  shorten: true,
+                  currency: counterCurrency,
+                  value: currency.marketcap,
+                  locale,
+                })}
+              </Text>
+            </TableCell>
+          )}
           {displayChart && (
             <TableCell>
               {currency.sparklineIn7d && (


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LIVE-968]

## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

The ticker overlaps the buy and swap buttons in small screen size because the flex-basis of the second column is set too small.

#### Video
https://user-images.githubusercontent.com/23487649/155300449-5acbf76b-df78-4221-9732-d38cd2e387d7.mp4


Before:
![Screenshot from 2022-02-21 09-21-01](https://user-images.githubusercontent.com/23487649/154915534-22d40fa1-dbcd-46de-82ba-775cd04a8b8d.png)

After:
![Screenshot from 2022-02-21 09-21-15](https://user-images.githubusercontent.com/23487649/154915612-3c539b8d-9800-4bf4-b16c-ea8db8b19e73.png)

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LIVE-968]: https://ledgerhq.atlassian.net/browse/LIVE-968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ