### PR TITLE
LIVE-1477 Add missing url for fw update + redirection bug

### DIFF
--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -97,6 +97,8 @@ export const urls = {
   updateDeviceFirmware: {
     nanoS:
       "https://support.ledger.com/hc/en-us/articles/360002731113?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=firmwareupdate",
+    nanoSP:
+      "https://support.ledger.com/hc/en-us/articles/4445777839901?&utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=firmwareupdate",
     nanoX:
       "https://support.ledger.com/hc/en-us/articles/360013349800?utm_source=ledger_live_desktop&utm_medium=self_referral&utm_content=firmwareupdate",
     blue:
@@ -104,6 +106,8 @@ export const urls = {
   },
   lostPinOrSeed: {
     nanoS:
+      "https://support.ledger.com/hc/en-us/articles/4404382075537-Don-t-have-your-Recovery-phrase-?support=true",
+    nanoSP:
       "https://support.ledger.com/hc/en-us/articles/4404382075537-Don-t-have-your-Recovery-phrase-?support=true",
     nanoX:
       "https://support.ledger.com/hc/en-us/articles/4404382075537-Don-t-have-your-Recovery-phrase-?support=true",

--- a/src/renderer/components/FirmwareUpdateBanner.js
+++ b/src/renderer/components/FirmwareUpdateBanner.js
@@ -27,7 +27,7 @@ const FirmwareUpdateBanner = ({ old, right }: { old?: boolean, right?: any }) =>
     });
     const search = urlParams.toString();
     history.push({
-      pathname: "manager",
+      pathname: "/manager",
       search: `?${search}`,
     });
   };


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LIVE-1477


## 💻  Description / Demo (image or video)
Since there was no link specific for the lns+ the firmware upgrade guide link didnt do anything. This fixes that, and also introduces a bug fix for the firmware banner when inside the settings screen. It didn't navigate to the manager, that should also be fixed here.

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
