### PR TITLE
LIVE-1653 - Fix experimental countervalues toggle

### DIFF
--- a/src/renderer/experimental.js
+++ b/src/renderer/experimental.js
@@ -128,8 +128,8 @@ export const experimentalFeatures: Feature[] = [
     title: "Experimental countervalues API",
     description:
       "This may cause the countervalues displayed for your accounts to become incorrect.",
-    valueOn: "https://countervalues.live.ledger.com",
-    valueOff: "https://countervalues-experimental.live.ledger.com",
+    valueOn: "https://countervalues-experimental.live.ledger.com",
+    valueOff: "https://countervalues.live.ledger.com",
   },
   {
     type: "integer",

--- a/src/renderer/screens/settings/sections/Experimental/ExperimentalSwitch.js
+++ b/src/renderer/screens/settings/sections/Experimental/ExperimentalSwitch.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useState, useCallback } from "react";
+import React, { useCallback } from "react";
 import Track from "~/renderer/analytics/Track";
 import Switch from "~/renderer/components/Switch";
 
@@ -21,14 +21,13 @@ const ExperimentalSwitch = ({
   isDefault,
   readOnly,
 }: Props) => {
-  const [checked, setChecked] = useState(!isDefault);
+  const checked = !isDefault;
 
   const handleOnChange = useCallback(
     (evt: boolean) => {
       onChange(name, evt ? valueOn : valueOff);
-      setChecked(evt);
     },
-    [onChange, valueOn, valueOff, name, setChecked],
+    [onChange, valueOn, valueOff, name],
   );
 
   return (


### PR DESCRIPTION
**Bug description:** _"On LLD 2.38.3, customer’s experimental countervalues API toggle keep changing it’s status back to enabled after customer disabled it and moved to a different menu."_

Fixed 2 things:
- For `LEDGER_COUNTERVALUES_API`, the values of `valueOn` and `valueOff` in `src/renderer/experimental.js` were reversed (`valueOff` should be matching the `default` value declared in LLC's `env.ts` and `valueOn` should be the experimental value). This mismatch between the `default` value and the `valueOff` was causing the experimental switch toggle to have no effect.
- The state of the switch in `ExperimentalSwitch` now reflects the _real_ state of the experimental feature, it's not an internal state. This internal state was causing an issue where because of the previously described issue, clicking on the switch would switch the internal state, thus making it appear like the switch was having an effect, but actually nothing was happening in the background, only the switch's internal state was changing. Thus when leaving and coming back to the page, the switch was reverted back to it's initial state (it's "real" state).

## 🦒 Context (issues, jira)

[LIVE-1653]
[TECSUPPORT-1119]

## 💻  Description / Demo (image or video)

#### Before:

_(see video in ticket [TECSUPPORT-1119], can't share here for privacy reasons)_

The user goes to the "Experimental features" setting section.
He notices that "Experimental countervalues API" is on.
He toggles it "off", then goes to the "Help" section and comes back to "Experimental features" and sees that even though it was toggled "off", it's back "on".

#### After:

https://user-images.githubusercontent.com/91890529/157856151-f021598b-041c-4a10-9c59-b66e2292e6b4.mov




## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LIVE-1653]: https://ledgerhq.atlassian.net/browse/LIVE-1653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TECSUPPORT-1119]: https://ledgerhq.atlassian.net/browse/TECSUPPORT-1119