### PR TITLE
[LIVE-1317] "something else" choice at repair modal for Nano S

### DIFF
--- a/src/renderer/components/RepairDeviceButton.js
+++ b/src/renderer/components/RepairDeviceButton.js
@@ -130,6 +130,7 @@ const RepairDeviceButton: React$ComponentType<Props> = React.forwardRef(function
         desc={t("settings.repairDevice.desc")}
         progress={progress}
         error={error}
+        enableSomethingElseChoice={true}
       />
     </>
   );

--- a/src/renderer/components/RepairDeviceButton.js
+++ b/src/renderer/components/RepairDeviceButton.js
@@ -130,7 +130,7 @@ const RepairDeviceButton: React$ComponentType<Props> = React.forwardRef(function
         desc={t("settings.repairDevice.desc")}
         progress={progress}
         error={error}
-        enableSomethingElseChoice={true}
+        enableSomethingElseChoice
       />
     </>
   );

--- a/src/renderer/components/RepairDeviceButton.js
+++ b/src/renderer/components/RepairDeviceButton.js
@@ -15,11 +15,12 @@ import { openModal, closeModal } from "~/renderer/actions/modals";
 type Props = {
   buttonProps?: *,
   onRepair?: boolean => void,
+  onClose?: ({ needHelp?: boolean }) => void,
   Component?: any,
 };
 
 const RepairDeviceButton: React$ComponentType<Props> = React.forwardRef(function RepairDevice(
-  { onRepair, buttonProps, Component }: Props,
+  { onRepair, onClose, buttonProps, Component }: Props,
   ref: React$ElementRef<*>,
 ) {
   const { t } = useTranslation();
@@ -52,18 +53,24 @@ const RepairDeviceButton: React$ComponentType<Props> = React.forwardRef(function
     setOpened(true);
   }, [dispatch]);
 
-  const close = useCallback(() => {
-    if (sub && sub.current) sub.current.unsubscribe();
-    if (timeout && timeout.current) clearTimeout(timeout.current);
-    if (onRepair) {
-      onRepair(false);
-    }
-    setOpened(false);
-    dispatch(closeModal("MODAL_STUB"));
-    setIsLoading(false);
-    setError(null);
-    setProgress(0);
-  }, [onRepair, dispatch]);
+  const close = useCallback(
+    ({ needHelp }: { needHelp?: boolean }) => {
+      if (sub && sub.current) sub.current.unsubscribe();
+      if (timeout && timeout.current) clearTimeout(timeout.current);
+      if (onRepair) {
+        onRepair(false);
+      }
+      if (onClose) {
+        onClose({ needHelp });
+      }
+      setOpened(false);
+      dispatch(closeModal("MODAL_STUB"));
+      setIsLoading(false);
+      setError(null);
+      setProgress(0);
+    },
+    [onRepair, onClose, dispatch],
+  );
 
   const repair = useCallback(
     (version = null) => {

--- a/src/renderer/modals/RepairModal/index.js
+++ b/src/renderer/modals/RepairModal/index.js
@@ -135,7 +135,11 @@ class RepairModal extends PureComponent<Props, *> {
     selectedOption: null,
     availableRepairChoices: [
       ...repairChoices,
-      { forceMCU: "", label: "Something else", id: "somethingElse" },
+      {
+        forceMCU: "",
+        label: this.props.t("connectTroubleshooting.steps.4.repair.somethingElse"),
+        id: "somethingElse",
+      },
     ],
   };
 

--- a/src/renderer/modals/RepairModal/index.js
+++ b/src/renderer/modals/RepairModal/index.js
@@ -128,20 +128,33 @@ type Props = {
   progress: number,
   error?: ?Error,
   isAlreadyBootloader?: boolean,
+  enableSomethingElseChoice?: boolean,
 };
 
-class RepairModal extends PureComponent<Props, *> {
-  state = {
-    selectedOption: null,
-    availableRepairChoices: [
-      ...repairChoices,
-      {
+type State = {
+  selectedOption: ChoiceOption | null,
+  availableRepairChoices: Array<ChoiceOption>,
+};
+
+class RepairModal extends PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    const availableRepairChoices = [...repairChoices];
+
+    if (props.enableSomethingElseChoice) {
+      availableRepairChoices.push({
         forceMCU: "",
         label: this.props.t("connectTroubleshooting.steps.4.repair.somethingElse"),
         id: "somethingElse",
-      },
-    ],
-  };
+      });
+    }
+
+    this.state = {
+      selectedOption: null,
+      availableRepairChoices,
+    };
+  }
 
   onSelectOption = selectedOption => {
     this.setState({ selectedOption });

--- a/src/renderer/modals/RepairModal/index.js
+++ b/src/renderer/modals/RepairModal/index.js
@@ -133,11 +133,30 @@ type Props = {
 class RepairModal extends PureComponent<Props, *> {
   state = {
     selectedOption: null,
+    availableRepairChoices: [
+      ...repairChoices,
+      { forceMCU: "", label: "Something else", id: "somethingElse" },
+    ],
   };
 
   onSelectOption = selectedOption => {
     this.setState({ selectedOption });
     track(`${this.props.analyticsName}SelectOption`, { selectedOption });
+  };
+
+  onSubmit = () => {
+    const { selectedOption } = this.state;
+    const { onReject, repair } = this.props;
+
+    if (!selectedOption) {
+      return;
+    }
+
+    if (selectedOption.id === "somethingElse") {
+      onReject({ needHelp: true });
+    } else {
+      repair(selectedOption.forceMCU);
+    }
   };
 
   render() {
@@ -159,7 +178,7 @@ class RepairModal extends PureComponent<Props, *> {
       isAlreadyBootloader,
       ...props
     } = this.props;
-    const { selectedOption } = this.state;
+    const { selectedOption, availableRepairChoices } = this.state;
     const onClose = !cancellable && isLoading ? undefined : onReject;
     const disableRepair =
       isLoading || !selectedOption || !!(error && error instanceof MCUNotGenuineToDashboard);
@@ -190,7 +209,7 @@ class RepairModal extends PureComponent<Props, *> {
 
               {!isLoading && !error ? (
                 <Box py={2} px={5} color="palette.text.shade100" fontSize={4}>
-                  {repairChoices.map(choice => (
+                  {availableRepairChoices.map(choice => (
                     <Choice
                       key={choice.id}
                       onSelect={this.onSelectOption}
@@ -211,13 +230,15 @@ class RepairModal extends PureComponent<Props, *> {
                 <div style={{ flex: 1 }} />
                 <Button onClick={onReject}>{t(`common.${error ? "close" : "cancel"}`)}</Button>
                 <Button
-                  onClick={selectedOption ? () => repair(selectedOption.forceMCU) : null}
+                  onClick={this.onSubmit}
                   primary={!isDanger}
                   danger={isDanger}
                   isLoading={isLoading}
                   disabled={disableRepair}
                 >
-                  {t("settings.repairDevice.button")}
+                  {selectedOption?.id === "somethingElse"
+                    ? t("common.continue")
+                    : t("settings.repairDevice.button")}
                 </Button>
               </Box>
             ) : null

--- a/src/renderer/screens/USBTroubleshooting/solutions/RepairFunnel.js
+++ b/src/renderer/screens/USBTroubleshooting/solutions/RepairFunnel.js
@@ -36,6 +36,15 @@ const RepairFunnelSolution = ({
     [repairRef, sendEvent],
   );
 
+  const onRepairDeviceClose = useCallback(
+    ({ needHelp }) => {
+      if (needHelp) {
+        sendEvent("DONE", { deviceModel: "nanoS" });
+      }
+    },
+    [sendEvent],
+  );
+
   return !done ? (
     <Wrapper>
       <Title>{t("connectTroubleshooting.steps.4.deviceSelection.title")}</Title>
@@ -43,7 +52,7 @@ const RepairFunnelSolution = ({
         {t("connectTroubleshooting.steps.4.deviceSelection.desc")}
       </Subtitle>
       <div style={{ display: "none" }}>
-        <RepairDeviceButton ref={repairRef} />
+        <RepairDeviceButton ref={repairRef} onClose={onRepairDeviceClose} />
       </div>
       <DeviceSelector onClick={onSelectDevice} />
     </Wrapper>

--- a/src/renderer/screens/settings/sections/Help/RepairDeviceButton.js
+++ b/src/renderer/screens/settings/sections/Help/RepairDeviceButton.js
@@ -110,6 +110,7 @@ class RepairDeviceButton extends PureComponent<Props, State> {
           desc={t("settings.repairDevice.desc")}
           progress={progress}
           error={error}
+          enableSomethingElseChoice={false}
         />
       </>
     );


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LIVE-1317](https://ledgerhq.atlassian.net/browse/LIVE-1317?atlOrigin=eyJpIjoiMWJkNTJmYzUyYzc4NGRmZmFlNzEwZDFlMTkwZDUxNWEiLCJwIjoiaiJ9)

The "something else" choice redirects to the end of the usb-troubleshooting flow

Add to adapt a bit compared to the given design (from figma): the Nano S repair modal is old and has not been updated to the new troubleshooting screens.

## 💻  Description / Demo (image or video)

<details>
  <summary>Video: new feature</summary>

https://user-images.githubusercontent.com/15096913/163337621-789599a3-3066-4cf5-ab43-f8fe0d16d1ec.mp4

</details>

<details>
  <summary>Video: the other repair modal screens are not broken</summary>


https://user-images.githubusercontent.com/15096913/163339871-774ec649-5b2c-4929-b752-bc429613c3e8.mp4


</details>

## 🖤  Expectations to reach

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira 
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
