### PR TITLE
feat(account): improve the empty state

### DIFF
--- a/src/renderer/components/Button.ui.tsx
+++ b/src/renderer/components/Button.ui.tsx
@@ -47,7 +47,7 @@ export default function Button({
     }
   };
   const inner = (
-    <Base {...rest} onClick={isClickDisabled ? undefined : onClickHandler}>
+    <Base disabled={disabled} {...rest} onClick={isClickDisabled ? undefined : onClickHandler}>
       {children}
     </Base>
   );

--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -130,6 +130,7 @@ const AccountHeaderSettingsButtonComponent = ({ account, parentAccount, openModa
 const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) => {
   const mainAccount = getMainAccount(account, parentAccount);
   const contrastText = useTheme("colors.palette.text.shade60");
+  const isAccountHasToken = useMemo(() => !isAccountEmpty(account), [account.id]);
 
   const decorators = perFamilyAccountActions[mainAccount.currency.family];
   const manage = perFamilyManageActions[mainAccount.currency.family];
@@ -275,21 +276,17 @@ const AccountHeaderActions = ({ account, parentAccount, openModal, t }: Props) =
 
   const ManageActionsHeader = manageActions.map(item => renderAction(item));
 
-  const NonEmptyAccountHeader = (
-    <FadeInButtonsContainer data-test-id="account-buttons-group" show={showButtons}>
-      {availableOnBuy && BuyHeader}
-      {availableOnSwap && SwapHeader}
-      {manageActions.length > 0 && ManageActionsHeader}
-      {canSend(account, parentAccount) && (
-        <SendAction account={account} parentAccount={parentAccount} onClick={onSend} />
-      )}
-      <ReceiveAction account={account} parentAccount={parentAccount} onClick={onReceive} />
-    </FadeInButtonsContainer>
-  );
-
   return (
     <Box horizontal alignItems="center" justifyContent="flex-end" flow={2} mt={15}>
-      {!isAccountEmpty(account) ? NonEmptyAccountHeader : null}
+      <FadeInButtonsContainer data-test-id="account-buttons-group" show={showButtons}>
+        {availableOnBuy && BuyHeader}
+        {isAccountHasToken && availableOnSwap && SwapHeader}
+        {manageActions.length > 0 && ManageActionsHeader}
+        {isAccountHasToken && canSend(account, parentAccount) && (
+          <SendAction account={account} parentAccount={parentAccount} onClick={onSend} />
+        )}
+        <ReceiveAction account={account} parentAccount={parentAccount} onClick={onReceive} />
+      </FadeInButtonsContainer>
     </Box>
   );
 };


### PR DESCRIPTION
## 🦒 Context (issues, jira)

Until now, the header in the account page for an empty account (no txs) wasn't
rendered. Because of this, walletconnect button wasn't rendered, you needed
some tokens to see it appears. This commit fixes this, from now, walletconnect
button and receive/buy buttons would be rendered for any empty accounts.
As it is not required to own tokens to use walletconnect, this modification makes
sense to me. Regarding the receive/buy buttons, I think it's better to have them
always available, even for empty accounts (we missed a business opportunity by
hidding the buy button in this case).

## 💻  Description / Demo (image or video)

**Before**

<img width="1440" alt="Screenshot 2022-04-08 at 15 04 42" src="https://user-images.githubusercontent.com/33158502/162441404-ae63ec7e-abc4-4410-94da-f2793bde629a.png">

**After**

<img width="1440" alt="Screenshot 2022-04-08 at 15 04 44" src="https://user-images.githubusercontent.com/33158502/162441416-a17f0f7f-e9c6-4bec-8c30-3debaaa318d7.png">



<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
