### PR TITLE
fix(swap): properly sort the source account selector [LIVE-819]

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,4 +8,6 @@ module.exports = {
     __APP_VERSION__: "2.0.0",
   },
   globalSetup: "<rootDir>/tests/setup.js",
+  setupFiles: ["<rootDir>/tests/jestSetup.js"],
+  transformIgnorePatterns: ["/node_modules/(?!(@polkadot|@babel/runtime)/)"],
 };

--- a/src/renderer/actions/swap.test.js
+++ b/src/renderer/actions/swap.test.js
@@ -1,0 +1,31 @@
+import { sortAccountsByStatus } from "./swap";
+
+const accounts = [
+  { type: "Account", name: "test1", disabled: false },
+  { type: "TokenAccount", name: "test1 - sub1", disabled: true },
+  { type: "TokenAccount", name: "test1 - sub2", disabled: false },
+  { type: "Account", name: "test2", disabled: true },
+  { type: "Account", name: "test3", disabled: false },
+  { type: "Account", name: "test4", disabled: true },
+  { type: "TokenAccount", name: "test4 - sub1", disabled: false },
+  { type: "Account", name: "test5", disabled: true },
+  { type: "TokenAccount", name: "test5 - sub1", disabled: true },
+  { type: "Account", name: "test6", disabled: false },
+];
+
+const expectedOrder = [
+  "test1",
+  "test1 - sub2",
+  "test1 - sub1",
+  "test3",
+  "test4",
+  "test4 - sub1",
+  "test6",
+  "test2",
+  "test5",
+  "test5 - sub1",
+];
+
+test("SortAccountsByStatus should keep disable accounts with active subAccounts before disable accounts", () => {
+  expect(sortAccountsByStatus(accounts).map(value => value.name)).toEqual(expectedOrder);
+});

--- a/src/renderer/screens/market/MarketCoinScreen/index.tsx
+++ b/src/renderer/screens/market/MarketCoinScreen/index.tsx
@@ -285,7 +285,7 @@ export default function MarketCoinScreen() {
         atlDate={atlDate}
         locale={locale}
         counterCurrency={counterCurrency}
-        loading={loading}
+        loading={process.env.PLAYWRIGHT_RUN ? false : loading}
       />
     </Container>
   ) : null;

--- a/tests/jestSetup.js
+++ b/tests/jestSetup.js
@@ -1,0 +1,4 @@
+import { TextDecoder, TextEncoder } from "util";
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LIVE-819]
[LIVE-751]

## 💻  Description / Demo (image or video)

Fix the sort of the source selector by putting fully disabled accounts / token accounts at the bottom of the list while preserving the parent/children grouping.

Before: 
<img width="534" alt="image-20220228-124928" src="https://user-images.githubusercontent.com/3009753/162400951-1e23fe68-06f5-4d5f-b67e-1ec147fa391c.png">

After:
<img width="513" alt="Screenshot 2022-04-08 at 11 13 35" src="https://user-images.githubusercontent.com/3009753/162405075-b54f3102-56f8-4921-b572-fcf70a7c98ac.png">

<!-- please attached an image or even better a video that demo what this PR do -->

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [ ] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->


[LIVE-819]: https://ledgerhq.atlassian.net/browse/LIVE-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-751]: https://ledgerhq.atlassian.net/browse/LIVE-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ