### PR TITLE
WalletConnect - Ethereum Goerli in dev mode

### DIFF
--- a/src/renderer/screens/account/AccountHeaderActions.js
+++ b/src/renderer/screens/account/AccountHeaderActions.js
@@ -40,6 +40,7 @@ import {
   SendActionDefault,
   SwapActionDefault,
 } from "./AccountActionsDefault";
+import useEnv from "~/renderer/hooks/useEnv";
 
 const ButtonSettings: ThemedComponent<{ disabled?: boolean }> = styled(Tabbable).attrs(() => ({
   alignItems: "center",
@@ -87,6 +88,10 @@ type Props = {
 const AccountHeaderSettingsButtonComponent = ({ account, parentAccount, openModal, t }: Props) => {
   const currency = getAccountCurrency(account);
 
+  const devModeEnabled = useEnv("MANAGER_DEV_MODE");
+  const walletConnectBaseNetworks = ["ethereum", "bsc", "polygon"];
+  const walletConnectNetworks = devModeEnabled ? [...walletConnectBaseNetworks, "ethereum_ropsten", "ethereum_goerli"] : walletConnectBaseNetworks;
+
   const onWalletConnect = useCallback(() => {
     setTrackingSource("account header actions");
     openModal("MODAL_WALLETCONNECT_PASTE_LINK", { account });
@@ -102,7 +107,7 @@ const AccountHeaderSettingsButtonComponent = ({ account, parentAccount, openModa
           rounded
         />
       </Tooltip>
-      {["ethereum", "bsc", "polygon"].includes(currency.id) ? (
+      {walletConnectNetworks.includes(currency.id) ? (
         <Tooltip content={t("walletconnect.titleAccount")}>
           <ButtonSettings onClick={onWalletConnect}>
             <Box justifyContent="center">


### PR DESCRIPTION
## 🦒 Context (issues, jira)

- Adds logic to AccountHeaderActions.js to determine if developer mode is enabled
- If enabled, test nets can be added to a walletConnectNetworks array that consists of the baseNetworks (`["ethereum", "bsc", "polygon"];`). In this PR, the networks would be `["ethereum", "bsc", "polygon", "ethereum_ropsten", "ethereum_goerli"];`


## 💻  Description / Demo (image or video)

https://user-images.githubusercontent.com/100605721/169877006-58d0a629-d733-4cb5-ba38-88d2833e389c.mov


## 🖤  Expectations to reach

PR must pass CI, rebase develop if conflicts. Thanks!

- **on QA**: at least one of these two checkboxes must be checked:
  - [ ] a specific test planned is defined on Jira
  - [x] this PR is covered by automatic UI test
- **on delivery**: at least one of these two checkboxes must be checked: <!-- NB: Delivery incrementally with feature flagging is better than a very long PR. so prefer Option 1 if Option 2 takes more than a sprint -->
  - [ ] Option 1: **no impact**: The changes of this PR have ZERO impact on the userland (invisible for users)
  - [x] Option 2: **atomic delivery**: the changes is atomic and complete (no partial delivery)

<!--
If expectations aren't met, please document it carefully (on the reason you can't check it) and what do you need from maintainers.
-->
