### PR TITLE
Replace learn staging URL

### DIFF
--- a/src/renderer/screens/learn/index.tsx
+++ b/src/renderer/screens/learn/index.tsx
@@ -11,7 +11,6 @@ import LoadingScreen from "./LoadingScreen";
 import NoConnectionScreen from "./NoConnectionScreen";
 import ErrorScreen from "./ErrorScreen";
 import { getPagePaddingLeft, getPagePaddingRight } from "~/renderer/components/Page";
-import palettes from "~/renderer/styles/palettes";
 
 const Container = styled(Flex).attrs({
   flex: 1,
@@ -28,7 +27,7 @@ const Iframe = styled.iframe`
 `;
 
 const learnProdURL = "https://www.ledger.com/ledger-live-learn";
-const learnStagingURL = "https://ecommerce-website.aws.stg.ldg-tech.com/ledger-live-learn";
+const learnStagingURL = "https://www-ppr.ledger.com/ledger-live-learn";
 const TIMEOUT = 60 * 1000;
 
 /** TODO: once design & wording are ready, implement properly */
@@ -46,16 +45,11 @@ const TimeoutScreen = () => (
 
 export default function LearnScreen() {
   const { i18n } = useTranslation();
-  const theme = useTheme();
   const themeType: string = useTheme("colors.palette.type");
   const useStagingUrl = useSelector(enableLearnPageStagingUrlSelector);
   const params = new URLSearchParams({
     theme: themeType,
     lang: i18n.languages[0],
-    pagePaddingLeft: `${getPagePaddingLeft({ theme })}px`,
-    pagePaddingRight: `${getPagePaddingRight({ theme })}px`,
-    darkBackgroundColor: `${palettes.dark.background.default}`,
-    lightBackgroundColor: `${palettes.light.background.default}`,
   });
   const uri = `${useStagingUrl ? learnStagingURL : learnProdURL}?${params.toString()}`;
 


### PR DESCRIPTION
Change staging URL used for the Learn page (for a purpose of testing by the e-commerce team).

## 🦒 Context (issues, jira)

[LIVE-1925]

## 💻  Description / Demo (image or video)



## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [ ] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [x] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
