### PR TITLE
LIVE-1478 Update outdated illustrations from fw update moda

### DIFF
--- a/src/renderer/components/DeviceAction/rendering.js
+++ b/src/renderer/components/DeviceAction/rendering.js
@@ -53,7 +53,7 @@ import { context } from "~/renderer/drawers/Provider";
 import { track } from "~/renderer/analytics/segment";
 import { relaunchOnboarding } from "~/renderer/actions/onboarding";
 
-const AnimationWrapper: ThemedComponent<{ modelId?: DeviceModelId }> = styled.div`
+export const AnimationWrapper: ThemedComponent<{ modelId?: DeviceModelId }> = styled.div`
   width: 600px;
   max-width: 100%;
   height: ${p => (p.modelId === "blue" ? 300 : 200)}px;

--- a/src/renderer/modals/UpdateFirmwareModal/steps/01-step-install-full-firmware.js
+++ b/src/renderer/modals/UpdateFirmwareModal/steps/01-step-install-full-firmware.js
@@ -23,7 +23,6 @@ import type { StepProps } from "../";
 import { getEnv } from "@ledgerhq/live-common/lib/env";
 
 import Animation from "~/renderer/animations";
-import FlashMCU from "~/renderer/components/FlashMCU";
 import { getDeviceAnimation } from "~/renderer/components/DeviceAction/animations";
 import { AnimationWrapper } from "~/renderer/components/DeviceAction/rendering";
 import useTheme from "~/renderer/hooks/useTheme";

--- a/src/renderer/modals/UpdateFirmwareModal/steps/01-step-install-full-firmware.js
+++ b/src/renderer/modals/UpdateFirmwareModal/steps/01-step-install-full-firmware.js
@@ -22,6 +22,12 @@ import { mockedEventEmitter } from "~/renderer/components/debug/DebugMock";
 import type { StepProps } from "../";
 import { getEnv } from "@ledgerhq/live-common/lib/env";
 
+import Animation from "~/renderer/animations";
+import FlashMCU from "~/renderer/components/FlashMCU";
+import { getDeviceAnimation } from "~/renderer/components/DeviceAction/animations";
+import { AnimationWrapper } from "~/renderer/components/DeviceAction/rendering";
+import useTheme from "~/renderer/hooks/useTheme";
+
 const Container: ThemedComponent<{}> = styled(Box).attrs(() => ({
   alignItems: "center",
   fontSize: 4,
@@ -67,6 +73,7 @@ const Body = ({
   deviceInfo: DeviceInfo,
 }) => {
   const { t } = useTranslation();
+  const type = useTheme("colors.palette.type");
 
   const isBlue = deviceModelId === "blue";
 
@@ -101,15 +108,21 @@ const Body = ({
                 .map((hash, i) => <span key={`${i}-${hash}`}>{hash}</span>)}
           </Identifier>
         </Box>
-        <Box mt={isBlue ? 4 : null}>
-          <Interactions
-            wire="wired"
-            type={deviceModelId}
-            width={isBlue ? 150 : 375}
-            screen="validation"
-            action="accept"
-          />
-        </Box>
+        {isBlue ? (
+          <Box mt={4}>
+            <Interactions
+              wire="wired"
+              type={deviceModelId}
+              width={150}
+              screen="validation"
+              action="accept"
+            />
+          </Box>
+        ) : (
+          <AnimationWrapper modelId={deviceModelId}>
+            <Animation animation={getDeviceAnimation(deviceModelId, type, "validate")} />
+          </AnimationWrapper>
+        )}
       </>
     );
   }
@@ -122,15 +135,21 @@ const Body = ({
           {t("manager.modal.confirmUpdate")}
         </Text>
       </Box>
-      <Box mt={isBlue ? 4 : null}>
-        <Interactions
-          wire="wired"
-          type={deviceModelId}
-          width={isBlue ? 150 : 375}
-          screen="validation"
-          action="accept"
-        />
-      </Box>
+      {isBlue ? (
+        <Box mt={4}>
+          <Interactions
+            wire="wired"
+            type={deviceModelId}
+            width={150}
+            screen="validation"
+            action="accept"
+          />
+        </Box>
+      ) : (
+        <AnimationWrapper modelId={deviceModelId}>
+          <Animation animation={getDeviceAnimation(deviceModelId, type, "validate")} />
+        </AnimationWrapper>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LIVE-1478


## 💻  Description / Demo (image or video)
In the context of firmware updates we still had a few illustrations using the previous illustration paradigm. Dynamically generated illustrations of the devices with the actions and whatnot. We replace those with lotties when possible, although the will still show for Blue and on some upgrade paths of the Nano S.

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
