### PR TITLE
Optimize lodash usage (do not import the root)

### DIFF
--- a/src/renderer/components/Carousel/helpers.js
+++ b/src/renderer/components/Carousel/helpers.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { useMemo } from "react";
-import _ from "lodash";
+import map from "lodash/map";
 import { Trans } from "react-i18next";
 import Slide from "./Slide";
 import { urls } from "~/config/urls";
@@ -270,7 +270,7 @@ export const useDefaultSlides = () => {
   return useMemo(
     () =>
       // $FlowFixMe
-      _.map(process.env.PLAYWRIGHT_RUN ? [SLIDES[2], SLIDES[1]] : SLIDES, (slide: Props) => ({
+      map(process.env.PLAYWRIGHT_RUN ? [SLIDES[2], SLIDES[1]] : SLIDES, (slide: Props) => ({
         id: slide.name,
         // eslint-disable-next-line react/display-name
         Component: () => <Slide {...slide} />,

--- a/src/renderer/init.js
+++ b/src/renderer/init.js
@@ -11,7 +11,7 @@ import i18n from "i18next";
 import { remote, webFrame, ipcRenderer } from "electron";
 import { render } from "react-dom";
 import moment from "moment";
-import _ from "lodash";
+import each from "lodash/each";
 import { reload, getKey, loadLSS } from "~/renderer/storage";
 import { hardReset } from "~/renderer/reset";
 
@@ -64,7 +64,7 @@ async function init() {
 
   if (process.env.PLAYWRIGHT_RUN) {
     const spectronData = await getKey("app", "PLAYWRIGHT_RUN", {});
-    _.each(spectronData.localStorage, (value, key) => {
+    each(spectronData.localStorage, (value, key) => {
       global.localStorage.setItem(key, value);
     });
 


### PR DESCRIPTION
This fixes the convention we had everywhere in the code in the usage of lodash: we must not import _ from "lodash" but use the functional imports.

if this pass the CI, it shall be good.