### PR TITLE
fix(walletconnect): dapp name not required

### DIFF
--- a/src/renderer/modals/WalletConnectDeeplink/Body.js
+++ b/src/renderer/modals/WalletConnectDeeplink/Body.js
@@ -183,7 +183,6 @@ const Body = ({ onClose, link }: BodyProps) => {
       )}
       renderFooter={() => (
         <Footer
-          wcDappName={wcContext.dappInfo?.name}
           wcStatus={wcContext.status}
           account={account}
           onReject={handleReject}

--- a/src/renderer/modals/WalletConnectDeeplink/Footer.js
+++ b/src/renderer/modals/WalletConnectDeeplink/Footer.js
@@ -6,12 +6,12 @@ import Button from "~/renderer/components/Button";
 import { STATUS } from "~/renderer/screens/WalletConnect/Provider";
 import { useTranslation } from "react-i18next";
 
-const Footer = ({ onContinue, onReject, onCancel, wcDappName, wcStatus, account }: FooterProps) => {
+const Footer = ({ onContinue, onReject, onCancel, wcStatus, account }: FooterProps) => {
   const { t } = useTranslation();
 
   return (
     <Box horizontal justifyContent="flex-end">
-      {wcStatus === STATUS.CONNECTING && wcDappName ? (
+      {wcStatus === STATUS.CONNECTING ? (
         <>
           <Button onClick={onReject} outline>
             {t("common.reject")}

--- a/src/renderer/modals/WalletConnectDeeplink/types.js
+++ b/src/renderer/modals/WalletConnectDeeplink/types.js
@@ -8,7 +8,6 @@ export type BodyProps = {
 };
 
 export type FooterProps = {
-  wcDappName: ?string,
   account: ?Account,
   wcStatus: STATUS,
   onContinue: Function,


### PR DESCRIPTION
## 🦒 Context (issues, jira)

Walletconnect peerMeta data isn't required dapp-side to use WalletConnect.
Even when using nameless dapps, users should be able to use Ledger Live via WC.

## 💻  Description / Demo (image or video)

Noting change on the UI-side.
<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
