### PR TITLE
Bugfix: Update nft links key

### DIFF
--- a/src/renderer/hooks/useNftLinks.js
+++ b/src/renderer/hooks/useNftLinks.js
@@ -34,13 +34,13 @@ const linksPerCurrency = {
       type: "separator",
       label: "",
     },
-    links?.etherscan && {
-      key: "etherscan",
-      id: "etherscan",
+    links?.explorer && {
+      key: "explorer",
+      id: "explorer",
       label: t("NFT.viewer.actions.open", { viewer: "Explorer" }),
       Icon: IconGlobe,
       type: "external",
-      callback: () => openURL(links.etherscan),
+      callback: () => openURL(links.explorer),
     },
   ],
   polygon: (t, links, dispatch) => [
@@ -66,13 +66,13 @@ const linksPerCurrency = {
       type: "separator",
       label: "",
     },
-    links?.polygonscan && {
-      key: "polygonscan",
-      id: "polygonscan",
+    links?.explorer && {
+      key: "explorer",
+      id: "explorer",
       label: t("NFT.viewer.actions.open", { viewer: "Explorer" }),
       Icon: IconGlobe,
       type: "external",
-      callback: () => openURL(links.polygonscan),
+      callback: () => openURL(links.explorer),
     },
   ],
 };


### PR DESCRIPTION
## 🦒 Context (issues, jira)

The staging version of our metadata service is now using a new key for the explorer link for the NFT.
This PR update the support for this new key.

## 💻  Description / Demo (image or video)

<img width="1182" alt="Screenshot 2022-04-11 at 16 05 14" src="https://user-images.githubusercontent.com/44363395/162757013-92ef181e-9f85-48e6-ba50-80318f206cb0.png">

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
