### PR TITLE
[LIVE-1314] Update account creation selection after downloading several apps

### DIFF
--- a/src/renderer/screens/manager/AppsList/InstallSuccessBanner.js
+++ b/src/renderer/screens/manager/AppsList/InstallSuccessBanner.js
@@ -85,7 +85,12 @@ const InstallSuccessBanner = ({ state, isIncomplete, dispatch, addAccount, disab
   }, [installQueue.length, uninstallQueue.length, recentlyInstalledApps, appByName, installed]);
 
   const onAddAccount = useCallback(() => {
-    const app = installedSupportedApps[0];
+    if (installedSupportedApps.length === 0) {
+      return;
+    }
+
+    const app = installedSupportedApps[installedSupportedApps.length - 1];
+
     if (app.currencyId) {
       addAccount(getCryptoCurrencyById(app.currencyId));
       setHasBeenShown(true);


### PR DESCRIPTION
## 🦒 Context (issues, jira)

[LIVE-1314](https://ledgerhq.atlassian.net/browse/LIVE-1314?atlOrigin=eyJpIjoiODQxYTZlMDQ5NDg4NGRjNzk5YzIzMTBiMGQzOGZjMzQiLCJwIjoiaiJ9)

Issue: when downloading an app with dependencies app (for ex: ETC app that needs ETH app), the account type to create that is selected when clicking on the displayed banner is from the dependency app (ETH for ex) and not the wanted app (ETC here)

## 💻  Description / Demo (image or video)

Solution: After downloading several apps, the account type to create that is selected is associated to the last downloaded app. In the case of an app needing a dependency, it solves the above issue.
 
<details>
  <summary>Previous behavior with wrong selection for ETC</summary>


https://user-images.githubusercontent.com/15096913/163426702-4683f2eb-53a0-4a37-93e7-719a40110c42.mp4



</details>

<details>
  <summary>New behavior with correct selection for ETC</summary>


https://user-images.githubusercontent.com/15096913/163426728-e3e82b92-285c-4fd2-8b5e-80563eadd52d.mp4



</details>

## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [x] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)
