### PR TITLE
feat(account): improve the empty state by displaying options in the header

### DIFF
--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { compose } from "redux";
 import { connect } from "react-redux";
 import { withTranslation, Trans } from "react-i18next";
@@ -84,6 +84,7 @@ type Props = {
 } & OwnProps;
 
 const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) => {
+  const isAccountHasToken = useMemo(() => !isAccountEmpty(account), [account.id]);
   const mainAccount = getMainAccount(account, parentAccount);
   const contrastText = useTheme("colors.palette.text.shade60");
 
@@ -228,21 +229,18 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
 
   const ManageActionsHeader = manageActions.map(item => renderAction(item));
 
-  const NonEmptyAccountHeader = (
-    <FadeInButtonsContainer data-test-id="account-buttons-group" show={showButtons}>
-      {canSend(account, parentAccount) && (
-        <SendAction account={account} parentAccount={parentAccount} onClick={onSend} />
-      )}
-      <ReceiveAction account={account} parentAccount={parentAccount} onClick={onReceive} />
-      {availableOnBuy && BuyHeader}
-      {availableOnSwap && SwapHeader}
-      {manageActions.length > 0 && ManageActionsHeader}
-    </FadeInButtonsContainer>
-  );
-
   return (
     <Box horizontal alignItems="center" justifyContent="flex-end" flow={2} mt={15}>
-      {!isAccountEmpty(account) ? NonEmptyAccountHeader : null}
+      <FadeInButtonsContainer data-test-id="account-buttons-group" show={showButtons}>
+        {isAccountHasToken && canSend(account, parentAccount) && (
+          <SendAction account={account} parentAccount={parentAccount} onClick={onSend} />
+        )}
+        <ReceiveAction account={account} parentAccount={parentAccount} onClick={onReceive} />
+        {availableOnBuy && BuyHeader}
+        {isAccountHasToken && availableOnSwap && SwapHeader}
+        {manageActions.length > 0 && ManageActionsHeader}
+      </FadeInButtonsContainer>
+
       <Tooltip content={t("stars.tooltip")}>
         <Star
           accountId={account.id}


### PR DESCRIPTION
## 🦒 Context (issues, jira)

Until now, the header in the account page for an empty account wasn't
rendered. Because of this, walletconnect button wasn't rendered, you needed
some tokens to see it appears. This commit fixes this, from now, walletconnect
button and receive/buy buttons would be rendered for any empty accounts.
As it is not required to own tokens to use walletconnect, this modification makes
sense to me. Regarding the receive/buy buttons, I think it's better to have them
always available, even for empty accounts (we missed a business opportunity by
hidding the buy button in this case).

## 💻  Description / Demo (image or video)

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->

## 🧪 How to test

**Scenario 1**
- Ensure you have an empty Polygon or BSC account
- Go to the account page of your empty account
- The buy and the receive buttons must be displayed in the header

**Scenario 2**
- Ensure you have an empty Ethereum account
- Go to the account page of your empty account
- The buy, receive, and walletconnect buttons must be displayed in the header