### PR TITLE
LIVE-1456 Highlight sidebar "accounts" correctly

### DIFF
--- a/src/renderer/components/MainSideBar/index.js
+++ b/src/renderer/components/MainSideBar/index.js
@@ -344,7 +344,7 @@ const MainSideBar = () => {
                 label={t("sidebar.accounts")}
                 icon={IconWallet}
                 iconActiveColor="wallet"
-                isActive={location.pathname === "/accounts"}
+                isActive={location.pathname.startsWith("/account")}
                 onClick={handleClickAccounts}
                 disabled={noAccounts}
                 collapsed={secondAnim}


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LIVE-1456


## 💻  Description / Demo (image or video)
When navigating to any subroute of the accounts section, we want the accounts entry in the sidebar to be highlighted. Due to the hard check on the pathname being "accounts" this was only the case on the account list screen. This addresses that.

<img width="1281" alt="Screenshot 2022-02-24 at 11 23 48" src="https://user-images.githubusercontent.com/4631227/155506390-72784686-4a4c-45bf-af86-a338a93c7a22.png">

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [x] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
