### PR TITLE
feat(walletconnect): enable polygon/bsc

### DIFF
--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -5,7 +5,7 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { withTranslation, Trans } from "react-i18next";
 import styled from "styled-components";
-import type { Account, AccountLike } from "@ledgerhq/live-common/lib/types";
+import type { Account, AccountLike, CryptoCurrency } from "@ledgerhq/live-common/lib/types";
 import Tooltip from "~/renderer/components/Tooltip";
 import {
   isAccountEmpty,
@@ -235,6 +235,38 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
     );
   };
 
+  const getFilteredActions = useCallback(
+    (currency: CryptoCurrency) => {
+      const actions = [];
+
+      switch (currency.id) {
+        case "ethereum":
+          actions.push({
+            key: "Stake",
+            onClick: onPlatformStake,
+            event: "Eth Stake Account Button",
+            icon: IconCoins,
+            label: <Trans i18nKey="account.stake" values={{ currency: currency.name }} />,
+          });
+
+        // eslint-disable-next-line no-duplicate-case, no-fallthrough
+        case "ethereum":
+        case "polygon":
+          actions.push({
+            key: "WalletConnect",
+            onClick: onWalletConnect,
+            event: "Wallet Connect Account Button",
+            eventProperties: { currencyName: currency.name },
+            icon: IconWalletConnect,
+            label: <Trans i18nKey="walletconnect.titleAccount" />,
+          });
+      }
+
+      return actions;
+    },
+    [currency.id],
+  );
+
   const manageActions: {
     label: any,
     onClick: () => void,
@@ -256,17 +288,7 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
           },
         ]
       : []),
-    ...(currency.id === "ethereum"
-      ? [
-          {
-            key: "Stake",
-            onClick: onPlatformStake,
-            event: "Eth Stake Account Button",
-            icon: IconCoins,
-            label: <Trans i18nKey="account.stake" values={{ currency: currency.name }} />,
-          },
-        ]
-      : []),
+    ...getFilteredActions(currency),
   ];
 
   const BuyHeader = <BuyActionDefault onClick={onBuy} />;

--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -127,7 +127,7 @@ const AccountHeaderSettingsButtonComponent = ({ account, parentAccount, openModa
   );
 };
 
-const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) => {
+const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
   const mainAccount = getMainAccount(account, parentAccount);
   const contrastText = useTheme("colors.palette.text.shade60");
 
@@ -176,6 +176,11 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
     });
 
   const history = useHistory();
+
+  const onWalletConnect = useCallback(() => {
+    setTrackingSource("account header actions");
+    openModal("MODAL_WALLETCONNECT_PASTE_LINK", { account });
+  }, [openModal, account]);
 
   const onBuy = useCallback(() => {
     setTrackingSource("account header actions");
@@ -252,6 +257,7 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
         // eslint-disable-next-line no-duplicate-case, no-fallthrough
         case "ethereum":
         case "polygon":
+        case "bsc":
           actions.push({
             key: "WalletConnect",
             onClick: onWalletConnect,

--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -5,7 +5,7 @@ import { compose } from "redux";
 import { connect } from "react-redux";
 import { withTranslation, Trans } from "react-i18next";
 import styled from "styled-components";
-import type { Account, AccountLike, CryptoCurrency } from "@ledgerhq/live-common/lib/types";
+import type { Account, AccountLike } from "@ledgerhq/live-common/lib/types";
 import Tooltip from "~/renderer/components/Tooltip";
 import {
   isAccountEmpty,
@@ -176,11 +176,6 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
     });
 
   const history = useHistory();
-
-  const onWalletConnect = useCallback(() => {
-    setTrackingSource("account header actions");
-    openModal("MODAL_WALLETCONNECT_PASTE_LINK", { account });
-  }, [openModal, account]);
 
   const onBuy = useCallback(() => {
     setTrackingSource("account header actions");

--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -102,7 +102,7 @@ const AccountHeaderSettingsButtonComponent = ({ account, parentAccount, openModa
           rounded
         />
       </Tooltip>
-      {currency.id === "ethereum" ? (
+      {["ethereum", "bsc", "polygon"].includes(currency.id) ? (
         <Tooltip content={t("walletconnect.titleAccount")}>
           <ButtonSettings onClick={onWalletConnect}>
             <Box justifyContent="center">
@@ -240,39 +240,6 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
     );
   };
 
-  const getFilteredActions = useCallback(
-    (currency: CryptoCurrency) => {
-      const actions = [];
-
-      switch (currency.id) {
-        case "ethereum":
-          actions.push({
-            key: "Stake",
-            onClick: onPlatformStake,
-            event: "Eth Stake Account Button",
-            icon: IconCoins,
-            label: <Trans i18nKey="account.stake" values={{ currency: currency.name }} />,
-          });
-
-        // eslint-disable-next-line no-duplicate-case, no-fallthrough
-        case "ethereum":
-        case "polygon":
-        case "bsc":
-          actions.push({
-            key: "WalletConnect",
-            onClick: onWalletConnect,
-            event: "Wallet Connect Account Button",
-            eventProperties: { currencyName: currency.name },
-            icon: IconWalletConnect,
-            label: <Trans i18nKey="walletconnect.titleAccount" />,
-          });
-      }
-
-      return actions;
-    },
-    [currency.id],
-  );
-
   const manageActions: {
     label: any,
     onClick: () => void,
@@ -294,7 +261,17 @@ const AccountHeaderActions = ({ account, parentAccount, openModal }: Props) => {
           },
         ]
       : []),
-    ...getFilteredActions(currency),
+    ...(currency.id === "ethereum"
+      ? [
+          {
+            key: "Stake",
+            onClick: onPlatformStake,
+            event: "Eth Stake Account Button",
+            icon: IconCoins,
+            label: <Trans i18nKey="account.stake" values={{ currency: currency.name }} />,
+          },
+        ]
+      : []),
   ];
 
   const BuyHeader = <BuyActionDefault onClick={onBuy} />;


### PR DESCRIPTION
This commit adds the walletconnect button to the polygon/bsc account page.

## 🦒 Context (issues, jira)

Wallet Connect is EVM-compatible, as we support Polygon and BSC, it makes sense to enable this button on the account page.

## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->

## 🧪 How to test

- Ensure you have a non-empty Polygon and BSC account
- Go to the account page of your empty accounts
- The walletconnect button must be displayed in the header