### PR TITLE
LIVE-922 Use update app size when updating

### DIFF
--- a/src/renderer/screens/manager/AppsList/Item.js
+++ b/src/renderer/screens/manager/AppsList/Item.js
@@ -87,6 +87,20 @@ const Item: React$ComponentType<Props> = ({
   const version = (installed && installed.version) || app.version;
   const newVersion = installed && installed.availableVersion;
 
+  const availableApp = useMemo(() => state.apps.find(({ name }) => name === app.name), [
+    app.name,
+    state.apps,
+  ]);
+
+  const bytes = useMemo(
+    () =>
+      (onlyUpdate && availableApp?.bytes) ||
+      ((installed && installed.blocks) || 0) * deviceModel.getBlockSize(deviceInfo.version) ||
+      app.bytes ||
+      0,
+    [app.bytes, availableApp.bytes, deviceInfo.version, deviceModel, installed, onlyUpdate],
+  );
+
   return (
     <AppRow id={`managerAppsList-${name}`}>
       <Box flex="0.7" horizontal>
@@ -104,12 +118,7 @@ const Item: React$ComponentType<Props> = ({
             />{" "}
             •{" "}
             <ByteSize
-              value={
-                ((installed && installed.blocks) || 0) *
-                  deviceModel.getBlockSize(deviceInfo.version) ||
-                app.bytes ||
-                0
-              }
+              value={bytes}
               formatFunction={Math.ceil}
               deviceModel={deviceModel}
               firmwareVersion={deviceInfo.version}


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LIVE-922


## 💻  Description / Demo (image or video)
The logic for updating an application seems to work perfectly fine, I initially thought we were using the wrong app size in the logic side but it seems to be limited to the UI in this point. The application size for possible updates shows the app size of the already installed application.

<img width="1281" alt="Screenshot 2022-02-23 at 18 17 19" src="https://user-images.githubusercontent.com/4631227/155375123-824f27ca-9bc1-4a9c-b04c-ffb946f845cd.png">


## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [x] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
