### PR TITLE
fix: wrong api call in github actions

### DIFF
--- a/.github/workflows/checklist-pr.yml
+++ b/.github/workflows/checklist-pr.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            await github.rest.issues.createCommitComment({
+            await github.rest.issues.createComment({
               owner: "LedgerHQ",
               repo: "ledger-live-desktop",
               issue_number: "${{ github.event.pull_request.number }}",


### PR DESCRIPTION
## 🦒 Context (issues, jira)

https://ledger.slack.com/archives/C01S1M0T5D2/p1646737002287999

## 💻  Description / Demo (image or video)

Fix wrong api call on octokit lib to comment on PR.

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [x] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
