### PR TITLE
LIVE-921 Specific error handling for NoSuchAppOnProvider

### DIFF
--- a/src/renderer/components/DeviceAction/index.js
+++ b/src/renderer/components/DeviceAction/index.js
@@ -8,6 +8,7 @@ import {
   OutdatedApp,
   LatestFirmwareVersionRequired,
   DeviceNotOnboarded,
+  NoSuchAppOnProvider,
 } from "@ledgerhq/live-common/lib/errors";
 import { getCurrentDevice } from "~/renderer/reducers/devices";
 import { setPreferredDeviceModel, setLastSeenDeviceInfo } from "~/renderer/actions/settings";
@@ -269,6 +270,14 @@ const DeviceAction = <R, H, P>({
         error: new DeviceNotOnboarded(),
         withOnboardingCTA: true,
         info: true,
+      });
+    }
+
+    if (error instanceof NoSuchAppOnProvider) {
+      return renderError({
+        error,
+        withOpenManager: true,
+        withExportLogs: true,
       });
     }
 

--- a/src/renderer/components/DeviceAction/rendering.js
+++ b/src/renderer/components/DeviceAction/rendering.js
@@ -201,12 +201,14 @@ const OpenManagerBtn = ({
   updateApp,
   firmwareUpdate,
   mt = 2,
+  ml = 0,
 }: {
   closeAllModal: () => void,
   appName?: string,
   updateApp?: boolean,
   firmwareUpdate?: boolean,
   mt?: number,
+  ml?: number,
 }) => {
   const history = useHistory();
   const { setDrawer } = useContext(context);
@@ -228,7 +230,7 @@ const OpenManagerBtn = ({
   }, [updateApp, firmwareUpdate, appName, history, closeAllModal, setDrawer]);
 
   return (
-    <Button mt={mt} primary onClick={onClick}>
+    <Button mt={mt} ml={ml} primary onClick={onClick}>
       <Trans i18nKey="DeviceAction.openManager" />
     </Button>
   );
@@ -489,7 +491,9 @@ export const renderError = ({
               mx={1}
             />
           ) : null}
-          {onRetry ? (
+          {withOpenManager ? (
+            <OpenManagerButton mt={0} ml={withExportLogs ? 4 : 0} />
+          ) : onRetry ? (
             <Button primary ml={withExportLogs ? 4 : 0} onClick={onRetry}>
               <Trans i18nKey="common.retry" />
             </Button>

--- a/src/renderer/components/ErrorIcon.js
+++ b/src/renderer/components/ErrorIcon.js
@@ -14,7 +14,11 @@ import {
   ManagerDeviceLockedError,
 } from "@ledgerhq/errors";
 
-import { SwapGenericAPIError, DeviceNotOnboarded } from "@ledgerhq/live-common/lib/errors";
+import {
+  SwapGenericAPIError,
+  DeviceNotOnboarded,
+  NoSuchAppOnProvider,
+} from "@ledgerhq/live-common/lib/errors";
 
 export type ErrorIconProps = {
   error: Error,
@@ -33,6 +37,7 @@ const ErrorIcon = ({ error, size = 44 }: ErrorIconProps) => {
     case error instanceof UserRefusedOnDevice:
     case error instanceof UserRefusedAddress:
     case error instanceof SwapGenericAPIError:
+    case error instanceof NoSuchAppOnProvider:
       return <CrossCircle size={size} />;
     case error instanceof ManagerDeviceLockedError:
       return <Lock size={size} />;

--- a/static/i18n/en/app.json
+++ b/static/i18n/en/app.json
@@ -3601,6 +3601,10 @@
     }
   },
   "errors": {
+    "NoSuchAppOnProvider": {
+      "title": "The {{appName}} app cannot be found for your specific configuration.",
+      "description": "Try reinstalling the app from the Manager"
+    },
     "countervaluesUnavailable": {
       "title": "We're not able to provide a countervalue for this asset at the moment"
     },


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LIVE-921


## 💻  Description / Demo (image or video)
<img width="1136" alt="image" src="https://user-images.githubusercontent.com/4631227/155178538-8cc32dff-5c18-485b-8b5e-9bf1040c43ce.png">
(Don't have your device only visible because I tested it on the receive flow)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->

## 🖤  How to test this

It's pretty rare falling into this error in the wild unless you are messing around with providers and weird versions. In particular, as of today, you are able to fall into it by not having Bitcoin installed on a 2.0.0 LNS, setting provider 7, and then trying to access a flow that would automatically install bitcoin.

The error is expected to be like above and the link to the manager should work. 
That's it.