### PR TITLE
LIVE-1461 end of coin name hidden if too long so it doesn t overlap on coin price

### DIFF
--- a/src/renderer/screens/market/MarketList.tsx
+++ b/src/renderer/screens/market/MarketList.tsx
@@ -127,11 +127,11 @@ export const TableRow = styled(Flex).attrs({
     padding-left: 5px;
   }
   ${TableCellBase}:nth-child(2) {
-    flex: 1 0 250px;
+    flex: 1 0 230px;
     justify-content: flex-start;
   }
   ${TableCellBase}:nth-child(3) {
-    flex: 1 0 70px;
+    flex: 1 0 80px;
     justify-content: flex-end;
   }
   ${TableCellBase}:nth-child(4) {

--- a/src/renderer/screens/market/MarketList.tsx
+++ b/src/renderer/screens/market/MarketList.tsx
@@ -131,7 +131,7 @@ export const TableRow = styled(Flex).attrs({
     justify-content: flex-start;
   }
   ${TableCellBase}:nth-child(3) {
-    flex: 1 0 150px;
+    flex: 1 0 70px;
     justify-content: flex-end;
   }
   ${TableCellBase}:nth-child(4) {

--- a/src/renderer/screens/market/MarketList.tsx
+++ b/src/renderer/screens/market/MarketList.tsx
@@ -126,11 +126,11 @@ export const TableRow = styled(Flex).attrs({
     padding-left: 5px;
   }
   ${TableCellBase}:nth-child(2) {
-    flex: 1 0 150px;
+    flex: 1 0 230px;
     justify-content: flex-start;
   }
   ${TableCellBase}:nth-child(3) {
-    flex: 1 0 150px;
+    flex: 1 0 70px;
     justify-content: flex-end;
   }
   ${TableCellBase}:nth-child(4),

--- a/src/renderer/screens/market/MarketRowItem.tsx
+++ b/src/renderer/screens/market/MarketRowItem.tsx
@@ -145,7 +145,7 @@ function MarketRowItem({
       ) : (
         <TableRow onClick={onCurrencyClick}>
           <TableCell>{currency?.marketcapRank ?? "-"}</TableCell>
-          <TableCell>
+          <TableCell overflow="hidden" mr={3}>
             <CryptoCurrencyIconWrapper>
               {currency.internalCurrency ? (
                 <CryptoCurrencyIcon
@@ -160,7 +160,7 @@ function MarketRowItem({
                 <img width="32px" height="32px" src={currency.image} alt={"currency logo"} />
               )}
             </CryptoCurrencyIconWrapper>
-            <Flex pl={3} flexDirection="row" alignItems="center">
+            <Flex pl={3} flexDirection="row" alignItems="center" overflow="hidden">
               <Flex flexDirection="column" alignItems="left" pr={2}>
                 <Text variant="body">{currency.name}</Text>
                 <Text variant="small" color="neutral.c60">

--- a/src/renderer/screens/market/MarketRowItem.tsx
+++ b/src/renderer/screens/market/MarketRowItem.tsx
@@ -143,7 +143,7 @@ function MarketRowItem({
       ) : (
         <TableRow onClick={onCurrencyClick}>
           <TableCell>{currency?.marketcapRank ?? "-"}</TableCell>
-          <TableCell>
+          <TableCell overflow="hidden" mr={3}>
             <CryptoCurrencyIconWrapper>
               {currency.internalCurrency ? (
                 <CryptoCurrencyIcon
@@ -158,7 +158,7 @@ function MarketRowItem({
                 <img width="32px" height="32px" src={currency.image} alt={"currency logo"} />
               )}
             </CryptoCurrencyIconWrapper>
-            <Flex pl={3} flexDirection="row" alignItems="center">
+            <Flex pl={3} flexDirection="row" alignItems="center" overflow="hidden">
               <Flex flexDirection="column" alignItems="left" pr={2}>
                 <Text variant="body">{currency.name}</Text>
                 <Text variant="small" color="neutral.c60">


### PR DESCRIPTION
[LIVE-1461]


## 🦒 Context (issues, jira)

On the market list we now hide the end of a coin name if it is too long so it does not overlap on the coin price

BEFORE
<img width="737" alt="Screenshot 2022-02-24 at 10 05 28" src="https://user-images.githubusercontent.com/17146928/156772304-657a1adc-6904-44c0-ac1c-8546359f5509.png">


NOW
<img width="813" alt="Screenshot 2022-03-04 at 14 32 41" src="https://user-images.githubusercontent.com/17146928/156772433-b46f87f4-f7da-46f8-9794-698f3245ad97.png">


## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LIVE-1461]: https://ledgerhq.atlassian.net/browse/LIVE-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ